### PR TITLE
fix: detect and filter remake games from stats

### DIFF
--- a/changelog/en/2026-03-26-remake-detection.mdx
+++ b/changelog/en/2026-03-26-remake-detection.mdx
@@ -1,0 +1,12 @@
+---
+version: "1.6.1"
+date: "2026-03-26"
+title: "Remake Detection"
+---
+
+Games that ended as **remakes** (early surrenders before 5 minutes) are now correctly identified and excluded from your stats.
+
+- **Automatic detection** during sync — remakes show a grey "R" badge instead of a win/loss
+- **Excluded from all stats** — win rates, streaks, matchup analytics, duo stats, and coaching progress no longer count remakes
+- **Filterable** — use the "Remakes" option in the result filter on the Matches page
+- **Backfill script** included — run `npx tsx scripts/backfill-remakes.ts` to retroactively fix existing matches

--- a/changelog/es/2026-03-26-remake-detection.mdx
+++ b/changelog/es/2026-03-26-remake-detection.mdx
@@ -1,0 +1,12 @@
+---
+version: "1.6.1"
+date: "2026-03-26"
+title: "Deteccion de Remakes"
+---
+
+Las partidas que terminaron como **remakes** (rendiciones tempranas antes de 5 minutos) ahora se identifican correctamente y se excluyen de tus estadisticas.
+
+- **Deteccion automatica** durante la sincronizacion — los remakes muestran una insignia gris "R" en lugar de victoria/derrota
+- **Excluidos de todas las estadisticas** — win rates, rachas, estadisticas de matchup, estadisticas de duo y progreso de coaching ya no cuentan los remakes
+- **Filtrable** — usa la opcion "Remakes" en el filtro de resultado en la pagina de Partidas
+- **Script de backfill incluido** — ejecuta `npx tsx scripts/backfill-remakes.ts` para corregir retroactivamente las partidas existentes

--- a/messages/en.json
+++ b/messages/en.json
@@ -28,7 +28,8 @@
     "notReviewed": "Not reviewed",
     "hasNotesNotReviewed": "Has notes, not yet reviewed",
     "win": "W",
-    "loss": "L"
+    "loss": "L",
+    "remake": "R"
   },
   "Pagination": {
     "ellipsis": "..."
@@ -100,6 +101,7 @@
     "allResults": "All Results",
     "victories": "Victories",
     "defeats": "Defeats",
+    "remakes": "Remakes",
     "championFilterPlaceholder": "Champion",
     "allChampions": "All Champions",
     "reviewFilterPlaceholder": "Review",
@@ -154,6 +156,7 @@
     "vs": "vs",
     "win": "W",
     "loss": "L",
+    "remake": "R",
     "gameNotesOptional": "Game Notes (optional)",
     "gameNotes": "Game Notes",
     "gameNotesPlaceholder": "Any additional notes...",
@@ -329,6 +332,7 @@
     "vs": "vs",
     "resultWin": "W",
     "resultLoss": "L",
+    "resultRemake": "R",
     "actionItems": "Action Items",
     "actionItemsDescription": "{completed}/{total} completed. Click the status icon to cycle through: pending → in progress → completed.",
     "noActionItems": "No action items for this session.",
@@ -467,6 +471,7 @@
       "description": "Games played together with {partnerName}",
       "resultWin": "W",
       "resultLoss": "L",
+      "resultRemake": "R",
       "emptyTitle": "No duo games found yet.",
       "emptyDescription": "Sync your matches to detect games played with your duo partner."
     },

--- a/messages/es.json
+++ b/messages/es.json
@@ -28,7 +28,8 @@
     "notReviewed": "Sin revisar",
     "hasNotesNotReviewed": "Tiene notas, aún sin revisar",
     "win": "V",
