### PR TITLE
feat: add CSV export for match history

### DIFF
--- a/changelog/en/2026-03-26-csv-export.mdx
+++ b/changelog/en/2026-03-26-csv-export.mdx
@@ -1,0 +1,11 @@
+---
+version: "1.6.0"
+date: "2026-03-26"
+title: "CSV Export for Match History"
+---
+
+You can now **export your match history as a CSV file** directly from the Matches page.
+
+- **"Export CSV" button** in the top-right corner of the Matches page
+- **Respects active filters** — export only victories, a specific champion, reviewed games, or search results
+- **All key fields** included: date, result, champion, matchup, keystone, KDA, CS, gold, vision score, duration, review status, notes, and duo partner

--- a/changelog/es/2026-03-26-csv-export.mdx
+++ b/changelog/es/2026-03-26-csv-export.mdx
@@ -1,0 +1,11 @@
+---
+version: "1.6.0"
+date: "2026-03-26"
+title: "Exportar historial de partidas en CSV"
+---
+
+Ahora puedes **exportar tu historial de partidas como archivo CSV** directamente desde la pagina de Partidas.
+
+- **Boton "Exportar CSV"** en la esquina superior derecha de la pagina de Partidas
+- **Respeta los filtros activos** — exporta solo victorias, un campeon especifico, partidas revisadas o resultados de busqueda
+- **Todos los campos clave** incluidos: fecha, resultado, campeon, matchup, runa clave, KDA, CS, oro, puntuacion de vision, duracion, estado de revision, notas y companero de duo

--- a/messages/en.json
+++ b/messages/en.json
@@ -104,7 +104,8 @@
     "notReviewed": "Not Reviewed",
     "hasNotes": "Has Notes",
     "noMatchesFiltered": "No games match your filters.",
-    "noMatchesEmpty": "No matches yet. Click Update Games to get started."
+    "noMatchesEmpty": "No matches yet. Click Update Games to get started.",
+    "exportCsv": "Export CSV"
   },
   "MatchDetail": {
     "reviewed": "Reviewed",

--- a/messages/es.json
+++ b/messages/es.json
@@ -104,7 +104,8 @@
     "notReviewed": "Sin revisar",
     "hasNotes": "Con notas",
     "noMatchesFiltered": "Ninguna partida coincide con tus filtros.",
-    "noMatchesEmpty": "Sin partidas aún. Haz clic en Actualizar Partidas para empezar."
+    "noMatchesEmpty": "Sin partidas aún. Haz clic en Actualizar Partidas para empezar.",
+    "exportCsv": "Exportar CSV"
   },
   "MatchDetail": {
     "reviewed": "Revisada",

--- a/src/app/(app)/matches/matches-client.tsx
+++ b/src/app/(app)/matches/matches-client.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -21,6 +21,7 @@ import {
   AlertCircle,
   ChevronRight,
   ChevronLeft,
+  Download,
 } from "lucide-react";
 import type { Match } from "@/db/schema";
 import { getChampionIconUrl } from "@/lib/riot-api";
@@ -66,6 +67,21 @@ function buildMatchesUrl(
   }
   const qs = sp.toString();
   return `/matches${qs ? `?${qs}` : ""}`;
+}
+
+function buildExportUrl(filters: {
+  search: string;
+  result: string;
+  champion: string;
+  review: string;
+}): string {
+  const sp = new URLSearchParams();
+  if (filters.search) sp.set("search", filters.search);
+  if (filters.result !== "all") sp.set("result", filters.result);
+  if (filters.champion !== "all") sp.set("champion", filters.champion);
+  if (filters.review !== "all") sp.set("review", filters.review);
+  const qs = sp.toString();
+  return `/api/export/matches${qs ? `?${qs}` : ""}`;
 }
 
 // ─── Server Pagination ──────────────────────────────────────────────────────
