### PR TITLE
fix: exclude remakes from review/dashboard and fix changelog ordering

### DIFF
--- a/changelog/en/2026-03-26-remake-detection.mdx
+++ b/changelog/en/2026-03-26-remake-detection.mdx
@@ -1,5 +1,5 @@
 ---
-version: "1.6.1"
+version: "1.7.1"
 date: "2026-03-26"
 title: "Remake Detection"
 ---

--- a/changelog/en/2026-03-26-remake-review-dashboard.mdx
+++ b/changelog/en/2026-03-26-remake-review-dashboard.mdx
@@ -1,0 +1,12 @@
+---
+version: "1.7.2"
+date: "2026-03-26"
+title: "Remake Cleanup: Review & Dashboard"
+---
+
+Follow-up fixes to the remake detection feature.
+
+- **Remakes excluded from review** — remake games no longer appear in the Post-Game or VOD Review queues
+- **Dashboard updated** — remakes show a grey "R" badge in recent games and are excluded from average KDA/CS calculations
+- **Review counts fixed** — the unreviewed and VOD-pending counts no longer include remakes
+- **Changelog ordering fixed** — the remake detection entry now correctly appears as the latest version (v1.7.1)

--- a/changelog/es/2026-03-26-remake-detection.mdx
+++ b/changelog/es/2026-03-26-remake-detection.mdx
@@ -1,5 +1,5 @@
 ---
-version: "1.6.1"
+version: "1.7.1"
 date: "2026-03-26"
 title: "Deteccion de Remakes"
 ---

--- a/changelog/es/2026-03-26-remake-review-dashboard.mdx
+++ b/changelog/es/2026-03-26-remake-review-dashboard.mdx
@@ -1,0 +1,12 @@
+---
+version: "1.7.2"
+date: "2026-03-26"
+title: "Limpieza de Remakes: Revision y Dashboard"
+---
+
+Correcciones de seguimiento a la funcion de deteccion de remakes.
+
+- **Remakes excluidos de la revision** — las partidas remake ya no aparecen en las colas de Post-Game ni de Revision de VOD
+- **Dashboard actualizado** — los remakes muestran una insignia gris "R" en las partidas recientes y se excluyen de los calculos de KDA/CS promedio
+- **Conteos de revision corregidos** — los conteos de partidas sin revisar y pendientes de VOD ya no incluyen remakes
+- **Orden del changelog corregido** — la entrada de deteccion de remakes ahora aparece correctamente como la ultima version (v1.7.1)

--- a/messages/en.json
+++ b/messages/en.json
@@ -79,6 +79,7 @@
     "csLabel": "{cs} CS",
     "winShort": "W",
     "lossShort": "L",
+    "remakeShort": "R",
     "nextSession": "Next Session",
     "view": "View",
     "noVodSelected": "No VOD selected yet",

--- a/messages/es.json
+++ b/messages/es.json
@@ -79,6 +79,7 @@
     "csLabel": "{cs} CS",
     "winShort": "V",
     "lossShort": "D",
+    "remakeShort": "R",
     "nextSession": "Próxima sesión",
     "view": "Ver",
     "noVodSelected": "Sin VOD seleccionado aún",

