### PR TITLE
feat: add light mode with theme toggle and semantic color system

### DIFF
--- a/.opencode/skills/pr-workflow/SKILL.md
+++ b/.opencode/skills/pr-workflow/SKILL.md
@@ -89,9 +89,16 @@ Create the PR with `gh pr create`. The PR body should follow this format:
 ## Summary
 - Brief description of changes
 
+Fixes #N
+<!-- Use "Fixes #N" for each GitHub issue this PR resolves. -->
+<!-- GitHub auto-closes the issue when the PR merges. -->
+<!-- Use "Relates to #N" if the PR partially addresses but doesn't fully close an issue. -->
+
 ## Changelog
 - Version X.Y.Z: <what changed for users>
 ```
+
+**Issue linking is mandatory.** Before creating a PR, check `gh issue list` for related issues. If the PR resolves one or more issues, include `Fixes #N` (one per line) in the PR body. If it partially addresses an issue, use `Relates to #N` instead.
 
 ### 5. CI checks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,13 @@ Final todos should be:
 
 All tasks, features, and bugs are tracked as **GitHub Issues** (not a local TODO file). Use `gh issue list` at the start of every session to understand what's open.
 
-When a PR resolves an issue, include `Fixes #N` in the PR description to auto-close it on merge. Reference issues in commit messages when relevant.
+**Issue linking in PRs is mandatory.** Before creating any PR:
+1. Check `gh issue list` for related issues
+2. If the PR fully resolves an issue, include `Fixes #N` in the PR body (one per line for multiple issues)
+3. If the PR partially addresses an issue, use `Relates to #N` instead
+4. GitHub auto-closes issues linked with `Fixes` when the PR merges
 
-Full conventions are in the `todo-tracking` OpenCode skill.
+Reference issues in commit messages when relevant.
+
+Full PR conventions are in the `pr-workflow` OpenCode skill.
 <!-- END:github-issues-rules -->

--- a/changelog/en/2026-03-25-light-mode.mdx
+++ b/changelog/en/2026-03-25-light-mode.mdx
@@ -1,0 +1,12 @@
+---
+version: "1.5.0"
+date: "2026-03-25"
+title: "Light Mode & Theme Toggle"
+---
+
+The app now supports **light mode** alongside the original dark theme.
+
+- **Theme toggle** in the sidebar lets you switch between Dark, Light, and System (follows your OS preference)
+- **All charts and analytics** adapt their colors to the active theme — no washed-out graphs
+- **Every page** uses theme-aware colors for wins, losses, streaks, coaching markers, and more
+- **Changelog, glows, and gradients** all respect the current theme

--- a/changelog/es/2026-03-25-light-mode.mdx
+++ b/changelog/es/2026-03-25-light-mode.mdx
@@ -1,0 +1,12 @@
+---
+version: "1.5.0"
+date: "2026-03-25"
+title: "Modo Claro y Selector de Tema"
+---
+
+La app ahora soporta **modo claro** junto al tema oscuro original.
+
+- **Selector de tema** en la barra lateral para cambiar entre Oscuro, Claro y Sistema (sigue la preferencia de tu SO)
+- **Todos los graficos y analiticas** adaptan sus colores al tema activo — sin graficos deslavados
+- **Todas las paginas** usan colores adaptados al tema para victorias, derrotas, rachas, marcadores de coaching y mas
+- **Changelog, brillos y degradados** respetan el tema actual