@@ -210,6 +226,16 @@ export function MatchesClient({
             {t("summary", { totalMatches, wins, losses, winRate })}
           </p>
         </div>
+        {totalMatches > 0 && (
+          <a
+            href={buildExportUrl(filters)}
+            download
+            className={buttonVariants({ variant: "outline", size: "sm" })}
+          >
+            <Download className="mr-2 h-4 w-4" />
+            {t("exportCsv")}
+          </a>
+        )}
       </div>
 
       {!isRiotLinked && (

--- a/src/app/api/export/matches/route.ts
+++ b/src/app/api/export/matches/route.ts
@@ -1,0 +1,185 @@
+import { db } from "@/db";
+import { matches } from "@/db/schema";
+import { eq, and, desc, sql } from "drizzle-orm";
+import { getCurrentUser } from "@/lib/session";
+
+// ─── CSV Helpers ─────────────────────────────────────────────────────────────
+
+/** Escape a value for CSV: wrap in quotes if it contains commas, quotes, or newlines. */
+function csvEscape(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 19).replace("T", " ");
+}
+
+const CSV_HEADERS = [
+  "Match ID",
+  "Date",
+  "Result",
+  "Champion",
+  "Matchup",
+  "Keystone",
+  "Kills",
+  "Deaths",
+  "Assists",
+  "CS",
+  "CS/min",
+  "Duration",
+  "Gold",
+  "Vision Score",
+  "Queue ID",
+  "Reviewed",
+  "Comment",
+  "Review Notes",
+  "VOD URL",
+  "Duo Partner Champion",
+] as const;
+
+function matchToCsvRow(match: {
+  id: string;
+  gameDate: Date;
+  result: string;
+  championName: string;
+  matchupChampionName: string | null;
+  runeKeystoneName: string | null;
+  kills: number;
+  deaths: number;
+  assists: number;
+  cs: number;
+  csPerMin: number | null;
+  gameDurationSeconds: number;
+  goldEarned: number | null;
+  visionScore: number | null;
+  queueId: number | null;
+  reviewed: boolean;
+  comment: string | null;
+  reviewNotes: string | null;
+  vodUrl: string | null;
+  duoPartnerChampionName: string | null;
+}): string {
+  return [
+    csvEscape(match.id),
+    csvEscape(formatDate(match.gameDate)),
+    csvEscape(match.result),
+    csvEscape(match.championName),
+    csvEscape(match.matchupChampionName),
+    csvEscape(match.runeKeystoneName),
+    csvEscape(match.kills),
+    csvEscape(match.deaths),
+    csvEscape(match.assists),
+    csvEscape(match.cs),
+    csvEscape(match.csPerMin != null ? match.csPerMin.toFixed(1) : null),
+    csvEscape(formatDuration(match.gameDurationSeconds)),
+    csvEscape(match.goldEarned),
+    csvEscape(match.visionScore),
+    csvEscape(match.queueId),
+    csvEscape(match.reviewed ? "Yes" : "No"),
+    csvEscape(match.comment),
+    csvEscape(match.reviewNotes),
+    csvEscape(match.vodUrl),
+    csvEscape(match.duoPartnerChampionName),
+  ].join(",");
+}
+
+// ─── Route Handler ───────────────────────────────────────────────────────────
+
+export async function GET(request: Request) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Parse filter params (same as matches page)
+  const url = new URL(request.url);
+  const search = url.searchParams.get("search") ?? "";
+  const result = url.searchParams.get("result") ?? "all";
+  const champion = url.searchParams.get("champion") ?? "all";
+  const review = url.searchParams.get("review") ?? "all";
+
+  // Build WHERE conditions
+  const conditions = [eq(matches.userId, user.id)];
+  if (result === "Victory" || result === "Defeat") {
+    conditions.push(eq(matches.result, result));
+  }
+  if (champion !== "all") {
+    conditions.push(eq(matches.championName, champion));
+  }
+  if (review === "reviewed") {
+    conditions.push(eq(matches.reviewed, true));
+  } else if (review === "unreviewed") {
+    conditions.push(eq(matches.reviewed, false));
+  } else if (review === "has-notes") {
+    conditions.push(
+      sql`${matches.comment} IS NOT NULL AND ${matches.comment} != ''`
+    );
+  }
+  if (search) {
+    const pattern = `%${search}%`;
+    conditions.push(
+      sql`(
+        ${matches.championName} LIKE ${pattern}
+        OR ${matches.matchupChampionName} LIKE ${pattern}
+        OR ${matches.runeKeystoneName} LIKE ${pattern}
+        OR ${matches.comment} LIKE ${pattern}
+        OR ${matches.reviewNotes} LIKE ${pattern}
+      )`
+    );
+  }
+
+  const allMatches = await db.query.matches.findMany({
+    where: and(...conditions),
+    orderBy: desc(matches.gameDate),
+    columns: {
+      id: true,
+      gameDate: true,
+      result: true,
+      championName: true,
+      matchupChampionName: true,
+      runeKeystoneName: true,
+      kills: true,
+      deaths: true,
+      assists: true,
+      cs: true,
+      csPerMin: true,
+      gameDurationSeconds: true,
+      goldEarned: true,
+      visionScore: true,
+      queueId: true,
+      reviewed: true,
+      comment: true,
+      reviewNotes: true,
+      vodUrl: true,
+      duoPartnerChampionName: true,
+    },
+  });
+
+  const csvLines = [
+    CSV_HEADERS.join(","),
+    ...allMatches.map(matchToCsvRow),
+  ];
+  const csvContent = csvLines.join("\n");
+
+  const today = new Date().toISOString().slice(0, 10);
+  const filename = `matches-export-${today}.csv`;
+
+  return new Response(csvContent, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
+  });
+}

--- a/tests/smoke/api-routes.spec.ts
+++ b/tests/smoke/api-routes.spec.ts
@@ -10,4 +10,37 @@ test.describe("API routes", () => {
     expect(body.user).toBeDefined();
     expect(body.user.name).toBe("DemoPlayer");
   });
+
+  test("/api/export/matches — returns CSV with correct headers", async ({ request }) => {
+    const response = await request.get("/api/export/matches");
+    expect(response.status()).toBe(200);
+
+    const contentType = response.headers()["content-type"];
+    expect(contentType).toContain("text/csv");
+
+    const disposition = response.headers()["content-disposition"];
+    expect(disposition).toContain("attachment");
+    expect(disposition).toContain("matches-export-");
+
+    const body = await response.text();
+    const lines = body.trim().split("\n");
+    // At least the header row + some seeded matches
+    expect(lines.length).toBeGreaterThan(1);
+    // Verify CSV header columns
+    expect(lines[0]).toBe(
+      "Match ID,Date,Result,Champion,Matchup,Keystone,Kills,Deaths,Assists,CS,CS/min,Duration,Gold,Vision Score,Queue ID,Reviewed,Comment,Review Notes,VOD URL,Duo Partner Champion"
+    );
+  });
+
+  test("/api/export/matches — respects result filter", async ({ request }) => {
+    const response = await request.get("/api/export/matches?result=Victory");
+    expect(response.status()).toBe(200);
+
+    const body = await response.text();
+    const lines = body.trim().split("\n");
+    // Skip header, check all data rows contain "Victory"
+    for (const line of lines.slice(1)) {
+      expect(line).toContain("Victory");
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Add an **Export CSV** button to the Matches page that downloads all matching games as a CSV file
- New API route `GET /api/export/matches` with support for the same filters as the matches page (search, result, champion, review status)
- Proper CSV escaping, i18n labels (en/es), and 2 new smoke tests

Fixes #5

## Changelog
- Version 1.6.0: CSV export for match history — download your games from the Matches page with filter support