--- a/src/app/(app)/dashboard/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/dashboard-client.tsx
@@ -153,22 +153,23 @@ export function DashboardClient({
       ? Math.round((totalWins / matchStats.total) * 100)
       : 0;
 
-  // Average KDA from recent matches
+  // Average KDA from recent matches (excluding remakes)
+  const meaningfulRecent = recentMatches.filter((m) => m.result !== "Remake");
   const avgKills =
-    recentMatches.length > 0
-      ? (recentMatches.reduce((s, m) => s + m.kills, 0) / recentMatches.length).toFixed(1)
+    meaningfulRecent.length > 0
+      ? (meaningfulRecent.reduce((s, m) => s + m.kills, 0) / meaningfulRecent.length).toFixed(1)
       : "0";
   const avgDeaths =
-    recentMatches.length > 0
-      ? (recentMatches.reduce((s, m) => s + m.deaths, 0) / recentMatches.length).toFixed(1)
+    meaningfulRecent.length > 0
+      ? (meaningfulRecent.reduce((s, m) => s + m.deaths, 0) / meaningfulRecent.length).toFixed(1)
       : "0";
   const avgAssists =
-    recentMatches.length > 0
-      ? (recentMatches.reduce((s, m) => s + m.assists, 0) / recentMatches.length).toFixed(1)
+    meaningfulRecent.length > 0
+      ? (meaningfulRecent.reduce((s, m) => s + m.assists, 0) / meaningfulRecent.length).toFixed(1)
       : "0";
   const avgCS =
-    recentMatches.length > 0
-      ? (recentMatches.reduce((s, m) => s + m.cs, 0) / recentMatches.length).toFixed(0)
+    meaningfulRecent.length > 0
+      ? (meaningfulRecent.reduce((s, m) => s + m.cs, 0) / meaningfulRecent.length).toFixed(0)
       : "0";
 
   // Games needing review
@@ -336,7 +337,9 @@ export function DashboardClient({
                       className={`w-1 h-8 rounded-full ${
                          match.result === "Victory"
                           ? "bg-win"
-                          : "bg-loss"
+                          : match.result === "Remake"
+                            ? "bg-muted-foreground/40"
+                            : "bg-loss"
                       }`}
                     />
                     <Image
@@ -387,11 +390,11 @@ export function DashboardClient({
                     </div>
                     <Badge
                       variant={
-                        match.result === "Victory" ? "default" : "destructive"
+                        match.result === "Victory" ? "default" : match.result === "Remake" ? "secondary" : "destructive"
                       }
                       className="text-xs w-6 justify-center"
                     >
-                      {match.result === "Victory" ? t("winShort") : t("lossShort")}
+                      {match.result === "Victory" ? t("winShort") : match.result === "Remake" ? t("remakeShort") : t("lossShort")}
                     </Badge>
                   </Link>
                 ))}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -95,11 +95,11 @@ export default async function DashboardPage() {
           sql`CASE WHEN ${matches.result} = 'Remake' THEN 1 END`
         ),
         unreviewed: count(
-          sql`CASE WHEN ${matches.reviewed} = 0 THEN 1 END`
+          sql`CASE WHEN ${matches.reviewed} = 0 AND ${matches.result} != 'Remake' THEN 1 END`
         ),
         // VOD-pending: unreviewed games that already have post-game notes (comment or highlights)
         vodPending: count(
-          sql`CASE WHEN ${matches.reviewed} = 0 AND (
+          sql`CASE WHEN ${matches.reviewed} = 0 AND ${matches.result} != 'Remake' AND (
             ${matches.comment} IS NOT NULL
             OR EXISTS (SELECT 1 FROM ${matchHighlights} WHERE ${matchHighlights.matchId} = ${matches.id})
           ) THEN 1 END`

--- a/src/app/(app)/review/page.tsx
+++ b/src/app/(app)/review/page.tsx
@@ -1,6 +1,6 @@
 import { db } from "@/db";
 import { matches, matchHighlights } from "@/db/schema";
-import { eq, and, asc, desc, inArray, count } from "drizzle-orm";
+import { eq, ne, and, asc, desc, inArray, count } from "drizzle-orm";
 import { requireUser } from "@/lib/session";
 import { getLatestVersion } from "@/lib/riot-api";
 import { ReviewClient } from "./review-client";
@@ -27,7 +27,8 @@ export default async function ReviewPage({
 
   const reviewedWhere = and(
     eq(matches.userId, user.id),
-    eq(matches.reviewed, true)
+    eq(matches.reviewed, true),
+    ne(matches.result, "Remake")
   );
 
   const matchColumns = {
@@ -68,7 +69,8 @@ export default async function ReviewPage({
       db.query.matches.findMany({
         where: and(
           eq(matches.userId, user.id),
-          eq(matches.reviewed, false)
+          eq(matches.reviewed, false),
+          ne(matches.result, "Remake")
         ),
         orderBy: asc(matches.gameDate),
         limit: 50,


### PR DESCRIPTION
## Summary
- **Remakes excluded from review page** — both unreviewed and reviewed queries now filter out `result = 'Remake'`, so remake games no longer appear in Post-Game or VOD Review queues
- **Dashboard updated** — remakes show a grey bar and "R" badge in recent games, and average KDA/CS excludes remakes
- **Dashboard review counts fixed** — `unreviewed` and `vodPending` aggregate counts exclude remakes
- **Changelog version corrected** — remake detection bumped from v1.6.1 to v1.7.1 so it sorts above v1.7.0 (Goal Tracking) as intended

Relates to #25

## Changelog
- Version 1.7.2: exclude remakes from review/dashboard, fix changelog ordering