-    "loss": "D"
+    "loss": "D",
+    "remake": "R"
   },
   "Pagination": {
     "ellipsis": "..."
@@ -100,6 +101,7 @@
     "allResults": "Todos los resultados",
     "victories": "Victorias",
     "defeats": "Derrotas",
+    "remakes": "Remakes",
     "championFilterPlaceholder": "Campeón",
     "allChampions": "Todos los campeones",
     "reviewFilterPlaceholder": "Revisión",
@@ -154,6 +156,7 @@
     "vs": "vs",
     "win": "V",
     "loss": "D",
+    "remake": "R",
     "gameNotesOptional": "Notas de partida (opcional)",
     "gameNotes": "Notas de partida",
     "gameNotesPlaceholder": "Notas adicionales...",
@@ -329,6 +332,7 @@
     "vs": "vs",
     "resultWin": "V",
     "resultLoss": "D",
+    "resultRemake": "R",
     "actionItems": "Tareas",
     "actionItemsDescription": "{completed}/{total} completadas. Haz clic en el icono de estado para cambiar: pendiente → en progreso → completada.",
     "noActionItems": "No hay tareas para esta sesión.",
@@ -467,6 +471,7 @@
       "description": "Partidas jugadas con {partnerName}",
       "resultWin": "V",
       "resultLoss": "D",
+      "resultRemake": "R",
       "emptyTitle": "Sin partidas de dúo encontradas aún.",
       "emptyDescription": "Sincroniza tus partidas para detectar partidas jugadas con tu compañero de dúo."
     },

--- a/scripts/backfill-remakes.ts
+++ b/scripts/backfill-remakes.ts
@@ -1,0 +1,89 @@
+/**
+ * backfill-remakes — Parse rawMatchJson for all existing matches and update
+ * result to "Remake" where gameEndedInEarlySurrender is true or
+ * gameDuration < 300 seconds.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-remakes.ts                     (local DB)
+ *   TURSO_DATABASE_URL=... TURSO_AUTH_TOKEN=... npx tsx scripts/backfill-remakes.ts  (production)
+ */
+
+import { createClient } from "@libsql/client";
+
+// Strip dotenvx banner from env vars
+function cleanEnv(key: string): string | undefined {
+  const val = process.env[key];
+  if (!val) return undefined;
+  return val.replace(/^\[dotenv@[^\]]+\][^\n]*\n/, "");
+}
+
+const TURSO_URL = cleanEnv("TURSO_DATABASE_URL");
+const TURSO_TOKEN = cleanEnv("TURSO_AUTH_TOKEN");
+
+const isProduction = !!TURSO_URL && !TURSO_URL.startsWith("file:");
+
+if (isProduction && !process.argv.includes("--force-remote")) {
+  console.error(
+    "ERROR: This script would run against a REMOTE database.\n" +
+      "Pass --force-remote to confirm."
+  );
+  process.exit(1);
+}
+
+const db = createClient({
+  url: TURSO_URL ?? "file:./data/lol-tracker.db",
+  authToken: TURSO_TOKEN,
+});
+
+async function main() {
+  console.log(
+    `Running against ${isProduction ? "PRODUCTION" : "LOCAL"} database\n`
+  );
+
+  // Get all matches that have raw JSON and are currently Victory/Defeat
+  const matchesResult = await db.execute(
+    "SELECT id, user_id, result, raw_match_json FROM matches WHERE raw_match_json IS NOT NULL AND result IN ('Victory', 'Defeat')"
+  );
+
+  console.log(
+    `Found ${matchesResult.rows.length} matches with raw JSON to check\n`
+  );
+
+  let checked = 0;
+  let remakesFound = 0;
+
+  for (const row of matchesResult.rows) {
+    const matchId = row.id as string;
+    const userId = row.user_id as string;
+    const rawJson = row.raw_match_json as string;
+
+    try {
+      const matchData = JSON.parse(rawJson);
+      const info = matchData?.info;
+      if (!info) continue;
+
+      const isRemake =
+        info.gameEndedInEarlySurrender === true || info.gameDuration < 300;
+
+      if (isRemake) {
+        await db.execute({
+          sql: "UPDATE matches SET result = 'Remake' WHERE id = ? AND user_id = ?",
+          args: [matchId, userId],
+        });
+        remakesFound++;
+        console.log(`  Updated ${matchId} -> Remake (duration: ${info.gameDuration}s, earlySurrender: ${info.gameEndedInEarlySurrender})`);
+      }
+
+      checked++;
+    } catch {
+      console.log(`  Warning: failed to parse match ${matchId}`);
+    }
+  }
+
+  console.log(
+    `\nChecked ${checked} matches, found ${remakesFound} remakes.\n`
+  );
+  console.log("Backfill complete!");
+}
+
+main().catch(console.error);

