### PR TITLE
fix: backfill migration tracking to prevent destructive replay on production

### DIFF
--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -56,6 +56,71 @@ async function migrate() {
     )
   `);
 
+  // ─── Backfill: detect existing DB that predates this migrate script ───────
+  //
+  // Migrations 0000–0010 were applied to production/preview via drizzle-kit push
+  // BEFORE this migrate script existed. If we detect an existing database with
+  // an empty tracking table, we backfill tracking rows so those migrations are
+  // never replayed.
+  //
+  // WHY THIS MATTERS: Migration 0002 contains DROP TABLE + table rebuilds that
+  // would destroy columns added by later migrations (0003–0010), causing
+  // permanent data loss if replayed.
+  //
+  // Detection: __drizzle_migrations is empty AND the `users` table already
+  // exists. On a truly fresh DB (new Preview env), `users` won't exist yet,
+  // so the backfill is skipped and all migrations run normally.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  const trackingCount = await client.execute(
+    "SELECT count(*) as cnt FROM __drizzle_migrations"
+  );
+  const hasTrackingRows = Number(trackingCount.rows[0].cnt) > 0;
+
+  if (!hasTrackingRows) {
+    const tableCheck = await client.execute(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='users'"
+    );
+    const isExistingDb = tableCheck.rows.length > 0;
+
+    if (isExistingDb) {
+      // These are the exact migration tags from drizzle/meta/_journal.json
+      // entries 0–10, all of which were applied before this script existed.
+      const preExistingTags = [
+        "0000_dusty_khan",
+        "0001_worried_guardian",
+        "0002_mushy_jackpot",
+        "0003_tiresome_hardball",
+        "0004_abnormal_alex_wilder",
+        "0005_smart_randall_flagg",
+        "0006_little_sheva_callister",
+        "0007_lively_vampiro",
+        "0008_complete_dakota_north",
+        "0009_lumpy_dragon_lord",
+        "0010_curved_gladiator",
+      ];
+
+      console.log(
+        `[migrate] Detected existing database with empty migration tracking.`
+      );
+      console.log(
+        `[migrate] Backfilling ${preExistingTags.length} pre-existing migrations...`
+      );
+
+      for (const tag of preExistingTags) {
+        await client.execute({
+          sql: "INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)",
+          args: [tag, Date.now()],
+        });
+        console.log(`[migrate]   ✓ Backfilled ${tag}`);
+      }
+
+      console.log(
+        `[migrate] Backfill complete. Only new migrations will be applied.`
+      );
+    }
+  }
+
   // Load the journal
   const journalPath = path.resolve(__dirname, "../drizzle/meta/_journal.json");
   const journal: Journal = JSON.parse(fs.readFileSync(journalPath, "utf-8"));

--- a/tests/e2e/coaching-flow.spec.ts
+++ b/tests/e2e/coaching-flow.spec.ts
@@ -175,17 +175,18 @@ test.describe("Coaching flow", () => {
       page.locator('[data-slot="badge"]:has-text("Completed")').first()
     ).toBeVisible();
 
-    // Verify notes are displayed
+    // Verify notes are displayed (may appear in both the notes card and
+    // highlight sections — use .first() to avoid strict mode violation)
     await expect(
-      page.getByText("Great session on wave management fundamentals.")
+      page.getByText("Great session on wave management fundamentals.").first()
     ).toBeVisible();
 
     // Verify action items are shown
     await expect(
-      page.getByText("Practice freezing near tower for 5 games")
+      page.getByText("Practice freezing near tower for 5 games").first()
     ).toBeVisible();
     await expect(
-      page.getByText("Watch 2 VODs focusing on ward placement")
+      page.getByText("Watch 2 VODs focusing on ward placement").first()
     ).toBeVisible();
   });
 

--- a/tests/e2e/settings-flow.spec.ts
+++ b/tests/e2e/settings-flow.spec.ts
@@ -95,7 +95,7 @@ test.describe("Settings flow", () => {
 
     // Wait for toast
     await expect(
-      page.getByText("Language & region updated")
+      page.getByText("Language & region updated").first()
     ).toBeVisible({ timeout: 10_000 });
 
     // The preview should show a date
@@ -108,8 +108,10 @@ test.describe("Settings flow", () => {
       .filter({ hasText: "English (UK)" })
       .click();
 
+    // The previous toast may still be visible, so use .first() to avoid
+    // strict mode violations when two toasts are stacked
     await expect(
-      page.getByText("Language & region updated")
+      page.getByText("Language & region updated").first()
     ).toBeVisible({ timeout: 10_000 });
   });
 


### PR DESCRIPTION
## Summary

- Fixes broken production deployment caused by the auto-migrate script (from #22) attempting to replay all 12 migrations against a database where migrations 0000–0010 were already applied via `drizzle-kit push`
- Adds backfill detection to `scripts/migrate.ts`: when the tracking table is empty but `users` table exists, inserts tracking rows for the 11 pre-existing migrations so they are never replayed
- **Prevents permanent data loss**: migration 0002 contains `DROP TABLE matches` + table rebuilds that would destroy 7 columns added by later migrations (0003–0010)

## Problem

PR #22 introduced `scripts/migrate.ts` to auto-apply Drizzle migrations on Vercel build. However, production and preview databases had their schema applied via `drizzle-kit push` before this script existed — there are no tracking rows in `__drizzle_migrations`. On first run, the script tries to replay all migrations from scratch, including the destructive migration 0002.

Production diagnostic confirmed: `__drizzle_migrations` table exists but is empty (0 rows), all data is intact, goals table does not exist yet.

## Solution

After creating the tracking table, the script checks:
1. Is `__drizzle_migrations` empty?
2. Does the `users` table exist?

If both true → existing database that predates the script. Backfill tracking rows for migrations 0000–0010. Then the normal migration loop only applies 0011 (goals table creation — safe and idempotent).

## Test scenarios (all pass locally)

| Scenario | Behavior |
|---|---|
| Already-migrated DB (12 tracking rows) | No-op |
| Existing DB + empty tracking (production) | Backfills 0000–0010, applies 0011 |
| Fresh DB (no tables) | Skips backfill, applies all 12 normally |
| Re-run after fix | No-op (all 12 tracked) |