--- a/src/app/(app)/analytics/analytics-client.tsx
+++ b/src/app/(app)/analytics/analytics-client.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import Image from "next/image";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
+import { useChartColors } from "@/hooks/use-chart-colors";
 import {
   LineChart,
   Line,
@@ -306,6 +307,7 @@ export function AnalyticsClient({
   const { data: session } = useSession();
   const locale = session?.user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("Analytics");
+  const cc = useChartColors();
 
   const rollingWR = useMemo(() => computeRollingWinRate(matches, locale), [matches, locale]);
   const matchupStats = useMemo(() => computeMatchupStats(matches), [matches]);
@@ -533,7 +535,7 @@ export function AnalyticsClient({
                 {lpChartMeta.netChange !== 0 && (
                   <span
                     className={`font-mono font-semibold ${
-                      lpChartMeta.netChange >= 0 ? "text-green-400" : "text-red-400"
+                      lpChartMeta.netChange >= 0 ? "text-win" : "text-loss"
                     }`}
                   >
                     {lpChartMeta.netChange >= 0 ? "+" : ""}
@@ -549,27 +551,27 @@ export function AnalyticsClient({
                 <AreaChart data={rankChartData}>
                   <defs>
                     <linearGradient id="lpGradient" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="oklch(0.78 0.14 80)" stopOpacity={0.3} />
-                      <stop offset="95%" stopColor="oklch(0.78 0.14 80)" stopOpacity={0} />
+                      <stop offset="5%" stopColor={cc.gold} stopOpacity={0.3} />
+                      <stop offset="95%" stopColor={cc.gold} stopOpacity={0} />
                     </linearGradient>
                   </defs>
-                  <CartesianGrid strokeDasharray="3 3" stroke="oklch(0.25 0.03 260)" />
+                  <CartesianGrid strokeDasharray="3 3" stroke={cc.chartGrid} />
                   <XAxis
                     dataKey="date"
-                    stroke="oklch(0.55 0.02 260)"
+                    stroke={cc.chartAxis}
                     fontSize={12}
                     interval="preserveStartEnd"
                   />
                   <YAxis
-                    stroke="oklch(0.55 0.02 260)"
+                    stroke={cc.chartAxis}
                     fontSize={12}
                     domain={[lpChartMeta.yMin, lpChartMeta.yMax]}
                     tickFormatter={(v: number) => formatRank(v).split("—")[0].trim()}
                   />
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: "oklch(0.18 0.03 260)",
-                      border: "1px solid oklch(0.25 0.03 260)",
+                      backgroundColor: cc.chartTooltipBg,
+                      border: `1px solid ${cc.chartTooltipBorder}`,
                       borderRadius: "8px",
                     }}
                     content={({ active, payload }) => {
@@ -584,7 +586,7 @@ export function AnalyticsClient({
                             <p className="text-xs font-semibold text-gold mb-1">{t("tooltips.peakRankAchieved")}</p>
                           )}
                           {milestone && (
-                            <p className="text-xs font-semibold text-green-400 mb-1">{t("tooltips.firstTimeInTier", { tier: milestone.tier })}</p>
+                            <p className="text-xs font-semibold text-win mb-1">{t("tooltips.firstTimeInTier", { tier: milestone.tier })}</p>
                           )}
                           <p className="font-semibold text-gold">
                             {d.tier} {d.division}
@@ -604,11 +606,11 @@ export function AnalyticsClient({
                     <ReferenceLine
                       key={b.label}
                       y={b.lp}
-                      stroke="oklch(0.65 0.17 250)"
+                      stroke={cc.electric}
                       strokeDasharray="6 3"
                       label={{
                         value: b.label,
-                        fill: "oklch(0.65 0.17 250)",
+                        fill: cc.electric,
                         fontSize: 11,
                         position: "right",
                       }}
@@ -621,16 +623,16 @@ export function AnalyticsClient({
                       x={rankChartData[e.index].date}
                       stroke={
                         e.type === "promotion"
-                          ? "oklch(0.72 0.15 150)"
-                          : "oklch(0.65 0.22 27)"
+                          ? cc.chartPromotion
+                          : cc.chartDemotion
                       }
                       strokeDasharray="4 4"
                       label={{
                         value: e.type === "promotion" ? t("chartLabels.reached", { tier: e.to.split(" ")[0] }) : t("chartLabels.backTo", { tier: e.to.split(" ")[0] }),
                         fill:
                           e.type === "promotion"
-                            ? "oklch(0.72 0.15 150)"
-                            : "oklch(0.65 0.22 27)",
+                            ? cc.chartPromotion
+                            : cc.chartDemotion,
                         fontSize: 10,
                         position: "top",
                       }}
@@ -639,7 +641,7 @@ export function AnalyticsClient({
                   <Area
                     type="monotone"
                     dataKey="cumulativeLP"
-                    stroke="oklch(0.78 0.14 80)"
+                    stroke={cc.gold}
                     strokeWidth={2}
                     fill="url(#lpGradient)"
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -657,15 +659,15 @@ export function AnalyticsClient({
                               cx={props.cx}
                               cy={props.cy}
                               r={6}
-                              fill="oklch(0.78 0.14 80)"
-                              stroke="oklch(0.90 0.14 80)"
+                              fill={cc.gold}
+                              stroke={cc.goldLight}
                               strokeWidth={2}
                             />
                             <text
                               x={props.cx}
                               y={props.cy - 12}
                               textAnchor="middle"
-                              fill="oklch(0.85 0.12 80)"
+                              fill={cc.goldLight}
                               fontSize={9}
                               fontWeight="bold"
                             >
@@ -681,8 +683,8 @@ export function AnalyticsClient({
                             cx={props.cx}
                             cy={props.cy}
                             r={5}
-                            fill="oklch(0.78 0.14 80)"
-                            stroke="oklch(0.13 0.02 260)"
+                            fill={cc.gold}
+                            stroke={cc.background}
                             strokeWidth={2}
                           />
                         );
@@ -693,12 +695,12 @@ export function AnalyticsClient({
                           cx={props.cx}
                           cy={props.cy}
                           r={2}
-                          fill="oklch(0.78 0.14 80)"
+                          fill={cc.gold}
                           opacity={0.5}
                         />
                       );
                     }}
-                    activeDot={{ r: 5, fill: "oklch(0.85 0.12 80)" }}
+                    activeDot={{ r: 5, fill: cc.goldLight }}
                   />
                 </AreaChart>
               </ResponsiveContainer>
@@ -738,21 +740,21 @@ export function AnalyticsClient({
           <div className="h-[300px]">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={rollingWR}>
-                <CartesianGrid strokeDasharray="3 3" stroke="oklch(0.25 0.03 260)" />
+                <CartesianGrid strokeDasharray="3 3" stroke={cc.chartGrid} />
                 <XAxis
                   dataKey="date"
-                  stroke="oklch(0.55 0.02 260)"
+                  stroke={cc.chartAxis}
                   fontSize={12}
                   interval="preserveStartEnd"
                 />
                 <YAxis
-                  stroke="oklch(0.55 0.02 260)"
+                  stroke={cc.chartAxis}
                   fontSize={12}
                   domain={[0, 100]}
                   tickFormatter={(v) => `${v}%`}
                 />
                 <Tooltip
-                  cursor={{ stroke: "oklch(0.45 0.02 260)" }}
+                  cursor={{ stroke: cc.chartReference }}
                   content={({ active, payload }) => {
                     if (!active || !payload || !payload[0]) return null;
                     const d = payload[0].payload as (typeof rollingWR)[0];
@@ -761,7 +763,7 @@ export function AnalyticsClient({
                         <p className="text-sm font-semibold text-foreground">{d.date}</p>
                         <p className="text-sm">
                           {t("tooltips.winRate")}{" "}
-                          <span className={d.winRate >= 50 ? "text-gold" : "text-red-400"}>
+                          <span className={d.winRate >= 50 ? "text-gold" : "text-loss"}>
                             {d.winRate}%
                           </span>
                         </p>
@@ -772,9 +774,9 @@ export function AnalyticsClient({
                 />
                 <ReferenceLine
                   y={50}
-                  stroke="oklch(0.35 0.02 260)"
+                  stroke={cc.chartReference}
                   strokeDasharray="3 3"
-                  label={{ value: "50%", fill: "oklch(0.55 0.02 260)", fontSize: 11 }}
+                  label={{ value: "50%", fill: cc.chartAxis, fontSize: 11 }}
                 />
                 {/* Shaded bands between coaching sessions */}
                 {coachingBands.bands.map((band, i) => (
@@ -782,8 +784,8 @@ export function AnalyticsClient({
                     key={`band-${i}`}
                     x1={band.x1}
                     x2={band.x2}
-                    fill={band.isOngoing ? "oklch(0.6 0.2 300 / 0.08)" : "oklch(0.6 0.2 300 / 0.12)"}
-                    fillOpacity={1}
+                    fill={cc.neonPurple}
+                    fillOpacity={band.isOngoing ? 0.08 : 0.12}
                     strokeOpacity={0}
                   />
                 ))}
@@ -792,11 +794,12 @@ export function AnalyticsClient({
                   <ReferenceLine
                     key={`session-${i}`}
                     x={s.index}
-                    stroke={s.status === "scheduled" ? "oklch(0.6 0.2 300 / 0.6)" : "oklch(0.6 0.2 300)"}
+                    stroke={cc.neonPurple}
+                    strokeOpacity={s.status === "scheduled" ? 0.6 : 1}
                     strokeDasharray={s.status === "scheduled" ? "6 4" : "4 4"}
                     label={{
                       value: s.coachName,
-                      fill: "oklch(0.6 0.2 300)",
+                      fill: cc.neonPurple,
                       fontSize: 10,
                       position: "top",
                     }}
@@ -805,7 +808,7 @@ export function AnalyticsClient({
                 <Line
                   type="monotone"
                   dataKey="winRate"
-                  stroke="oklch(0.78 0.14 80)"
+                  stroke={cc.gold}
                   strokeWidth={2}
                   dot={false}
                   activeDot={{ r: 4 }}
@@ -831,19 +834,19 @@ export function AnalyticsClient({
             <div style={{ height: Math.max(200, topMatchups.length * 40 + 40) }}>
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={topMatchups} layout="vertical">
-                  <CartesianGrid strokeDasharray="3 3" stroke="oklch(0.25 0.03 260)" />
+                  <CartesianGrid strokeDasharray="3 3" stroke={cc.chartGrid} />
                   <XAxis
                     type="number"
                     domain={[0, 100]}
                     tickFormatter={(v) => `${v}%`}
-                    stroke="oklch(0.55 0.02 260)"
+                    stroke={cc.chartAxis}
                     fontSize={12}
                   />
                   <YAxis
                     type="category"
                     dataKey="name"
                     width={100}
-                    stroke="oklch(0.55 0.02 260)"
+                    stroke={cc.chartAxis}
                     fontSize={12}
                     tick={({ x, y, payload }: { x: string | number; y: string | number; payload: { value: string } }) => (
                       <a href={`/scout?enemy=${encodeURIComponent(payload.value)}`}>
@@ -860,7 +863,7 @@ export function AnalyticsClient({
                             x={-74}
                             y={0}
                             dy={4}
-                            fill="oklch(0.75 0.02 260)"
+                            fill={cc.mutedForeground}
                             fontSize={12}
                             textAnchor="start"
                           >
@@ -871,7 +874,7 @@ export function AnalyticsClient({
                     )}
                   />
                   <Tooltip
-                    cursor={{ fill: "oklch(0.25 0.03 260 / 0.3)" }}
+                    cursor={{ fill: `color-mix(in oklch, ${cc.chartGrid}, transparent 70%)` }}
                     content={({ active, payload }) => {
                       if (!active || !payload || !payload[0]) return null;
                       const d = payload[0].payload as (typeof topMatchups)[0];
@@ -880,7 +883,7 @@ export function AnalyticsClient({
                           <p className="font-semibold text-foreground">{d.name}</p>
                           <p className="text-sm">
                             Win Rate:{" "}
-                            <span className={d.winRate >= 50 ? "text-gold" : "text-red-400"}>
+                            <span className={d.winRate >= 50 ? "text-gold" : "text-loss"}>
                               {d.winRate}%
                             </span>{" "}
                             <span className="text-muted-foreground">
@@ -891,12 +894,12 @@ export function AnalyticsClient({
                       );
                     }}
                   />
-                  <ReferenceLine x={50} stroke="oklch(0.35 0.02 260)" strokeDasharray="3 3" />
+                  <ReferenceLine x={50} stroke={cc.chartReference} strokeDasharray="3 3" />
                   <Bar dataKey="winRate" radius={[0, 4, 4, 0]}>
                     {topMatchups.map((entry, index) => (
                       <Cell
                         key={index}
-                        fill={entry.winRate >= 50 ? "oklch(0.78 0.14 80)" : "#ef4444"}
+                        fill={entry.winRate >= 50 ? cc.gold : cc.loss}
                       />
                     ))}
                   </Bar>

--- a/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
+++ b/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
@@ -120,8 +120,8 @@ function ActionItemRow({ item }: { item: CoachingActionItem }) {
 
   const icons = {
     pending: <Circle className="h-4 w-4 text-muted-foreground" />,
-    in_progress: <Play className="h-4 w-4 text-yellow-500" />,
-    completed: <CheckCircle2 className="h-4 w-4 text-green-400" />,
+    in_progress: <Play className="h-4 w-4 text-status-progress" />,
+    completed: <CheckCircle2 className="h-4 w-4 text-win" />,
   };
 
   return (
@@ -383,8 +383,8 @@ export function CoachingDetailClient({
                       <div
                         className={`w-1 h-8 rounded-full ${
                           match.result === "Victory"
-                            ? "bg-green-500"
-                            : "bg-red-500"
+                            ? "bg-win"
+                            : "bg-loss"
                         }`}
                       />
                       <Image
@@ -536,12 +536,12 @@ export function CoachingDetailClient({
                 <div className="rounded-lg border border-border/50 bg-surface-elevated p-3 text-center">
                   <div className="flex items-center justify-center gap-2">
                     {progressStats.relevantHighlights > 0 && (
-                      <span className="text-sm font-bold text-green-400">
+                      <span className="text-sm font-bold text-win">
                         {progressStats.relevantHighlights}
                       </span>
                     )}
                     {progressStats.relevantLowlights > 0 && (
-                      <span className="text-sm font-bold text-red-400">
+                      <span className="text-sm font-bold text-loss">
                         {progressStats.relevantLowlights}
                       </span>
                     )}
@@ -592,8 +592,8 @@ export function CoachingDetailClient({
                         <div
                           className={`w-1 h-6 rounded-full ${
                             match.result === "Victory"
-                              ? "bg-green-500"
-                              : "bg-red-500"
+                              ? "bg-win"
+                              : "bg-loss"
                           }`}
                         />
                         <Image
@@ -668,8 +668,8 @@ export function CoachingDetailClient({
                                   <Swords
                                     className={`h-3 w-3 mt-0.5 shrink-0 ${
                                       h.type === "highlight"
-                                        ? "text-green-400"
-                                        : "text-red-400"
+                                        ? "text-win"
+                                        : "text-loss"
                                     }`}
                                   />
                                   <span

--- a/src/app/(app)/coaching/action-items/action-items-client.tsx
+++ b/src/app/(app)/coaching/action-items/action-items-client.tsx
@@ -82,8 +82,8 @@ function ActionItemRow({ item, locale }: { item: ActionItemWithSession; locale: 
 
   const icons: Record<string, React.ReactNode> = {
     pending: <Circle className="h-4 w-4 text-muted-foreground" />,
-    in_progress: <Play className="h-4 w-4 text-yellow-500" />,
-    completed: <CheckCircle2 className="h-4 w-4 text-green-400" />,
+    in_progress: <Play className="h-4 w-4 text-status-progress" />,
+    completed: <CheckCircle2 className="h-4 w-4 text-win" />,
   };
 
   const dateStr = formatDate(item.sessionDate, locale, "short-compact");

--- a/src/app/(app)/coaching/coaching-hub-client.tsx
+++ b/src/app/(app)/coaching/coaching-hub-client.tsx
@@ -88,8 +88,8 @@ function ActionItemMiniRow({ item }: { item: CoachingActionItem }) {
 
   const icons = {
     pending: <Circle className="h-3.5 w-3.5 text-muted-foreground" />,
-    in_progress: <Play className="h-3.5 w-3.5 text-yellow-500" />,
-    completed: <CheckCircle2 className="h-3.5 w-3.5 text-green-400" />,
+    in_progress: <Play className="h-3.5 w-3.5 text-status-progress" />,
+    completed: <CheckCircle2 className="h-3.5 w-3.5 text-win" />,
   };
 
   return (
@@ -201,7 +201,7 @@ export function CoachingHubClient({
                         </div>
                         <div className="flex items-center gap-2">
                           {!session.vodMatchId && (
-                            <Badge variant="outline" className="text-[10px] px-1.5 py-0 border-amber-500/40 text-amber-400">
+                            <Badge variant="outline" className="text-[10px] px-1.5 py-0 border-warning/40 text-warning">
                               <AlertTriangle className="h-2.5 w-2.5 mr-0.5" />
                               {t("badgeNoVod")}
                             </Badge>
@@ -361,7 +361,7 @@ export function CoachingHubClient({
                         )}
                         {/* Nudges for incomplete session data */}
                         {(topics.length === 0 || !items || items.total === 0) && (
-                          <p className="text-xs text-amber-400 flex items-center gap-1 mt-2">
+                          <p className="text-xs text-warning flex items-center gap-1 mt-2">
                             <AlertTriangle className="h-3 w-3 shrink-0" />
                             {topics.length === 0 && (!items || items.total === 0)
                               ? t("missingFocusAreasAndActionItems")
@@ -383,10 +383,10 @@ export function CoachingHubClient({
                         {t("intervalGames", { count: interval.matchCount })}
                       </span>
                       <span className="font-mono">
-                        <span className="text-green-400">
+                        <span className="text-win">
                           {interval.wins}W
                         </span>{" "}
-                        <span className="text-red-400">
+                        <span className="text-loss">
                           {interval.losses}L
                         </span>
                       </span>

--- a/src/app/(app)/coaching/new/schedule-session-client.tsx
+++ b/src/app/(app)/coaching/new/schedule-session-client.tsx
@@ -243,9 +243,9 @@ export function ScheduleSessionClient({
                     </div>
                     <div
                       className={`w-1 h-6 rounded-full ${
-                        match.result === "Victory"
-                          ? "bg-green-500"
-                          : "bg-red-500"
+                         match.result === "Victory"
+                          ? "bg-win"
+                          : "bg-loss"
                       }`}
                     />
                     <span className="text-sm font-medium inline-flex items-center gap-1.5">

--- a/src/app/(app)/dashboard/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/dashboard-client.tsx
@@ -206,7 +206,7 @@ export function DashboardClient({
                 {lpTrend !== null && (
                   <p
                     className={`text-xs font-mono font-semibold mt-1 flex items-center gap-1 ${
-                      lpTrend >= 0 ? "text-green-400" : "text-red-400"
+                      lpTrend >= 0 ? "text-win" : "text-loss"
                     }`}
                   >
                     {lpTrend >= 0 ? (
@@ -235,9 +235,9 @@ export function DashboardClient({
             <div className="flex items-center gap-2">
               <p className="text-2xl font-bold">{sessionWinRate}%</p>
               {sessionWinRate >= 50 ? (
-                <TrendingUp className="h-4 w-4 text-green-400" />
+                <TrendingUp className="h-4 w-4 text-win" />
               ) : recentMatches.length > 0 ? (
-                <TrendingDown className="h-4 w-4 text-red-400" />
+                <TrendingDown className="h-4 w-4 text-loss" />
               ) : null}
             </div>
             <p className="text-sm text-muted-foreground">
@@ -258,9 +258,9 @@ export function DashboardClient({
             {streak ? (
               <div className="flex items-center gap-2">
                 {streak.type === "W" ? (
-                  <Flame className="h-5 w-5 text-orange-500" />
+                  <Flame className="h-5 w-5 text-streak-hot" />
                 ) : (
-                  <Snowflake className="h-5 w-5 text-blue-400" />
+                  <Snowflake className="h-5 w-5 text-streak-cold" />
                 )}
                 <p className="text-2xl font-bold">
                   {streak.count}{streak.type}
@@ -321,9 +321,9 @@ export function DashboardClient({
                   >
                     <div
                       className={`w-1 h-8 rounded-full ${
-                        match.result === "Victory"
-                          ? "bg-green-500"
-                          : "bg-red-500"
+                         match.result === "Victory"
+                          ? "bg-win"
+                          : "bg-loss"
                       }`}
                     />
                     <Image
@@ -410,7 +410,7 @@ export function DashboardClient({
                   {formatDate(upcomingSession.date, locale, "datetime-short")}
                 </p>
                 {!upcomingSession.vodMatchId && (
-                  <p className="text-xs text-amber-400 flex items-center gap-1 mt-1">
+                  <p className="text-xs text-warning flex items-center gap-1 mt-1">
                     <AlertCircle className="h-3 w-3" />
                     {t("noVodSelected")}
                   </p>

--- a/src/app/(app)/duo/duo-client.tsx
+++ b/src/app/(app)/duo/duo-client.tsx
@@ -177,7 +177,7 @@ export function DuoStatsCards({ stats }: { stats: DuoStats }) {
           </div>
           <p
             className={`text-2xl font-bold ${
-              stats.winRate >= 50 ? "text-emerald-400" : "text-red-400"
+              stats.winRate >= 50 ? "text-win" : "text-loss"
             }`}
           >
             {stats.winRate}%
@@ -196,7 +196,7 @@ export function DuoStatsCards({ stats }: { stats: DuoStats }) {
           </div>
           <p
             className={`text-2xl font-bold ${
-              stats.soloWinRate >= 50 ? "text-emerald-400" : "text-red-400"
+              stats.soloWinRate >= 50 ? "text-win" : "text-loss"
             }`}
           >
             {stats.soloWinRate}%
@@ -211,9 +211,9 @@ export function DuoStatsCards({ stats }: { stats: DuoStats }) {
         <CardContent className="pt-6">
           <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
             {stats.winRate > stats.soloWinRate ? (
-              <TrendingUp className="h-4 w-4 text-emerald-400" />
+              <TrendingUp className="h-4 w-4 text-win" />
             ) : stats.winRate < stats.soloWinRate ? (
-              <TrendingDown className="h-4 w-4 text-red-400" />
+              <TrendingDown className="h-4 w-4 text-loss" />
             ) : (
               <Swords className="h-4 w-4" />
             )}
@@ -222,9 +222,9 @@ export function DuoStatsCards({ stats }: { stats: DuoStats }) {
           <p
             className={`text-2xl font-bold ${
               stats.winRate - stats.soloWinRate > 0
-                ? "text-emerald-400"
+                ? "text-win"
                 : stats.winRate - stats.soloWinRate < 0
-                  ? "text-red-400"
+                  ? "text-loss"
                   : ""
             }`}
           >
@@ -256,9 +256,9 @@ export function DuoKdaCards({
         </CardHeader>
         <CardContent>
           <p className="text-xl font-bold">
-            <span className="text-emerald-400">{stats.avgKills}</span>
+            <span className="text-kills">{stats.avgKills}</span>
             {" / "}
-            <span className="text-red-400">{stats.avgDeaths}</span>
+            <span className="text-deaths">{stats.avgDeaths}</span>
             {" / "}
             <span className="text-gold">{stats.avgAssists}</span>
           </p>
@@ -273,9 +273,9 @@ export function DuoKdaCards({
         </CardHeader>
         <CardContent>
           <p className="text-xl font-bold">
-            <span className="text-emerald-400">{stats.partnerAvgKills}</span>
+            <span className="text-kills">{stats.partnerAvgKills}</span>
             {" / "}
-            <span className="text-red-400">{stats.partnerAvgDeaths}</span>
+            <span className="text-deaths">{stats.partnerAvgDeaths}</span>
             {" / "}
             <span className="text-gold">{stats.partnerAvgAssists}</span>
           </p>
@@ -391,7 +391,7 @@ export function DuoSynergyCard({
               <div className="text-right text-sm">
                 <span
                   className={`font-bold ${
-                    s.winRate >= 50 ? "text-emerald-400" : "text-red-400"
+                    s.winRate >= 50 ? "text-win" : "text-loss"
                   }`}
                 >
                   {s.winRate}%
@@ -462,7 +462,7 @@ export function DuoRecentGames({
                   }
                   className={`w-12 justify-center text-xs ${
                     game.result === "Victory"
-                      ? "bg-emerald-400/20 text-emerald-400 border-emerald-400/30"
+                      ? "bg-win/20 text-win border-win/30"
                       : ""
                   }`}
                 >

--- a/src/app/(app)/matches/[id]/match-detail-client.tsx
+++ b/src/app/(app)/matches/[id]/match-detail-client.tsx
@@ -247,7 +247,7 @@ export function MatchDetailClient({
                   </Badge>
                 )}
                 {!match.reviewed && hasAnyNotes && (
-                  <Badge variant="outline" className="gap-1 text-yellow-500 border-yellow-500/30">
+                  <Badge variant="outline" className="gap-1 text-warning border-warning/30">
                     <EyeOff className="h-3 w-3" />
                     {t("pendingReview")}
                   </Badge>
@@ -513,7 +513,7 @@ export function MatchDetailClient({
 
                     {/* Review status badge */}
                     {match.reviewed && !hasReviewNotes && !match.reviewSkippedReason && (
-                      <p className="text-xs text-green-400 flex items-center gap-1.5">
+                      <p className="text-xs text-win flex items-center gap-1.5">
                         <Eye className="h-3 w-3" />
                         {t("markedAsReviewed")}
                       </p>

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -110,7 +110,7 @@ function MatchCardHeader({
     <div className="flex items-center gap-3">
       <div
         className={`w-1 h-10 rounded-full ${
-          match.result === "Victory" ? "bg-green-500" : "bg-red-500"
+          match.result === "Victory" ? "bg-win" : "bg-loss"
         }`}
       />
       <Image

--- a/src/app/(app)/scout/scout-client.tsx
+++ b/src/app/(app)/scout/scout-client.tsx
@@ -100,8 +100,8 @@ function ScoutingReport({
           <h2 className="text-xl font-bold">{t("vs")} {report.matchupChampionName}</h2>
           <div className="flex items-center gap-3 mt-1">
             <span className="text-lg font-mono">
-              <span className="text-green-400">{record.wins}W</span>{" "}
-              <span className="text-red-400">{record.losses}L</span>
+              <span className="text-win">{record.wins}W</span>{" "}
+              <span className="text-loss">{record.losses}L</span>
             </span>
             <Badge
               variant={record.winRate >= 50 ? "default" : "destructive"}
@@ -238,8 +238,8 @@ function ScoutingReport({
                     <span
                       className={`font-bold ${
                         pair.winRate >= 50
-                          ? "text-emerald-400"
-                          : "text-red-400"
+                          ? "text-win"
+                          : "text-loss"
                       }`}
                     >
                       {pair.winRate}%
@@ -333,9 +333,9 @@ function StatCell({
         <p
           className={`text-[10px] font-mono mt-0.5 flex items-center justify-center gap-0.5 ${
             isPositive
-              ? "text-green-400"
+              ? "text-win"
               : isNegative
-              ? "text-red-400"
+              ? "text-loss"
               : "text-muted-foreground"
           }`}
         >

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -146,6 +146,27 @@
   --color-surface: var(--surface);
   --color-surface-elevated: var(--surface-elevated);
 
+  /* Semantic gameplay colors */
+  --color-win: var(--win);
+  --color-loss: var(--loss);
+  --color-win-muted: var(--win-muted);
+  --color-loss-muted: var(--loss-muted);
+  --color-warning: var(--warning);
+  --color-status-progress: var(--status-progress);
+  --color-streak-hot: var(--streak-hot);
+  --color-streak-cold: var(--streak-cold);
+  --color-kills: var(--kills);
+  --color-deaths: var(--deaths);
+
+  /* Chart semantic colors */
+  --color-chart-grid: var(--chart-grid);
+  --color-chart-axis: var(--chart-axis);
+  --color-chart-tooltip-bg: var(--chart-tooltip-bg);
+  --color-chart-tooltip-border: var(--chart-tooltip-border);
+  --color-chart-reference: var(--chart-reference);
+  --color-chart-promotion: var(--chart-promotion);
+  --color-chart-demotion: var(--chart-demotion);
+
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
@@ -200,6 +221,27 @@
   --sidebar-accent-foreground: oklch(0.2 0.02 260);
   --sidebar-border: oklch(0.88 0.01 260);
   --sidebar-ring: oklch(0.78 0.14 80);
+
+  /* Semantic gameplay colors - light mode */
+  --win: oklch(0.55 0.16 150);
+  --loss: oklch(0.55 0.22 27);
+  --win-muted: oklch(0.60 0.12 150);
+  --loss-muted: oklch(0.60 0.16 27);
+  --warning: oklch(0.65 0.16 65);
+  --status-progress: oklch(0.65 0.16 85);
+  --streak-hot: oklch(0.60 0.20 45);
+  --streak-cold: oklch(0.55 0.14 250);
+  --kills: oklch(0.55 0.16 150);
+  --deaths: oklch(0.55 0.22 27);
+
+  /* Chart colors - light mode */
+  --chart-grid: oklch(0.88 0.01 260);
+  --chart-axis: oklch(0.55 0.02 260);
+  --chart-tooltip-bg: oklch(0.98 0.005 260);
+  --chart-tooltip-border: oklch(0.88 0.01 260);
+  --chart-reference: oklch(0.78 0.01 260);
+  --chart-promotion: oklch(0.50 0.16 150);
+  --chart-demotion: oklch(0.55 0.22 27);
 }
 
 /* ===== DARK MODE (primary) ===== */
@@ -262,6 +304,27 @@
   --sidebar-accent-foreground: oklch(0.88 0.01 250);
   --sidebar-border: oklch(0.25 0.03 260);
   --sidebar-ring: oklch(0.78 0.14 80);
+
+  /* Semantic gameplay colors - dark mode */
+  --win: oklch(0.72 0.17 150);
+  --loss: oklch(0.68 0.22 27);
+  --win-muted: oklch(0.65 0.12 150);
+  --loss-muted: oklch(0.60 0.16 27);
+  --warning: oklch(0.78 0.14 65);
+  --status-progress: oklch(0.80 0.14 85);
+  --streak-hot: oklch(0.70 0.18 45);
+  --streak-cold: oklch(0.68 0.14 250);
+  --kills: oklch(0.72 0.17 150);
+  --deaths: oklch(0.68 0.22 27);
+
+  /* Chart colors - dark mode */
+  --chart-grid: oklch(0.25 0.03 260);
+  --chart-axis: oklch(0.55 0.02 260);
+  --chart-tooltip-bg: oklch(0.18 0.03 260);
+  --chart-tooltip-border: oklch(0.25 0.03 260);
+  --chart-reference: oklch(0.35 0.02 260);
+  --chart-promotion: oklch(0.72 0.15 150);
+  --chart-demotion: oklch(0.65 0.22 27);
 }
 
 @layer base {
@@ -289,8 +352,8 @@
 
   /* Selection color - gold */
   ::selection {
-    background-color: oklch(0.78 0.14 80 / 0.3);
-    color: oklch(1 0 0);
+    background-color: oklch(from var(--gold) l c h / 0.3);
+    color: var(--foreground);
   }
 }
 
@@ -299,38 +362,44 @@
   /* Gold glow effect for primary actions */
   .glow-gold {
     box-shadow:
-      0 0 15px oklch(0.78 0.14 80 / 0.3),
-      0 0 45px oklch(0.78 0.14 80 / 0.1);
+      0 0 15px oklch(from var(--gold) l c h / 0.3),
+      0 0 45px oklch(from var(--gold) l c h / 0.1);
   }
 
   .glow-gold-sm {
     box-shadow:
-      0 0 8px oklch(0.78 0.14 80 / 0.25),
-      0 0 20px oklch(0.78 0.14 80 / 0.08);
+      0 0 8px oklch(from var(--gold) l c h / 0.25),
+      0 0 20px oklch(from var(--gold) l c h / 0.08);
   }
 
   /* Electric blue glow */
   .glow-electric {
     box-shadow:
-      0 0 15px oklch(0.65 0.17 250 / 0.3),
-      0 0 45px oklch(0.65 0.17 250 / 0.1);
+      0 0 15px oklch(from var(--electric) l c h / 0.3),
+      0 0 45px oklch(from var(--electric) l c h / 0.1);
   }
 
   .glow-electric-sm {
     box-shadow:
-      0 0 8px oklch(0.65 0.17 250 / 0.25),
-      0 0 20px oklch(0.65 0.17 250 / 0.08);
+      0 0 8px oklch(from var(--electric) l c h / 0.25),
+      0 0 20px oklch(from var(--electric) l c h / 0.08);
   }
 
   /* Purple glow */
   .glow-purple {
     box-shadow:
-      0 0 15px oklch(0.6 0.2 300 / 0.3),
-      0 0 45px oklch(0.6 0.2 300 / 0.1);
+      0 0 15px oklch(from var(--neon-purple) l c h / 0.3),
+      0 0 45px oklch(from var(--neon-purple) l c h / 0.1);
   }
 
   /* Subtle surface elevation */
   .surface-glow {
+    box-shadow:
+      0 1px 2px oklch(0 0 0 / 0.06),
+      0 4px 16px oklch(0 0 0 / 0.04),
+      inset 0 1px 0 oklch(1 0 0 / 0.06);
+  }
+  :is(.dark) .surface-glow {
     box-shadow:
       0 1px 2px oklch(0 0 0 / 0.3),
       0 4px 16px oklch(0 0 0 / 0.2),
@@ -339,20 +408,20 @@
 
   /* Border glow on hover */
   .border-glow-gold {
-    border-color: oklch(0.78 0.14 80 / 0.4);
-    box-shadow: 0 0 10px oklch(0.78 0.14 80 / 0.15);
+    border-color: oklch(from var(--gold) l c h / 0.4);
+    box-shadow: 0 0 10px oklch(from var(--gold) l c h / 0.15);
   }
 
   /* Text gradient utility */
   .text-gradient-gold {
-    background: linear-gradient(135deg, oklch(0.78 0.14 80), oklch(0.85 0.12 80), oklch(0.7 0.15 65));
+    background: linear-gradient(135deg, var(--gold), var(--gold-light), var(--gold-dark));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
   }
 
   .text-gradient-electric {
-    background: linear-gradient(135deg, oklch(0.65 0.17 250), oklch(0.6 0.2 300));
+    background: linear-gradient(135deg, var(--electric), var(--neon-purple));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -361,9 +430,9 @@
   /* Animated gradient background mesh */
   .bg-mesh {
     background-image:
-      radial-gradient(at 20% 20%, oklch(0.65 0.17 250 / 0.08) 0px, transparent 50%),
-      radial-gradient(at 80% 80%, oklch(0.78 0.14 80 / 0.06) 0px, transparent 50%),
-      radial-gradient(at 50% 50%, oklch(0.6 0.2 300 / 0.04) 0px, transparent 50%);
+      radial-gradient(at 20% 20%, oklch(from var(--electric) l c h / 0.08) 0px, transparent 50%),
+      radial-gradient(at 80% 80%, oklch(from var(--gold) l c h / 0.06) 0px, transparent 50%),
+      radial-gradient(at 50% 50%, oklch(from var(--neon-purple) l c h / 0.04) 0px, transparent 50%);
   }
 
   /* Card hover lift */
@@ -377,7 +446,8 @@
   /* Changelog MDX prose — lightweight typography for rendered markdown */
   .changelog-prose {
     line-height: 1.7;
-    color: oklch(0.85 0 0);
+    color: var(--foreground);
+    opacity: 0.85;
   }
   .changelog-prose p {
     margin-bottom: 0.75rem;
@@ -386,13 +456,14 @@
     margin-bottom: 0;
   }
   .changelog-prose strong {
-    color: oklch(0.95 0 0);
+    color: var(--foreground);
     font-weight: 600;
+    opacity: 1;
   }
   .changelog-prose h3 {
     font-size: 1rem;
     font-weight: 600;
-    color: oklch(0.78 0.14 80);
+    color: var(--gold);
     margin-top: 1.25rem;
     margin-bottom: 0.5rem;
   }
@@ -405,15 +476,15 @@
     margin-bottom: 0.25rem;
   }
   .changelog-prose a {
-    color: oklch(0.78 0.14 80);
+    color: var(--gold);
     text-decoration: underline;
     text-underline-offset: 2px;
   }
   .changelog-prose a:hover {
-    color: oklch(0.85 0.16 80);
+    color: var(--gold-light);
   }
   .changelog-prose code {
-    background: oklch(0.25 0 0);
+    background: var(--muted);
     padding: 0.125rem 0.375rem;
     border-radius: 0.25rem;
     font-size: 0.875em;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
+import { ThemeProvider } from "next-themes";
 import "./globals.css";
 
 const inter = Inter({
@@ -31,10 +32,18 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`${inter.variable} ${jetbrainsMono.variable} dark h-full antialiased`}
+      className={`${inter.variable} ${jetbrainsMono.variable} h-full antialiased`}
+      suppressHydrationWarning
     >
       <body className="min-h-screen bg-background font-sans antialiased">
-        {children}
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          enableSystem
+          disableTransitionOnChange
+        >
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -25,6 +25,7 @@ import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
 
@@ -261,14 +262,17 @@ function SidebarContent({
               </p>
             )}
           </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 shrink-0 hover:text-destructive"
-            onClick={() => signOut({ callbackUrl: "/login" })}
-          >
-            <LogOut className="h-4 w-4" />
-          </Button>
+          <div className="flex items-center gap-1 shrink-0">
+            <ThemeToggle />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 hover:text-destructive"
+              onClick={() => signOut({ callbackUrl: "/login" })}
+            >
+              <LogOut className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/highlights-editor.tsx
+++ b/src/components/highlights-editor.tsx
@@ -87,7 +87,7 @@ export function HighlightsEditor({
       {/* Highlights */}
       <div className="space-y-2">
         <label className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
-          <ThumbsUp className="h-3 w-3 text-green-400" />
+          <ThumbsUp className="h-3 w-3 text-win" />
           {t("highlightsLabel", { count: highlightItems.length, max: maxPerType })}
         </label>
 
@@ -97,7 +97,7 @@ export function HighlightsEditor({
           return (
             <div
               key={idx}
-              className="flex items-center gap-2 rounded-md border border-green-400/20 bg-green-400/5 px-3 py-1.5 text-sm"
+              className="flex items-center gap-2 rounded-md border border-win/20 bg-win/5 px-3 py-1.5 text-sm"
             >
               {item.topic && (
                 <Badge variant="secondary" className="text-[10px] shrink-0">
@@ -161,7 +161,7 @@ export function HighlightsEditor({
       {/* Lowlights */}
       <div className="space-y-2">
         <label className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
-          <ThumbsDown className="h-3 w-3 text-red-400" />
+          <ThumbsDown className="h-3 w-3 text-loss" />
           {t("lowlightsLabel", { count: lowlightItems.length, max: maxPerType })}
         </label>
 
@@ -171,7 +171,7 @@ export function HighlightsEditor({
           return (
             <div
               key={idx}
-              className="flex items-center gap-2 rounded-md border border-red-400/20 bg-red-400/5 px-3 py-1.5 text-sm"
+              className="flex items-center gap-2 rounded-md border border-loss/20 bg-loss/5 px-3 py-1.5 text-sm"
             >
               {item.topic && (
                 <Badge variant="secondary" className="text-[10px] shrink-0">
@@ -262,8 +262,8 @@ export function HighlightsDisplay({
                 <TooltipTrigger
                   className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] cursor-default ${
                     hasText
-                      ? "bg-green-400/20 text-green-300"
-                      : "bg-green-400/10 text-green-400"
+                      ? "bg-win/20 text-win-muted"
+                      : "bg-win/10 text-win"
                   }`}
                 >
                   <ThumbsUp className="h-2.5 w-2.5" />
@@ -284,8 +284,8 @@ export function HighlightsDisplay({
                 <TooltipTrigger
                   className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] cursor-default ${
                     hasText
-                      ? "bg-red-400/20 text-red-300"
-                      : "bg-red-400/10 text-red-400"
+                      ? "bg-loss/20 text-loss-muted"
+                      : "bg-loss/10 text-loss"
                   }`}
                 >
                   <ThumbsDown className="h-2.5 w-2.5" />
@@ -309,16 +309,16 @@ export function HighlightsDisplay({
       {highlightItems.length > 0 && (
         <div className="space-y-1.5">
           <p className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
-            <ThumbsUp className="h-3 w-3 text-green-400" />
+            <ThumbsUp className="h-3 w-3 text-win" />
             {t("highlightsHeading")}
           </p>
           {highlightItems.map((item, i) => (
             <div
               key={i}
-              className="flex items-start gap-2 rounded-md border border-green-400/20 border-l-2 border-l-green-400/50 bg-green-400/5 px-3 py-2 text-sm"
+              className="flex items-start gap-2 rounded-md border border-win/20 border-l-2 border-l-win/50 bg-win/5 px-3 py-2 text-sm"
             >
               {item.topic && (
-                <Badge variant="secondary" className="text-[10px] shrink-0 mt-0.5 bg-green-400/10 text-green-300 border-green-400/20">
+                <Badge variant="secondary" className="text-[10px] shrink-0 mt-0.5 bg-win/10 text-win-muted border-win/20">
                   {item.topic}
                 </Badge>
               )}
@@ -330,16 +330,16 @@ export function HighlightsDisplay({
       {lowlightItems.length > 0 && (
         <div className="space-y-1.5">
           <p className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
-            <ThumbsDown className="h-3 w-3 text-red-400" />
+            <ThumbsDown className="h-3 w-3 text-loss" />
             {t("lowlightsHeading")}
           </p>
           {lowlightItems.map((item, i) => (
             <div
               key={i}
-              className="flex items-start gap-2 rounded-md border border-red-400/20 border-l-2 border-l-red-400/50 bg-red-400/5 px-3 py-2 text-sm"
+              className="flex items-start gap-2 rounded-md border border-loss/20 border-l-2 border-l-loss/50 bg-loss/5 px-3 py-2 text-sm"
             >
               {item.topic && (
-                <Badge variant="secondary" className="text-[10px] shrink-0 mt-0.5 bg-red-400/10 text-red-300 border-red-400/20">
+                <Badge variant="secondary" className="text-[10px] shrink-0 mt-0.5 bg-loss/10 text-loss-muted border-loss/20">
                   {item.topic}
                 </Badge>
               )}

--- a/src/components/match-card.tsx
+++ b/src/components/match-card.tsx
@@ -116,8 +116,8 @@ export function MatchCard({
         href={`/matches/${match.id}`}
         className={`block rounded-lg border bg-card transition-all hover:bg-surface-elevated/50 ${
           isWin
-            ? "border-l-[3px] border-l-green-500/60"
-            : "border-l-[3px] border-l-red-500/60"
+            ? "border-l-[3px] border-l-win/60"
+            : "border-l-[3px] border-l-loss/60"
         }`}
       >
         <div className="flex items-center gap-3 px-4 py-3">
@@ -165,8 +165,8 @@ export function MatchCard({
                       <TooltipTrigger
                         className={`inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[10px] cursor-default ${
                           hasText
-                            ? "bg-green-400/20 text-green-300"
-                            : "bg-green-400/10 text-green-400"
+                            ? "bg-win/20 text-win-muted"
+                            : "bg-win/10 text-win"
                         }`}
                       >
                         <ThumbsUp className="h-2.5 w-2.5" />
@@ -187,8 +187,8 @@ export function MatchCard({
                       <TooltipTrigger
                         className={`inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[10px] cursor-default ${
                           hasText
-                            ? "bg-red-400/20 text-red-300"
-                            : "bg-red-400/10 text-red-400"
+                            ? "bg-loss/20 text-loss-muted"
+                            : "bg-loss/10 text-loss"
                         }`}
                       >
                         <ThumbsDown className="h-2.5 w-2.5" />
@@ -255,7 +255,7 @@ export function MatchCard({
             {match.reviewed && (
               <Tooltip>
                 <TooltipTrigger className="cursor-default">
-                  <Eye className="h-3.5 w-3.5 text-green-400/70" />
+                  <Eye className="h-3.5 w-3.5 text-win/70" />
                 </TooltipTrigger>
                 <TooltipContent side="bottom" className="max-w-sm">
                   <p className="line-clamp-4 whitespace-pre-wrap">{reviewStatusText}</p>
@@ -265,7 +265,7 @@ export function MatchCard({
             {!match.reviewed && (hasReviewNotes || hasHighlights || hasComment) && (
               <Tooltip>
                 <TooltipTrigger className="cursor-default">
-                  <EyeOff className="h-3.5 w-3.5 text-yellow-500/70" />
+                  <EyeOff className="h-3.5 w-3.5 text-warning/70" />
                 </TooltipTrigger>
                 <TooltipContent>{t("hasNotesNotReviewed")}</TooltipContent>
               </Tooltip>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Sun, Moon, Monitor } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useSyncExternalStore } from "react";
+
+const emptySubscribe = () => () => {};
+const getSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+function useMounted() {
+  return useSyncExternalStore(emptySubscribe, getSnapshot, getServerSnapshot);
+}
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const mounted = useMounted();
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" size="icon" className="h-8 w-8" disabled>
+        <Moon className="h-4 w-4" />
+      </Button>
+    );
+  }
+
+  const cycleTheme = () => {
+    if (theme === "dark") setTheme("light");
+    else if (theme === "light") setTheme("system");
+    else setTheme("dark");
+  };
+
+  const icon =
+    theme === "dark" ? (
+      <Moon className="h-4 w-4" />
+    ) : theme === "light" ? (
+      <Sun className="h-4 w-4" />
+    ) : (
+      <Monitor className="h-4 w-4" />
+    );
+
+  const label =
+    theme === "dark" ? "Dark" : theme === "light" ? "Light" : "System";
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-8 w-8 text-muted-foreground hover:text-foreground"
+      onClick={cycleTheme}
+      title={`Theme: ${label}. Click to switch.`}
+    >
+      {icon}
+    </Button>
+  );
+}

--- a/src/hooks/use-chart-colors.ts
+++ b/src/hooks/use-chart-colors.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+import { useTheme } from "next-themes";
+
+/**
+ * Reads computed CSS variable values so they can be passed as color strings
+ * to Recharts (which only accepts inline color values, not CSS custom
+ * properties).
+ *
+ * Re-reads on theme change so charts update when toggling light/dark.
+ */
+
+export interface ChartColors {
+  gold: string;
+  goldLight: string;
+  goldDark: string;
+  electric: string;
+  neonPurple: string;
+  chartGrid: string;
+  chartAxis: string;
+  chartTooltipBg: string;
+  chartTooltipBorder: string;
+  chartReference: string;
+  chartPromotion: string;
+  chartDemotion: string;
+  background: string;
+  foreground: string;
+  mutedForeground: string;
+  border: string;
+  surfaceElevated: string;
+  win: string;
+  loss: string;
+}
+
+function readColors(): ChartColors {
+  if (typeof window === "undefined") return {} as ChartColors;
+  const cs = getComputedStyle(document.documentElement);
+  const read = (varName: string) => cs.getPropertyValue(varName).trim();
+
+  return {
+    gold: read("--gold"),
+    goldLight: read("--gold-light"),
+    goldDark: read("--gold-dark"),
+    electric: read("--electric"),
+    neonPurple: read("--neon-purple"),
+    chartGrid: read("--chart-grid"),
+    chartAxis: read("--chart-axis"),
+    chartTooltipBg: read("--chart-tooltip-bg"),
+    chartTooltipBorder: read("--chart-tooltip-border"),
+    chartReference: read("--chart-reference"),
+    chartPromotion: read("--chart-promotion"),
+    chartDemotion: read("--chart-demotion"),
+    background: read("--background"),
+    foreground: read("--foreground"),
+    mutedForeground: read("--muted-foreground"),
+    border: read("--border"),
+    surfaceElevated: read("--surface-elevated"),
+    win: read("--win"),
+    loss: read("--loss"),
+  };
+}
+
+// Module-level cache so useSyncExternalStore can return a stable reference
+let cachedColors: ChartColors = {} as ChartColors;
+let cachedTheme: string | undefined;
+
+export function useChartColors(): ChartColors {
+  const { resolvedTheme } = useTheme();
+
+  const subscribe = useCallback(() => {
+    // No external subscription needed — we re-snapshot via getSnapshot
+    return () => {};
+  }, []);
+
+  const getSnapshot = useCallback(() => {
+    // Only re-read CSS when the theme actually changes
+    if (resolvedTheme !== cachedTheme) {
+      cachedTheme = resolvedTheme;
+      cachedColors = readColors();
+    }
+    return cachedColors;
+  }, [resolvedTheme]);
+
+  const getServerSnapshot = useCallback(() => ({} as ChartColors), []);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## Summary

- Add full light mode support with a dark/light/system theme toggle in the sidebar
- Replace all hardcoded `oklch()` color values across 12 component files with semantic CSS variables (`--win`, `--loss`, `--chart-*`, `--gold`, etc.)
- Create `useChartColors` hook that reads computed CSS variables at render time for Recharts prop injection
- Update gaming utility classes (`.glow-gold`, `.surface-glow`, `.text-gradient-gold`, `.changelog-prose`, etc.) to use CSS variables for theme awareness

### Changes

**Infrastructure**
- Wire up `next-themes` `ThemeProvider` in root layout with `suppressHydrationWarning`
- New `ThemeToggle` component cycling dark → light → system
- New `useChartColors` hook using `useSyncExternalStore` for lint-clean CSS variable reading

**Semantic color tokens** (added to `@theme inline`, `:root`, `.dark`)
- Gameplay: `--win`, `--loss`, `--win-muted`, `--loss-muted`, `--warning`, `--streak-hot`, `--streak-cold`, `--kills`, `--deaths`
- Charts: `--chart-grid`, `--chart-axis`, `--chart-tooltip-bg`, `--chart-tooltip-border`, `--chart-reference`, `--chart-promotion`, `--chart-demotion`

**Component migrations** (61+ hardcoded color replacements)
- `dashboard-client.tsx`, `highlights-editor.tsx`, `match-card.tsx`, `review-client.tsx`, `scout-client.tsx`, `duo-client.tsx`, `coaching-hub-client.tsx`, `coaching-detail-client.tsx`, `action-items-client.tsx`, `match-detail-client.tsx`, `schedule-session-client.tsx`

**Analytics charts** (~39 inline oklch values + 4 Tailwind classes → semantic variables via hook)

Fixes #17