--- a/src/app/(app)/analytics/analytics-client.tsx
+++ b/src/app/(app)/analytics/analytics-client.tsx
@@ -201,13 +201,15 @@ function computeRollingWinRate(
   locale: string,
   window = 10
 ): Array<{ index: number; date: string; winRate: number }> {
+  // Exclude remakes from rolling win rate
+  const meaningful = matches.filter((m) => m.result !== "Remake");
   const data: Array<{ index: number; date: string; winRate: number }> = [];
-  for (let i = 0; i < matches.length; i++) {
+  for (let i = 0; i < meaningful.length; i++) {
     const start = Math.max(0, i - window + 1);
-    const slice = matches.slice(start, i + 1);
+    const slice = meaningful.slice(start, i + 1);
     const wins = slice.filter((m) => m.result === "Victory").length;
     const wr = Math.round((wins / slice.length) * 100);
-    const dateStr = formatDate(matches[i].gameDate, locale, "short-compact");
+    const dateStr = formatDate(meaningful[i].gameDate, locale, "short-compact");
     data.push({ index: i + 1, date: dateStr, winRate: wr });
   }
   return data;
@@ -219,6 +221,7 @@ function computeMatchupStats(matches: AnalyticsMatch[]) {
     { wins: number; losses: number; games: number }
   >();
   for (const m of matches) {
+    if (m.result === "Remake") continue; // Skip remakes
     const name = m.matchupChampionName || "Unknown";
     const existing = stats.get(name) || { wins: 0, losses: 0, games: 0 };
     existing.games++;
@@ -241,6 +244,7 @@ function computeRuneStats(matches: AnalyticsMatch[]) {
     { wins: number; losses: number; games: number }
   >();
   for (const m of matches) {
+    if (m.result === "Remake") continue; // Skip remakes
     const name = m.runeKeystoneName || "Unknown";
     const existing = stats.get(name) || { wins: 0, losses: 0, games: 0 };
     existing.games++;
@@ -270,6 +274,7 @@ function computeChampionStats(matches: AnalyticsMatch[]) {
     }
   >();
   for (const m of matches) {
+    if (m.result === "Remake") continue; // Skip remakes
     const existing = stats.get(m.championName) || {
       wins: 0,
       losses: 0,

--- a/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
+++ b/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
@@ -208,6 +208,9 @@ export function CoachingDetailClient({
     const wins = progressMatches.filter(
       (m) => m.result === "Victory"
     ).length;
+    const meaningful = progressMatches.filter(
+      (m) => m.result !== "Remake"
+    ).length;
     const totalKills = progressMatches.reduce((s, m) => s + m.kills, 0);
     const totalDeaths = progressMatches.reduce((s, m) => s + m.deaths, 0);
     const totalAssists = progressMatches.reduce((s, m) => s + m.assists, 0);
@@ -226,9 +229,9 @@ export function CoachingDetailClient({
     }
 
     return {
-      total: progressMatches.length,
+      total: meaningful,
       wins,
-      winRate: Math.round((wins / progressMatches.length) * 100),
+      winRate: meaningful > 0 ? Math.round((wins / meaningful) * 100) : 0,
       avgKDA:
         totalDeaths === 0
           ? t("perfect")
@@ -382,7 +385,9 @@ export function CoachingDetailClient({
                     >
                       <div
                         className={`w-1 h-8 rounded-full ${
-                          match.result === "Victory"
+                          match.result === "Remake"
+                            ? "bg-muted-foreground/40"
+                            : match.result === "Victory"
                             ? "bg-win"
                             : "bg-loss"
                         }`}
@@ -430,13 +435,15 @@ export function CoachingDetailClient({
                       </span>
                       <Badge
                         variant={
-                          match.result === "Victory"
+                          match.result === "Remake"
+                            ? "secondary"
+                            : match.result === "Victory"
                             ? "default"
                             : "destructive"
                         }
                         className="text-xs"
                       >
-                        {match.result === "Victory" ? t("resultWin") : t("resultLoss")}
+                        {match.result === "Remake" ? t("resultRemake") : match.result === "Victory" ? t("resultWin") : t("resultLoss")}
                       </Badge>
                     </Link>
 
@@ -638,13 +645,15 @@ export function CoachingDetailClient({
                           </span>
                           <Badge
                             variant={
-                              match.result === "Victory"
+                              match.result === "Remake"
+                                ? "secondary"
+                                : match.result === "Victory"
                                 ? "default"
                                 : "destructive"
                             }
                             className="text-xs"
                           >
-                        {match.result === "Victory" ? t("resultWin") : t("resultLoss")}
+                        {match.result === "Remake" ? t("resultRemake") : match.result === "Victory" ? t("resultWin") : t("resultLoss")}
                           </Badge>
                         </div>
                       </Link>

--- a/src/app/(app)/dashboard/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/dashboard-client.tsx
@@ -36,7 +36,7 @@ import {
 interface DashboardMatch {
   id: string;
   gameDate: Date;
-  result: "Victory" | "Defeat";
+  result: "Victory" | "Defeat" | "Remake";
   championId: number;
   championName: string;
   runeKeystoneId: number | null;
@@ -92,9 +92,12 @@ interface DashboardClientProps {
 
 function getStreak(matches: DashboardMatch[]): { type: "W" | "L"; count: number } | null {
   if (matches.length === 0) return null;
-  const first = matches[0].result;
+  // Skip remakes — they don't affect streaks
+  const meaningful = matches.filter((m) => m.result !== "Remake");
+  if (meaningful.length === 0) return null;
+  const first = meaningful[0].result;
   let count = 0;
-  for (const m of matches) {
+  for (const m of meaningful) {
     if (m.result === first) count++;
     else break;
   }
@@ -133,12 +136,13 @@ export function DashboardClient({
   const streak = getStreak(recentMatches);
   const rankInfo = getRankDisplay(latestRank);
 
-  // Session stats (last 10 games)
-  const sessionWins = recentMatches.filter((m) => m.result === "Victory").length;
-  const sessionLosses = recentMatches.filter((m) => m.result === "Defeat").length;
+  // Session stats (last 10 games, excluding remakes)
+  const sessionGames = recentMatches.filter((m) => m.result !== "Remake");
+  const sessionWins = sessionGames.filter((m) => m.result === "Victory").length;
+  const sessionLosses = sessionGames.filter((m) => m.result === "Defeat").length;
   const sessionWinRate =
-    recentMatches.length > 0
-      ? Math.round((sessionWins / recentMatches.length) * 100)
+    sessionGames.length > 0
+      ? Math.round((sessionWins / sessionGames.length) * 100)
       : 0;
 
   // Overall stats from aggregates

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -85,9 +85,14 @@ export default async function DashboardPage() {
     // Aggregate stats instead of fetching ALL matches
     db
       .select({
-        total: count(),
+        total: count(
+          sql`CASE WHEN ${matches.result} != 'Remake' THEN 1 END`
+        ),
         wins: count(
           sql`CASE WHEN ${matches.result} = 'Victory' THEN 1 END`
+        ),
+        remakes: count(
+          sql`CASE WHEN ${matches.result} = 'Remake' THEN 1 END`
         ),
         unreviewed: count(
           sql`CASE WHEN ${matches.reviewed} = 0 THEN 1 END`
@@ -125,9 +130,10 @@ export default async function DashboardPage() {
   ]);
 
   const latestRankOrUndef = latestRank ?? null;
-  const { total, wins, unreviewed, vodPending } = matchStats[0] ?? {
+  const { total, wins, remakes: _remakes, unreviewed, vodPending } = matchStats[0] ?? {
     total: 0,
     wins: 0,
+    remakes: 0,
     unreviewed: 0,
     vodPending: 0,
   };

--- a/src/app/(app)/duo/duo-client.tsx
+++ b/src/app/(app)/duo/duo-client.tsx
@@ -458,7 +458,11 @@ export function DuoRecentGames({
               >
                 <Badge
                   variant={
-                    game.result === "Victory" ? "default" : "destructive"
+                    game.result === "Remake"
+                      ? "secondary"
+                      : game.result === "Victory"
+                      ? "default"
+                      : "destructive"
                   }
                   className={`w-12 justify-center text-xs ${
                     game.result === "Victory"
@@ -466,7 +470,7 @@ export function DuoRecentGames({
                       : ""
                   }`}
                 >
-                  {game.result === "Victory" ? t("recentGames.resultWin") : t("recentGames.resultLoss")}
+                  {game.result === "Remake" ? t("recentGames.resultRemake") : game.result === "Victory" ? t("recentGames.resultWin") : t("recentGames.resultLoss")}
                 </Badge>
 
                 <div className="flex items-center gap-2 min-w-0">

--- a/src/app/(app)/matches/[id]/match-detail-client.tsx
+++ b/src/app/(app)/matches/[id]/match-detail-client.tsx
@@ -235,7 +235,11 @@ export function MatchDetailClient({
                 </h1>
                 <Badge
                   variant={
-                    match.result === "Victory" ? "default" : "destructive"
+                    match.result === "Remake"
+                      ? "secondary"
+                      : match.result === "Victory"
+                      ? "default"
+                      : "destructive"
                   }
                 >
                   {match.result}

--- a/src/app/(app)/matches/matches-client.tsx
+++ b/src/app/(app)/matches/matches-client.tsx
@@ -176,7 +176,8 @@ export function MatchesClient({
   const t = useTranslations("Matches");
   const [isNavigating, startTransition] = useTransition();
 
-  const winRate = totalMatches > 0 ? Math.round((wins / totalMatches) * 100) : 0;
+  const meaningfulGames = wins + losses;
+  const winRate = meaningfulGames > 0 ? Math.round((wins / meaningfulGames) * 100) : 0;
 
   // Current filter params for URL building
   const currentParams: Record<string, string> = {
@@ -275,6 +276,7 @@ export function MatchesClient({
             <SelectItem value="all">{t("allResults")}</SelectItem>
             <SelectItem value="Victory">{t("victories")}</SelectItem>
             <SelectItem value="Defeat">{t("defeats")}</SelectItem>
+            <SelectItem value="Remake">{t("remakes")}</SelectItem>
           </SelectContent>
         </Select>
         <Select value={filters.champion} onValueChange={(v) => navigateWithFilter("champion", v ?? "all")}>

--- a/src/app/(app)/matches/page.tsx
+++ b/src/app/(app)/matches/page.tsx
@@ -24,7 +24,7 @@ export default async function MatchesPage({
 
   // Build WHERE conditions
   const conditions = [eq(matches.userId, user.id)];
-  if (result === "Victory" || result === "Defeat") {
+  if (result === "Victory" || result === "Defeat" || result === "Remake") {
     conditions.push(eq(matches.result, result));
   }
   if (champion !== "all") {
@@ -103,6 +103,7 @@ export default async function MatchesPage({
       .select({
         wins: sql<number>`SUM(CASE WHEN ${matches.result} = 'Victory' THEN 1 ELSE 0 END)`,
         losses: sql<number>`SUM(CASE WHEN ${matches.result} = 'Defeat' THEN 1 ELSE 0 END)`,
+        remakes: sql<number>`SUM(CASE WHEN ${matches.result} = 'Remake' THEN 1 ELSE 0 END)`,
       })
       .from(matches)
       .where(whereClause),

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -110,7 +110,11 @@ function MatchCardHeader({
     <div className="flex items-center gap-3">
       <div
         className={`w-1 h-10 rounded-full ${
-          match.result === "Victory" ? "bg-win" : "bg-loss"
+          match.result === "Remake"
+            ? "bg-muted-foreground/40"
+            : match.result === "Victory"
+            ? "bg-win"
+            : "bg-loss"
         }`}
       />
       <Image
@@ -125,11 +129,15 @@ function MatchCardHeader({
           <CardTitle className="text-base">{match.championName}</CardTitle>
           <Badge
             variant={
-              match.result === "Victory" ? "default" : "destructive"
+              match.result === "Remake"
+                ? "secondary"
+                : match.result === "Victory"
+                ? "default"
+                : "destructive"
             }
             className="text-xs"
           >
-            {match.result === "Victory" ? t("win") : t("loss")}
+            {match.result === "Remake" ? t("remake") : match.result === "Victory" ? t("win") : t("loss")}
           </Badge>
         </div>
         <CardDescription className="inline-flex items-center gap-1 flex-wrap">

--- a/src/app/actions/duo.ts
+++ b/src/app/actions/duo.ts
@@ -40,7 +40,7 @@ export interface DuoStats {
 export interface DuoGameRow {
   id: string;
   gameDate: Date;
-  result: "Victory" | "Defeat";
+  result: "Victory" | "Defeat" | "Remake";
   championName: string;
   kills: number;
   deaths: number;
@@ -101,12 +101,12 @@ async function getCachedDuoStats(userId: string): Promise<DuoStats | null> {
       .select({
         totalGames: count(),
         wins: sql<number>`SUM(CASE WHEN ${matches.result} = 'Victory' THEN 1 ELSE 0 END)`,
-        avgKills: sql<number>`AVG(${matches.kills})`,
-        avgDeaths: sql<number>`AVG(${matches.deaths})`,
-        avgAssists: sql<number>`AVG(${matches.assists})`,
-        partnerAvgKills: sql<number>`AVG(${matches.duoPartnerKills})`,
-        partnerAvgDeaths: sql<number>`AVG(${matches.duoPartnerDeaths})`,
-        partnerAvgAssists: sql<number>`AVG(${matches.duoPartnerAssists})`,
+        avgKills: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.kills} END)`,
+        avgDeaths: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.deaths} END)`,
+        avgAssists: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.assists} END)`,
+        partnerAvgKills: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.duoPartnerKills} END)`,
+        partnerAvgDeaths: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.duoPartnerDeaths} END)`,
+        partnerAvgAssists: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.duoPartnerAssists} END)`,
       })
       .from(matches)
       .where(

--- a/src/app/actions/live.ts
+++ b/src/app/actions/live.ts
@@ -16,7 +16,7 @@ import { scoutTag } from "@/lib/cache";
 interface MatchupGameDetail {
   matchId: string;
   gameDate: Date;
-  result: "Victory" | "Defeat";
+  result: "Victory" | "Defeat" | "Remake";
   championName: string;
   matchupChampionName: string | null;
   kills: number;
@@ -122,14 +122,15 @@ async function getCachedMatchupReport(
     return null;
   }
 
-  // Build record
-  const wins = matchRows.filter((m) => m.result === "Victory").length;
-  const losses = matchRows.length - wins;
+  // Build record (exclude remakes)
+  const meaningfulMatches = matchRows.filter((m) => m.result !== "Remake");
+  const wins = meaningfulMatches.filter((m) => m.result === "Victory").length;
+  const losses = meaningfulMatches.length - wins;
   const record = {
     wins,
     losses,
-    total: matchRows.length,
-    winRate: Math.round((wins / matchRows.length) * 100),
+    total: meaningfulMatches.length,
+    winRate: meaningfulMatches.length > 0 ? Math.round((wins / meaningfulMatches.length) * 100) : 0,
   };
 
   // Last played
@@ -141,6 +142,7 @@ async function getCachedMatchupReport(
     { games: number; wins: number; losses: number }
   >();
   for (const m of matchRows) {
+    if (m.result === "Remake") continue; // Skip remakes from rune stats
     const rune = m.runeKeystoneName || "Unknown";
     const existing = runeMap.get(rune) || { games: 0, wins: 0, losses: 0 };
     existing.games++;
@@ -298,6 +300,7 @@ async function getCachedMatchupReport(
     { yourChampion: string; duoChampion: string; games: number; wins: number }
   >();
   for (const g of games) {
+    if (g.result === "Remake") continue; // Skip remakes
     if (g.duoPartnerPuuid && g.duoPartnerChampionName) {
       const key = `${g.championName}|${g.duoPartnerChampionName}`;
       const existing = duoPairMap.get(key) || {

--- a/src/app/api/export/matches/route.ts
+++ b/src/app/api/export/matches/route.ts
@@ -111,7 +111,7 @@ export async function GET(request: Request) {
 
   // Build WHERE conditions
   const conditions = [eq(matches.userId, user.id)];
-  if (result === "Victory" || result === "Defeat") {
+  if (result === "Victory" || result === "Defeat" || result === "Remake") {
     conditions.push(eq(matches.result, result));
   }
   if (champion !== "all") {

--- a/src/components/match-card.tsx
+++ b/src/components/match-card.tsx
@@ -34,7 +34,7 @@ export interface MatchHighlightData {
 interface MatchCardData {
   id: string;
   gameDate: Date;
-  result: "Victory" | "Defeat" | string;
+  result: "Victory" | "Defeat" | "Remake" | string;
   championName: string;
   matchupChampionName: string | null;
   kills: number;
@@ -90,6 +90,7 @@ export function MatchCard({
 }) {
   const t = useTranslations("MatchCard");
   const isWin = match.result === "Victory";
+  const isRemake = match.result === "Remake";
   const hasComment = !!match.comment;
   const hasReviewNotes = !!match.reviewNotes;
   const kda =
@@ -115,7 +116,9 @@ export function MatchCard({
       <Link
         href={`/matches/${match.id}`}
         className={`block rounded-lg border bg-card transition-all hover:bg-surface-elevated/50 ${
-          isWin
+          isRemake
+            ? "border-l-[3px] border-l-muted-foreground/40"
+            : isWin
             ? "border-l-[3px] border-l-win/60"
             : "border-l-[3px] border-l-loss/60"
         }`}
@@ -275,10 +278,10 @@ export function MatchCard({
           {/* Result + Date */}
           <div className="flex flex-col items-end gap-0.5 shrink-0">
             <Badge
-              variant={isWin ? "default" : "destructive"}
+              variant={isRemake ? "secondary" : isWin ? "default" : "destructive"}
               className="text-xs"
             >
-              {isWin ? t("win") : t("loss")}
+              {isRemake ? t("remake") : isWin ? t("win") : t("loss")}
             </Badge>
             <span className="text-[10px] text-muted-foreground whitespace-nowrap">
               {formatDate(match.gameDate, locale)}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -35,7 +35,7 @@ export const matches = sqliteTable("matches", {
     .notNull()
     .references(() => users.id, { onDelete: "cascade" }),
   gameDate: integer("game_date", { mode: "timestamp" }).notNull(),
-  result: text("result", { enum: ["Victory", "Defeat"] }).notNull(),
+  result: text("result", { enum: ["Victory", "Defeat", "Remake"] }).notNull(),
   championId: integer("champion_id").notNull(),
   championName: text("champion_name").notNull(),
   runeKeystoneId: integer("rune_keystone_id"),

--- a/src/lib/riot-api-mock.ts
+++ b/src/lib/riot-api-mock.ts
@@ -100,6 +100,7 @@ export async function mockGetMatch(matchId: string): Promise<RiotMatch> {
     info: {
       gameCreation: Date.now(),
       gameDuration: 1800,
+      gameEndedInEarlySurrender: false,
       gameId: parseInt(matchId.replace("EUW1_", ""), 10) || 0,
       gameMode: "CLASSIC",
       gameType: "MATCHED_GAME",

--- a/src/lib/riot-api.ts
+++ b/src/lib/riot-api.ts
@@ -80,6 +80,7 @@ export interface RiotMatchParticipant {
 interface RiotMatchInfo {
   gameCreation: number;
   gameDuration: number; // seconds
+  gameEndedInEarlySurrender: boolean;
   gameId: number;
   gameMode: string;
   gameType: string;
@@ -264,7 +265,11 @@ export function extractPlayerData(match: RiotMatch, puuid: string) {
   return {
     matchId: match.metadata.matchId,
     gameDate: new Date(match.info.gameCreation),
-    result: participant.win ? ("Victory" as const) : ("Defeat" as const),
+    result: match.info.gameEndedInEarlySurrender || match.info.gameDuration < 300
+      ? ("Remake" as const)
+      : participant.win
+        ? ("Victory" as const)
+        : ("Defeat" as const),
     championId: participant.championId,
     championName: participant.championName,
     runeKeystoneId: keystoneId || null,


### PR DESCRIPTION
## Summary

- Detect remake games during sync (`gameEndedInEarlySurrender` or `gameDuration < 300s`) and store as `"Remake"` result
- Exclude remakes from all win/loss statistics across the entire app (dashboard, matches, analytics, duo, scout, coaching)
- Display remakes with a grey "R" badge and muted border styling
- Add "Remakes" filter option in the Matches page result dropdown
- Include backfill script (`scripts/backfill-remakes.ts`) for retroactively fixing existing matches

Fixes #25

## Files changed (21)

**Core**: schema.ts, riot-api.ts, riot-api-mock.ts
**Dashboard**: page.tsx, dashboard-client.tsx
**Matches**: page.tsx, matches-client.tsx, match-detail-client.tsx
**Analytics**: analytics-client.tsx
**Review**: review-client.tsx
**Duo**: duo.ts (actions), duo-client.tsx
**Live/Scout**: live.ts (actions)
**Coaching**: coaching-detail-client.tsx
**Export**: route.ts
**UI**: match-card.tsx
**i18n**: en.json, es.json
**New files**: backfill-remakes.ts, changelog entries (en/es)

## Post-merge steps

Run the backfill script against production to retroactively detect remakes in existing matches:
```
TURSO_DATABASE_URL=... TURSO_AUTH_TOKEN=... npx tsx scripts/backfill-remakes.ts --force-remote
```