### PR TITLE
refactor: centralize match result types, helpers, UI, and queries

### DIFF
--- a/changelog/en/2026-03-26-centralize-match-result.mdx
+++ b/changelog/en/2026-03-26-centralize-match-result.mdx
@@ -1,0 +1,17 @@
+---
+version: "1.8.0"
+date: "2026-03-26"
+title: "Centralized Match Result Handling"
+---
+
+Major refactor to centralize all match result logic (Victory/Defeat/Remake) into shared helpers, fixing 12 bugs and removing duplicated code across the codebase.
+
+- **Remakes no longer counted as losses** — duo stats, coaching intervals, sidebar review counts, and scout averages now correctly exclude remakes instead of silently counting them as defeats
+- **Coaching chart bands fixed** — coaching session markers on the win rate chart now align correctly with the remake-filtered data points
+- **LP trend improved** — the dashboard LP trend now uses the rank snapshot closest to the oldest of your last 10 games, giving consistent numbers that match the analytics page
+- **"Games analyzed" count fixed** — the analytics page header now shows only meaningful (non-remake) games
+- **Shared UI components** — new `ResultBadge` and `ResultBar` components replace 12+ scattered ternary expressions with consistent remake-aware rendering
+- **Duplicated rank utilities removed** — analytics page no longer maintains its own copy of LP/rank calculation functions
+- **Dead i18n keys cleaned up** — removed unused result translation keys from Coaching and Duo namespaces in favor of the shared Common namespace
+- **Seed data generates remakes** — the seed script now produces ~5% remakes with realistic short duration and minimal stats
+- **Export route typed** — the CSV export route now uses the shared `MatchResult` type

--- a/changelog/es/2026-03-26-centralize-match-result.mdx
+++ b/changelog/es/2026-03-26-centralize-match-result.mdx
@@ -1,0 +1,17 @@
+---
+version: "1.8.0"
+date: "2026-03-26"
+title: "Manejo Centralizado de Resultados de Partida"
+---
+
+Refactorizacion mayor para centralizar toda la logica de resultados de partida (Victoria/Derrota/Remake) en helpers compartidos, corrigiendo 12 bugs y eliminando codigo duplicado en todo el proyecto.
+
+- **Los remakes ya no cuentan como derrotas** — las estadisticas de duo, intervalos de coaching, conteos de revision en la barra lateral y promedios de scout ahora excluyen correctamente los remakes en lugar de contarlos silenciosamente como derrotas
+- **Bandas del grafico de coaching corregidas** — los marcadores de sesiones de coaching en el grafico de win rate ahora se alinean correctamente con los datos filtrados sin remakes
+- **Tendencia de LP mejorada** — la tendencia de LP del dashboard ahora usa la captura de rango mas cercana a la partida mas antigua de tus ultimas 10, dando numeros consistentes con la pagina de analiticas
+- **Conteo de "partidas analizadas" corregido** — el encabezado de la pagina de analiticas ahora muestra solo partidas significativas (sin remakes)
+- **Componentes UI compartidos** — nuevos componentes `ResultBadge` y `ResultBar` reemplazan mas de 12 expresiones ternarias dispersas con renderizado consistente que maneja remakes
+- **Utilidades de rango duplicadas eliminadas** — la pagina de analiticas ya no mantiene su propia copia de funciones de calculo de LP/rango
+- **Claves i18n muertas eliminadas** — se eliminaron claves de traduccion de resultados no utilizadas de los namespaces Coaching y Duo en favor del namespace compartido Common
+- **Los datos de seed generan remakes** — el script de seed ahora produce ~5% de remakes con duracion corta realista y estadisticas minimas
+- **Ruta de exportacion tipada** — la ruta de exportacion CSV ahora usa el tipo compartido `MatchResult`

--- a/messages/en.json
+++ b/messages/en.json
@@ -331,9 +331,6 @@
     "gamesDiscussed": "{count, plural, one {# game discussed} other {# games discussed}}",
     "watchVod": "Watch VOD",
     "vs": "vs",
-    "resultWin": "W",
-    "resultLoss": "L",
-    "resultRemake": "R",
     "actionItems": "Action Items",
     "actionItemsDescription": "{completed}/{total} completed. Click the status icon to cycle through: pending → in progress → completed.",
     "noActionItems": "No action items for this session.",
@@ -470,9 +467,6 @@
     "recentGames": {
       "title": "Recent Duo Games",
       "description": "Games played together with {partnerName}",
-      "resultWin": "W",
-      "resultLoss": "L",
-      "resultRemake": "R",
       "emptyTitle": "No duo games found yet.",
       "emptyDescription": "Sync your matches to detect games played with your duo partner."
     },
@@ -562,6 +556,16 @@
     "title": "What's New",
     "subtitle": "Latest updates and improvements to LoL Tracker",
     "empty": "No updates yet. Check back soon!"
+  },
+  "Common": {
+    "resultW": "W",
+    "resultL": "L",
+    "resultR": "R",
+    "resultVictory": "Victory",
+    "resultDefeat": "Defeat",
+    "resultRemake": "Remake",
+    "resultWin": "Win",
+    "resultLoss": "Loss"
   },
   "Goals": {
     "title": "Goals",

--- a/messages/es.json
+++ b/messages/es.json
@@ -331,9 +331,6 @@
     "gamesDiscussed": "{count, plural, one {# partida discutida} other {# partidas discutidas}}",
     "watchVod": "Ver VOD",
     "vs": "vs",
-    "resultWin": "V",
-    "resultLoss": "D",
-    "resultRemake": "R",
     "actionItems": "Tareas",
     "actionItemsDescription": "{completed}/{total} completadas. Haz clic en el icono de estado para cambiar: pendiente → en progreso → completada.",
     "noActionItems": "No hay tareas para esta sesión.",
@@ -470,9 +467,6 @@
     "recentGames": {
       "title": "Partidas de dúo recientes",
       "description": "Partidas jugadas con {partnerName}",
-      "resultWin": "V",
-      "resultLoss": "D",
-      "resultRemake": "R",
       "emptyTitle": "Sin partidas de dúo encontradas aún.",
       "emptyDescription": "Sincroniza tus partidas para detectar partidas jugadas con tu compañero de dúo."
     },
@@ -562,6 +556,16 @@
     "title": "Novedades",
     "subtitle": "Últimas actualizaciones y mejoras de LoL Tracker",
     "empty": "Aún no hay actualizaciones. ¡Vuelve pronto!"
+  },
+  "Common": {
+    "resultW": "V",
+    "resultL": "D",
+    "resultR": "R",
+    "resultVictory": "Victoria",
+    "resultDefeat": "Derrota",
+    "resultRemake": "Remake",
+    "resultWin": "Victoria",
+    "resultLoss": "Derrota"
   },
   "Goals": {
     "title": "Objetivos",

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -375,7 +375,7 @@ async function seed() {
     gameDate: Date;
     champion: { id: number; name: string };
     keystone: { id: number; name: string };
-    result: "Victory" | "Defeat";
+    result: "Victory" | "Defeat" | "Remake";
     kills: number;
     deaths: number;
     assists: number;
@@ -403,7 +403,14 @@ async function seed() {
     const gameDate = new Date(
       matchStart.getTime() + (timeSpan / totalMatches) * i + randInt(0, 3600000)
     );
-    const durationSeconds = randInt(1200, 2400); // 20–40 min
+    // ~5% remakes, then ~55% win rate among non-remakes (slightly positive, climbing)
+    const resultRoll = rand();
+    const result: "Victory" | "Defeat" | "Remake" =
+      resultRoll < 0.05 ? "Remake" : resultRoll < 0.05 + 0.95 * 0.55 ? "Victory" : "Defeat";
+    const isRemake = result === "Remake";
+
+    // Remakes are very short (2-3 min); real games 20-40 min
+    const durationSeconds = isRemake ? randInt(120, 210) : randInt(1200, 2400);
     const durationMin = durationSeconds / 60;
 
     // Main user plays from their pool 70% of the time
@@ -411,25 +418,23 @@ async function seed() {
     const keystone = pick(KEYSTONES);
     const matchup = pick(CHAMPIONS.filter((c) => c.id !== champion.id));
 
-    // ~55% win rate (slightly positive, climbing)
-    const result: "Victory" | "Defeat" = rand() < 0.55 ? "Victory" : "Defeat";
-
-    const kills = randInt(1, 15);
-    const deaths = randInt(0, 10);
-    const assists = randInt(1, 18);
-    const cs = Math.round(durationMin * (5 + rand() * 4)); // 5–9 cs/min
-    const csPerMin = Math.round((cs / durationMin) * 10) / 10;
-    const goldEarned = randInt(7000, 18000);
-    const visionScore = randInt(10, 50);
+    // Remakes have minimal stats
+    const kills = isRemake ? 0 : randInt(1, 15);
+    const deaths = isRemake ? 0 : randInt(0, 10);
+    const assists = isRemake ? 0 : randInt(1, 18);
+    const cs = isRemake ? 0 : Math.round(durationMin * (5 + rand() * 4)); // 5–9 cs/min
+    const csPerMin = isRemake ? 0 : Math.round((cs / durationMin) * 10) / 10;
+    const goldEarned = isRemake ? randInt(500, 1000) : randInt(7000, 18000);
+    const visionScore = isRemake ? randInt(0, 3) : randInt(10, 50);
 
     // Duo partner appears in ~40% of matches
     const hasDuo = rand() < 0.4;
     const duoChampion = hasDuo ? pick(SUPPORT_CHAMPIONS) : null;
 
-    // ~30% reviewed, ~10% skipped, rest unreviewed
+    // ~30% reviewed, ~10% skipped, rest unreviewed (remakes never reviewed)
     const reviewRoll = rand();
-    const reviewed = reviewRoll < 0.3;
-    const skipped = reviewRoll >= 0.3 && reviewRoll < 0.4;
+    const reviewed = isRemake ? false : reviewRoll < 0.3;
+    const skipped = isRemake ? false : reviewRoll >= 0.3 && reviewRoll < 0.4;
 
     seedMatches.push({
       matchId: `EUW1_${7000000000 + i}`,

--- a/src/app/(app)/analytics/analytics-client.tsx
+++ b/src/app/(app)/analytics/analytics-client.tsx
@@ -42,93 +42,9 @@ import { BarChart3, TrendingUp, Trophy, ArrowUpDown } from "lucide-react";
 import type { RankSnapshot } from "@/db/schema";
 import { getKeystoneIconUrlByName, getChampionIconUrl } from "@/lib/riot-api";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
+import { toCumulativeLP, getTierBoundaries, formatRank } from "@/lib/rank";
+import { filterMeaningful } from "@/lib/match-result";
 import { ChampionLink } from "@/components/champion-link";
-
-// ─── LP / Rank Utilities ─────────────────────────────────────────────────────
-
-const TIER_ORDER = [
-  "IRON",
-  "BRONZE",
-  "SILVER",
-  "GOLD",
-  "PLATINUM",
-  "EMERALD",
-  "DIAMOND",
-  "MASTER",
-  "GRANDMASTER",
-  "CHALLENGER",
-] as const;
-
-const DIVISION_ORDER = ["IV", "III", "II", "I"] as const;
-
-// LP per division = 100, 4 divisions per tier (except Master+ which has no divisions)
-const LP_PER_DIVISION = 100;
-const DIVISIONS_PER_TIER = 4;
-const LP_PER_TIER = LP_PER_DIVISION * DIVISIONS_PER_TIER; // 400
-
-/**
- * Convert tier + division + lp into a single cumulative LP number.
- * Iron IV 0 LP = 0, Iron III 0 LP = 100, Bronze IV 0 LP = 400, etc.
- * Master+ tiers have no divisions, treated as division I.
- */
-function toCumulativeLP(
-  tier: string | null | undefined,
-  division: string | null | undefined,
-  lp: number | null | undefined
-): number | null {
-  if (!tier) return null;
-  const tierIdx = TIER_ORDER.indexOf(tier.toUpperCase() as typeof TIER_ORDER[number]);
-  if (tierIdx === -1) return null;
-
-  // Master+ have no divisions — treat as single division
-  const isMasterPlus = tierIdx >= TIER_ORDER.indexOf("MASTER");
-  const divIdx = isMasterPlus
-    ? 0
-    : DIVISION_ORDER.indexOf((division || "IV") as typeof DIVISION_ORDER[number]);
-
-  const baseLp = tierIdx * LP_PER_TIER;
-  const divLp = (divIdx < 0 ? 0 : divIdx) * LP_PER_DIVISION;
-  return baseLp + divLp + (lp || 0);
-}
-
-/** Get tier boundaries for reference lines within a given LP range */
-function getTierBoundaries(
-  minLP: number,
-  maxLP: number
-): Array<{ lp: number; label: string }> {
-  const boundaries: Array<{ lp: number; label: string }> = [];
-  for (let i = 0; i < TIER_ORDER.length; i++) {
-    const boundary = i * LP_PER_TIER;
-    if (boundary > minLP && boundary < maxLP) {
-      const tierName =
-        TIER_ORDER[i].charAt(0) + TIER_ORDER[i].slice(1).toLowerCase();
-      boundaries.push({ lp: boundary, label: tierName });
-    }
-  }
-  return boundaries;
-}
-
-/** Format cumulative LP back to human-readable rank string */
-function formatRank(cumulativeLP: number): string {
-  const tierIdx = Math.min(
-    Math.floor(cumulativeLP / LP_PER_TIER),
-    TIER_ORDER.length - 1
-  );
-  const tier = TIER_ORDER[tierIdx];
-  const tierName = tier.charAt(0) + tier.slice(1).toLowerCase();
-
-  const isMasterPlus = tierIdx >= TIER_ORDER.indexOf("MASTER");
-  if (isMasterPlus) {
-    const lp = cumulativeLP - tierIdx * LP_PER_TIER;
-    return `${tierName} ${lp} LP`;
-  }
-
-  const lpInTier = cumulativeLP - tierIdx * LP_PER_TIER;
-  const divIdx = Math.min(Math.floor(lpInTier / LP_PER_DIVISION), 3);
-  const division = DIVISION_ORDER[divIdx];
-  const lp = lpInTier - divIdx * LP_PER_DIVISION;
-  return `${tierName} ${division} — ${lp} LP`;
-}
 
 /** Prepare rank snapshot data for the LP chart */
 function prepareRankChartData(snapshots: RankSnapshot[], locale: string) {
@@ -394,14 +310,17 @@ export function AnalyticsClient({
   }
 
   // Coaching session indices for shaded bands between consecutive sessions
+  // Must use the same filtered (remake-excluded) array that rollingWR uses,
+  // so band indices align with chart x-axis values.
   const coachingBands = useMemo(() => {
-    // Map each session to its closest match index
+    const meaningful = matches.filter((m) => m.result !== "Remake");
+    // Map each session to its closest match index in the filtered array
     const sessionIndices = coachingSessions.map((s) => {
       const sessionTime = s.date.getTime();
       let closestIdx = 0;
       let closestDiff = Infinity;
-      for (let i = 0; i < matches.length; i++) {
-        const diff = Math.abs(matches[i].gameDate.getTime() - sessionTime);
+      for (let i = 0; i < meaningful.length; i++) {
+        const diff = Math.abs(meaningful[i].gameDate.getTime() - sessionTime);
         if (diff < closestDiff) {
           closestDiff = diff;
           closestIdx = i;
@@ -524,6 +443,8 @@ export function AnalyticsClient({
     return null; // Use original
   }, [lpChartMeta, goalTargetLP]);
 
+  const meaningfulCount = useMemo(() => filterMeaningful(matches).length, [matches]);
+
   if (matches.length === 0) {
     return (
       <div className="space-y-6">
@@ -549,7 +470,7 @@ export function AnalyticsClient({
       <div>
         <h1 className="text-2xl font-bold tracking-tight text-gradient-gold">{t("pageTitle")}</h1>
         <p className="text-muted-foreground">
-          {t("gamesAnalyzed", { count: matches.length })}
+          {t("gamesAnalyzed", { count: meaningfulCount })}
         </p>
       </div>
 

--- a/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
+++ b/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
@@ -13,6 +13,7 @@ import {
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { ResultBadge, ResultBar } from "@/components/result-badge";
 import {
   Card,
   CardContent,
@@ -383,15 +384,7 @@ export function CoachingDetailClient({
                       href={`/matches/${match.id}`}
                       className="flex items-center gap-3 rounded-lg p-2 hover:bg-surface-elevated transition-colors"
                     >
-                      <div
-                        className={`w-1 h-8 rounded-full ${
-                          match.result === "Remake"
-                            ? "bg-muted-foreground/40"
-                            : match.result === "Victory"
-                            ? "bg-win"
-                            : "bg-loss"
-                        }`}
-                      />
+                      <ResultBar result={match.result} />
                       <Image
                         src={getChampionIconUrl(
                           ddragonVersion,
@@ -433,18 +426,7 @@ export function CoachingDetailClient({
                       <span className="text-xs text-muted-foreground">
                         {formatDuration(match.gameDurationSeconds)}
                       </span>
-                      <Badge
-                        variant={
-                          match.result === "Remake"
-                            ? "secondary"
-                            : match.result === "Victory"
-                            ? "default"
-                            : "destructive"
-                        }
-                        className="text-xs"
-                      >
-                        {match.result === "Remake" ? t("resultRemake") : match.result === "Victory" ? t("resultWin") : t("resultLoss")}
-                      </Badge>
+                      <ResultBadge result={match.result} />
                     </Link>
 
                     {/* VOD link */}
@@ -596,13 +578,7 @@ export function CoachingDetailClient({
                         href={`/matches/${match.id}`}
                         className="flex items-center gap-3 hover:opacity-80 transition-opacity"
                       >
-                        <div
-                          className={`w-1 h-6 rounded-full ${
-                            match.result === "Victory"
-                              ? "bg-win"
-                              : "bg-loss"
-                          }`}
-                        />
+                        <ResultBar result={match.result} size="sm" />
                         <Image
                           src={getChampionIconUrl(
                             ddragonVersion,
@@ -643,18 +619,7 @@ export function CoachingDetailClient({
                           <span className="text-xs text-muted-foreground">
                             {matchDateStr}
                           </span>
-                          <Badge
-                            variant={
-                              match.result === "Remake"
-                                ? "secondary"
-                                : match.result === "Victory"
-                                ? "default"
-                                : "destructive"
-                            }
-                            className="text-xs"
-                          >
-                        {match.result === "Remake" ? t("resultRemake") : match.result === "Victory" ? t("resultWin") : t("resultLoss")}
-                          </Badge>
+                          <ResultBadge result={match.result} />
                         </div>
                       </Link>
 

--- a/src/app/(app)/coaching/[id]/complete/complete-session-client.tsx
+++ b/src/app/(app)/coaching/[id]/complete/complete-session-client.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
+import { ResultBadge } from "@/components/result-badge";
 import {
   Card,
   CardContent,
@@ -203,14 +204,7 @@ export function CompleteSessionClient({
                 <span className="text-xs text-muted-foreground">
                   {t("vs")} {vodMatch.matchupChampionName || "?"}
                 </span>
-                <Badge
-                  variant={
-                    vodMatch.result === "Victory" ? "default" : "destructive"
-                  }
-                  className="text-xs"
-                >
-                  {vodMatch.result === "Victory" ? t("resultWin") : t("resultLoss")}
-                </Badge>
+                <ResultBadge result={vodMatch.result} />
               </div>
             )}
           </div>

--- a/src/app/(app)/coaching/new/schedule-session-client.tsx
+++ b/src/app/(app)/coaching/new/schedule-session-client.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { ResultBar } from "@/components/result-badge";
 import {
   Card,
   CardContent,
@@ -57,6 +58,7 @@ export function ScheduleSessionClient({
   const { data: authSession } = useSession();
   const locale = authSession?.user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("ScheduleSession");
+  const tCommon = useTranslations("Common");
   const [isPending, startTransition] = useTransition();
 
   const [coachName, setCoachName] = useState("");
@@ -241,13 +243,7 @@ export function ScheduleSessionClient({
                     >
                       {isSelected && <Check className="h-3 w-3" />}
                     </div>
-                    <div
-                      className={`w-1 h-6 rounded-full ${
-                         match.result === "Victory"
-                          ? "bg-win"
-                          : "bg-loss"
-                      }`}
-                    />
+                    <ResultBar result={match.result} size="sm" />
                     <span className="text-sm font-medium inline-flex items-center gap-1.5">
                       <Image
                         src={getChampionIconUrl(
@@ -313,7 +309,7 @@ export function ScheduleSessionClient({
                 {t("matchPreviewLabel", {
                   championName: selectedMatch.championName,
                   matchupChampionName: selectedMatch.matchupChampionName || "?",
-                  result: selectedMatch.result === "Victory" ? t("resultWin") : t("resultLoss"),
+                  result: selectedMatch.result === "Victory" ? tCommon("resultW") : selectedMatch.result === "Remake" ? tCommon("resultR") : tCommon("resultL"),
                 })}
               </p>
 

--- a/src/app/(app)/coaching/page.tsx
+++ b/src/app/(app)/coaching/page.tsx
@@ -8,6 +8,7 @@ import {
 import { eq, desc, and, gt, lte, inArray } from "drizzle-orm";
 import { requireUser } from "@/lib/session";
 import { getLatestVersion } from "@/lib/riot-api";
+import { isMeaningful } from "@/lib/match-result";
 import { cacheLife, cacheTag } from "next/cache";
 import { coachingTag } from "@/lib/cache";
 import { CoachingHubClient } from "./coaching-hub-client";
@@ -123,10 +124,11 @@ async function getCachedCoachingHubData(userId: string) {
         },
       });
 
-      const wins = intervalMatches.filter(
+      const meaningfulGames = intervalMatches.filter((m) => isMeaningful(m.result));
+      const wins = meaningfulGames.filter(
         (m) => m.result === "Victory"
       ).length;
-      const losses = intervalMatches.length - wins;
+      const losses = meaningfulGames.length - wins;
 
       // Count relevant highlights in these matches
       let relevantNoteCount = 0;
@@ -147,7 +149,7 @@ async function getCachedCoachingHubData(userId: string) {
 
       intervals.set(current.id, {
         sessionId: current.id,
-        matchCount: intervalMatches.length,
+        matchCount: meaningfulGames.length,
         wins,
         losses,
         relevantNoteCount,

--- a/src/app/(app)/dashboard/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/dashboard-client.tsx
@@ -6,6 +6,7 @@ import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { ResultBadge, ResultBar } from "@/components/result-badge";
 import { Progress } from "@/components/ui/progress";
 import {
   Card,
@@ -24,7 +25,7 @@ import {
   Calendar,
   Target,
 } from "lucide-react";
-import type { RankSnapshot, CoachingActionItem, Goal } from "@/db/schema";
+import type { RankSnapshot, CoachingActionItem, Goal, MatchResult } from "@/db/schema";
 import { getKeystoneIconUrlByName, getChampionIconUrl } from "@/lib/riot-api";
 import { ChampionLink } from "@/components/champion-link";
 import { formatDuration, formatDate, DEFAULT_LOCALE } from "@/lib/format";
@@ -36,7 +37,7 @@ import {
 interface DashboardMatch {
   id: string;
   gameDate: Date;
-  result: "Victory" | "Defeat" | "Remake";
+  result: MatchResult;
   championId: number;
   championName: string;
   runeKeystoneId: number | null;
@@ -333,15 +334,7 @@ export function DashboardClient({
                     href={`/matches/${match.id}`}
                     className="flex items-center gap-3 rounded-lg p-2 hover:bg-surface-elevated transition-colors"
                   >
-                    <div
-                      className={`w-1 h-8 rounded-full ${
-                         match.result === "Victory"
-                          ? "bg-win"
-                          : match.result === "Remake"
-                            ? "bg-muted-foreground/40"
-                            : "bg-loss"
-                      }`}
-                    />
+                    <ResultBar result={match.result} />
                     <Image
                       src={getChampionIconUrl(ddragonVersion, match.championName)}
                       alt={match.championName}
@@ -388,14 +381,7 @@ export function DashboardClient({
                         {t("csLabel", { cs: match.cs })}
                       </div>
                     </div>
-                    <Badge
-                      variant={
-                        match.result === "Victory" ? "default" : match.result === "Remake" ? "secondary" : "destructive"
-                      }
-                      className="text-xs w-6 justify-center"
-                    >
-                      {match.result === "Victory" ? t("winShort") : match.result === "Remake" ? t("remakeShort") : t("lossShort")}
-                    </Badge>
+                    <ResultBadge result={match.result} className="w-6 justify-center" />
                   </Link>
                 ))}
               </div>

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -139,20 +139,23 @@ export default async function DashboardPage() {
   };
   const postGamePending = unreviewed - vodPending;
 
-  // LP trend: compare latest rank snapshot vs. an older one.
-  // Each sync creates 1-2 snapshots (timestamped at sync time, not match time).
-  // We skip back ~20 snapshots (~10 syncs) to find the baseline rank, giving
-  // a "LP change over recent sessions" indicator.
+  // LP trend: compare first vs. last rank snapshot within the timeframe of
+  // the last 10 games, giving a consistent "LP change over recent games"
+  // indicator that aligns with the analytics page.
   let lpTrend: number | null = null;
   if (latestRankOrUndef?.tier && recentMatches.length >= 2) {
-    const baseSnapshot = await db.query.rankSnapshots.findFirst({
-      where: eq(rankSnapshots.userId, user.id),
-      orderBy: desc(rankSnapshots.capturedAt),
-      offset: 20,
-    });
+    // Find the oldest game date in recent matches for the baseline window
+    const oldestGameDate = recentMatches[recentMatches.length - 1].gameDate;
 
-    // Fall back to the very oldest snapshot if we don't have 20+ yet
-    const baseline = baseSnapshot ?? await db.query.rankSnapshots.findFirst({
+    // Baseline: the latest snapshot captured at or before the oldest recent game
+    const baseline = await db.query.rankSnapshots.findFirst({
+      where: and(
+        eq(rankSnapshots.userId, user.id),
+        sql`${rankSnapshots.capturedAt} <= ${oldestGameDate}`
+      ),
+      orderBy: desc(rankSnapshots.capturedAt),
+    }) ?? await db.query.rankSnapshots.findFirst({
+      // Fall back to the very oldest snapshot if none predates the window
       where: eq(rankSnapshots.userId, user.id),
       orderBy: asc(rankSnapshots.capturedAt),
     });

--- a/src/app/(app)/duo/duo-client.tsx
+++ b/src/app/(app)/duo/duo-client.tsx
@@ -12,7 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { ResultBadge } from "@/components/result-badge";
 import { Button } from "@/components/ui/button";
 import { Pagination } from "@/components/pagination";
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
@@ -456,22 +456,14 @@ export function DuoRecentGames({
                 href={`/matches/${game.id}`}
                 className="flex items-center gap-3 flex-wrap sm:flex-nowrap rounded-lg border border-border/50 p-3 bg-surface-elevated hover:bg-accent transition-colors"
               >
-                <Badge
-                  variant={
-                    game.result === "Remake"
-                      ? "secondary"
-                      : game.result === "Victory"
-                      ? "default"
-                      : "destructive"
-                  }
-                  className={`w-12 justify-center text-xs ${
+                <ResultBadge
+                  result={game.result}
+                  className={`w-12 justify-center ${
                     game.result === "Victory"
                       ? "bg-win/20 text-win border-win/30"
                       : ""
                   }`}
-                >
-                  {game.result === "Remake" ? t("recentGames.resultRemake") : game.result === "Victory" ? t("recentGames.resultWin") : t("recentGames.resultLoss")}
-                </Badge>
+                />
 
                 <div className="flex items-center gap-2 min-w-0">
                   <ChampionIcon

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -7,30 +7,19 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { SessionProvider } from "next-auth/react";
 import { Toaster } from "@/components/ui/sonner";
 import { db } from "@/db";
-import { matches, matchHighlights } from "@/db/schema";
-import { eq, count, sql } from "drizzle-orm";
+import { matches } from "@/db/schema";
+import { eq } from "drizzle-orm";
 import { getLatestChangelogVersion } from "@/lib/changelog";
+import { sidebarReviewCountsSelect } from "@/lib/match-queries";
 
 async function SidebarWithUser() {
   await connection();
   const user = await requireUser();
 
-  // Lightweight count for sidebar review badges
+  // Lightweight count for sidebar review badges (excludes remakes)
   const [reviewCounts, latestVersion] = await Promise.all([
     db
-      .select({
-        postGame: count(
-          sql`CASE WHEN ${matches.reviewed} = 0 AND ${matches.comment} IS NULL AND NOT EXISTS (
-            SELECT 1 FROM ${matchHighlights} WHERE ${matchHighlights.matchId} = ${matches.id}
-          ) THEN 1 END`
-        ),
-        vod: count(
-          sql`CASE WHEN ${matches.reviewed} = 0 AND (
-            ${matches.comment} IS NOT NULL
-            OR EXISTS (SELECT 1 FROM ${matchHighlights} WHERE ${matchHighlights.matchId} = ${matches.id})
-          ) THEN 1 END`
-        ),
-      })
+      .select(sidebarReviewCountsSelect())
       .from(matches)
       .where(eq(matches.userId, user.id))
       .then((rows) => rows[0]),

--- a/src/app/(app)/matches/[id]/match-detail-client.tsx
+++ b/src/app/(app)/matches/[id]/match-detail-client.tsx
@@ -6,6 +6,7 @@ import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { ResultBadge } from "@/components/result-badge";
 import {
   Card,
   CardContent,
@@ -233,17 +234,7 @@ export function MatchDetailClient({
                     className="hover:bg-accent/30"
                   />
                 </h1>
-                <Badge
-                  variant={
-                    match.result === "Remake"
-                      ? "secondary"
-                      : match.result === "Victory"
-                      ? "default"
-                      : "destructive"
-                  }
-                >
-                  {match.result}
-                </Badge>
+                <ResultBadge result={match.result} format="long" />
                 {match.reviewed && (
                   <Badge variant="secondary" className="gap-1">
                     <Eye className="h-3 w-3" />

--- a/src/app/(app)/matches/page.tsx
+++ b/src/app/(app)/matches/page.tsx
@@ -4,6 +4,7 @@ import { eq, and, desc, sql, inArray, count } from "drizzle-orm";
 import { requireUser } from "@/lib/session";
 import { getLatestVersion } from "@/lib/riot-api";
 import { MatchesClient } from "./matches-client";
+import { winLossRemakeSelect } from "@/lib/match-queries";
 
 const PAGE_SIZE = 10;
 
@@ -100,11 +101,7 @@ export default async function MatchesPage({
     getLatestVersion(),
     // Win/loss stats for the filtered set
     db
-      .select({
-        wins: sql<number>`SUM(CASE WHEN ${matches.result} = 'Victory' THEN 1 ELSE 0 END)`,
-        losses: sql<number>`SUM(CASE WHEN ${matches.result} = 'Defeat' THEN 1 ELSE 0 END)`,
-        remakes: sql<number>`SUM(CASE WHEN ${matches.result} = 'Remake' THEN 1 ELSE 0 END)`,
-      })
+      .select(winLossRemakeSelect)
       .from(matches)
       .where(whereClause),
   ]);

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -9,6 +9,7 @@ import { useTranslations } from "next-intl";
 import { savePostGameReview, bulkMarkReviewed } from "@/app/actions/matches";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { ResultBadge, ResultBar } from "@/components/result-badge";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import {
@@ -108,15 +109,7 @@ function MatchCardHeader({
   const t = useTranslations("Review");
   return (
     <div className="flex items-center gap-3">
-      <div
-        className={`w-1 h-10 rounded-full ${
-          match.result === "Remake"
-            ? "bg-muted-foreground/40"
-            : match.result === "Victory"
-            ? "bg-win"
-            : "bg-loss"
-        }`}
-      />
+      <ResultBar result={match.result} size="lg" />
       <Image
         src={getChampionIconUrl(ddragonVersion, match.championName)}
         alt={match.championName}
@@ -127,18 +120,7 @@ function MatchCardHeader({
       <div className="flex-1">
         <div className="flex items-center gap-2">
           <CardTitle className="text-base">{match.championName}</CardTitle>
-          <Badge
-            variant={
-              match.result === "Remake"
-                ? "secondary"
-                : match.result === "Victory"
-                ? "default"
-                : "destructive"
-            }
-            className="text-xs"
-          >
-            {match.result === "Remake" ? t("remake") : match.result === "Victory" ? t("win") : t("loss")}
-          </Badge>
+          <ResultBadge result={match.result} />
         </div>
         <CardDescription className="inline-flex items-center gap-1 flex-wrap">
           {formatDate(match.gameDate, locale)} &middot;{" "}

--- a/src/app/actions/duo.ts
+++ b/src/app/actions/duo.ts
@@ -1,13 +1,14 @@
 "use server";
 
 import { db } from "@/db";
-import { matches, users } from "@/db/schema";
+import { matches, users, type MatchResult } from "@/db/schema";
 import { eq, and, isNotNull, desc, sql, count } from "drizzle-orm";
 import { requireUser } from "@/lib/session";
 import { revalidatePath } from "next/cache";
 import { cacheLife, cacheTag } from "next/cache";
 import { duoTag, invalidateDuoBackfillCaches } from "@/lib/cache";
 import type { RiotMatch } from "@/lib/riot-api";
+import { duoStatsSelect, championSynergySelect } from "@/lib/match-queries";
 
 const PAGE_SIZE = 10;
 
@@ -40,7 +41,7 @@ export interface DuoStats {
 export interface DuoGameRow {
   id: string;
   gameDate: Date;
-  result: "Victory" | "Defeat" | "Remake";
+  result: MatchResult;
   championName: string;
   kills: number;
   deaths: number;
@@ -95,19 +96,10 @@ async function getCachedDuoStats(userId: string): Promise<DuoStats | null> {
   });
   if (!user?.duoPartnerUserId) return null;
 
-  // Run duo + solo aggregations in parallel — no rawMatchJson needed
+  // Run duo + solo aggregations in parallel — excludes remakes from totals
   const [duoAgg, soloAgg] = await Promise.all([
     db
-      .select({
-        totalGames: count(),
-        wins: sql<number>`SUM(CASE WHEN ${matches.result} = 'Victory' THEN 1 ELSE 0 END)`,
-        avgKills: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.kills} END)`,
-        avgDeaths: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.deaths} END)`,
-        avgAssists: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.assists} END)`,
-        partnerAvgKills: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.duoPartnerKills} END)`,
-        partnerAvgDeaths: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.duoPartnerDeaths} END)`,
-        partnerAvgAssists: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.duoPartnerAssists} END)`,
-      })
+      .select(duoStatsSelect())
       .from(matches)
       .where(
         and(
@@ -117,7 +109,7 @@ async function getCachedDuoStats(userId: string): Promise<DuoStats | null> {
       ),
     db
       .select({
-        totalGames: count(),
+        totalGames: sql<number>`SUM(CASE WHEN ${matches.result} != 'Remake' THEN 1 ELSE 0 END)`,
         wins: sql<number>`SUM(CASE WHEN ${matches.result} = 'Victory' THEN 1 ELSE 0 END)`,
       })
       .from(matches)
@@ -278,8 +270,7 @@ async function getCachedChampionSynergy(
     .select({
       yourChampion: matches.championName,
       partnerChampion: matches.duoPartnerChampionName,
-      games: sql<number>`count(*)`.as("games"),
-      wins: sql<number>`SUM(CASE WHEN ${matches.result} = 'Victory' THEN 1 ELSE 0 END)`.as("wins"),
+      ...championSynergySelect,
     })
     .from(matches)
     .where(
@@ -290,7 +281,7 @@ async function getCachedChampionSynergy(
       )
     )
     .groupBy(matches.championName, matches.duoPartnerChampionName)
-    .orderBy(sql`count(*) desc`)
+    .orderBy(sql`games desc`)
     .limit(15);
 
   return rows

--- a/src/app/actions/live.ts
+++ b/src/app/actions/live.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { db } from "@/db";
-import { matches, matchHighlights } from "@/db/schema";
+import { matches, matchHighlights, type MatchResult } from "@/db/schema";
 import { eq, and, desc, inArray, sql } from "drizzle-orm";
 import { requireUser } from "@/lib/session";
 import {
@@ -10,13 +10,14 @@ import {
 } from "@/lib/riot-api";
 import { cacheLife, cacheTag } from "next/cache";
 import { scoutTag } from "@/lib/cache";
+import { notRemake } from "@/lib/match-queries";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 interface MatchupGameDetail {
   matchId: string;
   gameDate: Date;
-  result: "Victory" | "Defeat" | "Remake";
+  result: MatchResult;
   championName: string;
   matchupChampionName: string | null;
   kills: number;
@@ -158,20 +159,21 @@ async function getCachedMatchupReport(
     }))
     .sort((a, b) => b.games - a.games);
 
-  // Average stats
-  const totalKills = matchRows.reduce((sum, m) => sum + m.kills, 0);
-  const totalDeaths = matchRows.reduce((sum, m) => sum + m.deaths, 0);
-  const totalAssists = matchRows.reduce((sum, m) => sum + m.assists, 0);
-  const totalCsPerMin = matchRows.reduce(
+  // Average stats (exclude remakes)
+  const meaningful = matchRows.filter((m) => m.result !== "Remake");
+  const totalKills = meaningful.reduce((sum, m) => sum + m.kills, 0);
+  const totalDeaths = meaningful.reduce((sum, m) => sum + m.deaths, 0);
+  const totalAssists = meaningful.reduce((sum, m) => sum + m.assists, 0);
+  const totalCsPerMin = meaningful.reduce(
     (sum, m) => sum + (m.csPerMin || 0),
     0
   );
-  const totalGold = matchRows.reduce((sum, m) => sum + (m.goldEarned || 0), 0);
-  const totalVision = matchRows.reduce(
+  const totalGold = meaningful.reduce((sum, m) => sum + (m.goldEarned || 0), 0);
+  const totalVision = meaningful.reduce(
     (sum, m) => sum + (m.visionScore || 0),
     0
   );
-  const n = matchRows.length;
+  const n = meaningful.length || 1; // Avoid division by zero
 
   const avgStats = {
     kills: Math.round((totalKills / n) * 10) / 10,
@@ -240,7 +242,7 @@ async function getCachedMatchupReport(
     return {
       matchId: m.id,
       gameDate: m.gameDate,
-      result: m.result as "Victory" | "Defeat",
+      result: m.result,
       championName: m.championName,
       matchupChampionName: m.matchupChampionName ?? null,
       kills: m.kills,
@@ -263,10 +265,10 @@ async function getCachedMatchupReport(
     };
   });
 
-  // ─── Overall average stats (for comparison baseline) ────────────────────
+  // ─── Overall average stats (for comparison baseline, excludes remakes) ──
   // If yourChampionName is set, compare against all games as that champion.
   // Otherwise, compare against all user games.
-  const overallConditions = [eq(matches.userId, userId)];
+  const overallConditions = [eq(matches.userId, userId), notRemake];
   if (yourChampionName) {
     overallConditions.push(eq(matches.championName, yourChampionName));
   }

--- a/src/app/api/export/matches/route.ts
+++ b/src/app/api/export/matches/route.ts
@@ -1,5 +1,5 @@
 import { db } from "@/db";
-import { matches } from "@/db/schema";
+import { matches, type MatchResult } from "@/db/schema";
 import { eq, and, desc, sql } from "drizzle-orm";
 import { getCurrentUser } from "@/lib/session";
 
@@ -112,7 +112,7 @@ export async function GET(request: Request) {
   // Build WHERE conditions
   const conditions = [eq(matches.userId, user.id)];
   if (result === "Victory" || result === "Defeat" || result === "Remake") {
-    conditions.push(eq(matches.result, result));
+    conditions.push(eq(matches.result, result as MatchResult));
   }
   if (champion !== "all") {
     conditions.push(eq(matches.championName, champion));

--- a/src/components/match-card.tsx
+++ b/src/components/match-card.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { Badge } from "@/components/ui/badge";
+import { ResultBadge } from "@/components/result-badge";
 import {
   Tooltip,
   TooltipTrigger,
@@ -21,6 +21,8 @@ import {
 } from "lucide-react";
 import { getChampionIconUrl } from "@/lib/riot-api";
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
+import type { MatchResult } from "@/lib/match-result";
+import { resultBorderColor } from "@/lib/match-result";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -34,7 +36,7 @@ export interface MatchHighlightData {
 interface MatchCardData {
   id: string;
   gameDate: Date;
-  result: "Victory" | "Defeat" | "Remake" | string;
+  result: MatchResult;
   championName: string;
   matchupChampionName: string | null;
   kills: number;
@@ -89,8 +91,6 @@ export function MatchCard({
   locale?: string;
 }) {
   const t = useTranslations("MatchCard");
-  const isWin = match.result === "Victory";
-  const isRemake = match.result === "Remake";
   const hasComment = !!match.comment;
   const hasReviewNotes = !!match.reviewNotes;
   const kda =
@@ -115,13 +115,7 @@ export function MatchCard({
     <TooltipProvider>
       <Link
         href={`/matches/${match.id}`}
-        className={`block rounded-lg border bg-card transition-all hover:bg-surface-elevated/50 ${
-          isRemake
-            ? "border-l-[3px] border-l-muted-foreground/40"
-            : isWin
-            ? "border-l-[3px] border-l-win/60"
-            : "border-l-[3px] border-l-loss/60"
-        }`}
+        className={`block rounded-lg border bg-card transition-all hover:bg-surface-elevated/50 border-l-[3px] ${resultBorderColor(match.result)}`}
       >
         <div className="flex items-center gap-3 px-4 py-3">
           {/* Champion */}
@@ -277,12 +271,7 @@ export function MatchCard({
 
           {/* Result + Date */}
           <div className="flex flex-col items-end gap-0.5 shrink-0">
-            <Badge
-              variant={isRemake ? "secondary" : isWin ? "default" : "destructive"}
-              className="text-xs"
-            >
-              {isRemake ? t("remake") : isWin ? t("win") : t("loss")}
-            </Badge>
+            <ResultBadge result={match.result} />
             <span className="text-[10px] text-muted-foreground whitespace-nowrap">
               {formatDate(match.gameDate, locale)}
             </span>

--- a/src/components/result-badge.tsx
+++ b/src/components/result-badge.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+// Shared UI components for rendering match results consistently.
+// Replaces 7+ copy-pasted Badge ternaries and 5+ bar ternaries across the app.
+
+import { useTranslations } from "next-intl";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import {
+  type MatchResult,
+  resultBadgeVariant,
+  resultBarColor,
+} from "@/lib/match-result";
+
+// ─── ResultBadge ─────────────────────────────────────────────────────────────
+
+type ResultFormat =
+  | "short" // "W" / "L" / "R"
+  | "long" // "Victory" / "Defeat" / "Remake" (localized)
+  | "raw"; // Uses the raw result string as-is (e.g. "Victory")
+
+interface ResultBadgeProps {
+  result: MatchResult | string;
+  /** "short" → W/L/R, "long" → Victory/Defeat/Remake, "raw" → raw string */
+  format?: ResultFormat;
+  className?: string;
+}
+
+export function ResultBadge({
+  result,
+  format = "short",
+  className,
+}: ResultBadgeProps) {
+  const t = useTranslations("Common");
+  const variant = resultBadgeVariant(result);
+
+  let label: string;
+  if (format === "raw") {
+    label = result;
+  } else if (format === "long") {
+    label =
+      result === "Victory"
+        ? t("resultVictory")
+        : result === "Remake"
+          ? t("resultRemake")
+          : t("resultDefeat");
+  } else {
+    // short
+    label =
+      result === "Victory"
+        ? t("resultW")
+        : result === "Remake"
+          ? t("resultR")
+          : t("resultL");
+  }
+
+  return (
+    <Badge variant={variant} className={cn("text-xs", className)}>
+      {label}
+    </Badge>
+  );
+}
+
+// ─── ResultBar ───────────────────────────────────────────────────────────────
+
+interface ResultBarProps {
+  result: MatchResult | string;
+  /** Height class — "sm" = h-6, "md" = h-8, "lg" = h-10 */
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+const barSizeClass = {
+  sm: "h-6",
+  md: "h-8",
+  lg: "h-10",
+} as const;
+
+export function ResultBar({
+  result,
+  size = "md",
+  className,
+}: ResultBarProps) {
+  return (
+    <div
+      className={cn(
+        "w-1 rounded-full",
+        barSizeClass[size],
+        resultBarColor(result),
+        className
+      )}
+    />
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -235,6 +235,8 @@ export const goals = sqliteTable("goals", {
 // ─── Type Exports ────────────────────────────────────────────────────────────
 
 export type Match = typeof matches.$inferSelect;
+/** The result column's union type, derived from the schema enum. */
+export type MatchResult = Match["result"];
 export type RankSnapshot = typeof rankSnapshots.$inferSelect;
 export type CoachingSession = typeof coachingSessions.$inferSelect;
 export type CoachingActionItem = typeof coachingActionItems.$inferSelect;

--- a/src/lib/match-queries.ts
+++ b/src/lib/match-queries.ts
@@ -1,0 +1,90 @@
+// Shared Drizzle SQL fragments for match result filtering and aggregation.
+// Keeps all remake-aware query logic in one place.
+
+import { sql, type SQL } from "drizzle-orm";
+import { matches, matchHighlights } from "@/db/schema";
+
+// ─── SQL Fragments ───────────────────────────────────────────────────────────
+
+/** SQL condition: result is NOT 'Remake'. Use in WHERE clauses. */
+export const notRemake: SQL = sql`${matches.result} != 'Remake'`;
+
+// ─── Aggregate Helpers ───────────────────────────────────────────────────────
+
+/**
+ * Build a SELECT that returns win/loss/remake/unreviewed/vodPending counts.
+ * Use with `db.select(matchStatCountsSelect).from(matches).where(...)`.
+ */
+export const matchStatCountsSelect = {
+  total: sql<number>`SUM(CASE WHEN ${matches.result} != 'Remake' THEN 1 ELSE 0 END)`.as("total"),
+  wins: sql<number>`SUM(CASE WHEN ${matches.result} = 'Victory' THEN 1 ELSE 0 END)`.as("wins"),
+  remakes: sql<number>`SUM(CASE WHEN ${matches.result} = 'Remake' THEN 1 ELSE 0 END)`.as("remakes"),
+  unreviewed: sql<number>`SUM(CASE WHEN ${matches.reviewed} = 0 AND ${matches.result} != 'Remake' THEN 1 ELSE 0 END)`.as("unreviewed"),
+  vodPending: sql<number>`SUM(CASE WHEN ${matches.reviewed} = 0 AND ${matches.result} != 'Remake' AND (
+    ${matches.comment} IS NOT NULL
+    OR EXISTS (SELECT 1 FROM ${matchHighlights} WHERE ${matchHighlights.matchId} = ${matches.id})
+  ) THEN 1 ELSE 0 END)`.as("vod_pending"),
+};
+
+/**
+ * Returns win/loss/remake counts for a result-aware query.
+ * Use: `db.select(winLossRemakeSelect).from(matches).where(...)`
+ */
+export const winLossRemakeSelect = {
+  wins: sql<number>`SUM(CASE WHEN ${matches.result} = 'Victory' THEN 1 ELSE 0 END)`.as("wins"),
+  losses: sql<number>`SUM(CASE WHEN ${matches.result} = 'Defeat' THEN 1 ELSE 0 END)`.as("losses"),
+  remakes: sql<number>`SUM(CASE WHEN ${matches.result} = 'Remake' THEN 1 ELSE 0 END)`.as("remakes"),
+};
+
+/**
+ * Average performance stats excluding remakes.
+ * Use: `db.select(avgPerformanceSelect).from(matches).where(...)`
+ */
+export const avgPerformanceSelect = {
+  avgKills: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.kills} END)`.as("avg_kills"),
+  avgDeaths: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.deaths} END)`.as("avg_deaths"),
+  avgAssists: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.assists} END)`.as("avg_assists"),
+  avgCsPerMin: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.csPerMin} END)`.as("avg_cs_per_min"),
+  avgGold: sql<number>`ROUND(AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.goldEarned} END))`.as("avg_gold"),
+  avgVision: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.visionScore} END)`.as("avg_vision"),
+  total: sql<number>`SUM(CASE WHEN ${matches.result} != 'Remake' THEN 1 ELSE 0 END)`.as("total_meaningful"),
+};
+
+/**
+ * Duo-specific aggregate counts that exclude remakes from totals.
+ */
+export function duoStatsSelect() {
+  return {
+    totalGames: sql<number>`SUM(CASE WHEN ${matches.result} != 'Remake' THEN 1 ELSE 0 END)`.as("total_games"),
+    wins: sql<number>`SUM(CASE WHEN ${matches.result} = 'Victory' THEN 1 ELSE 0 END)`.as("wins"),
+    avgKills: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.kills} END)`.as("avg_kills"),
+    avgDeaths: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.deaths} END)`.as("avg_deaths"),
+    avgAssists: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.assists} END)`.as("avg_assists"),
+    partnerAvgKills: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.duoPartnerKills} END)`.as("partner_avg_kills"),
+    partnerAvgDeaths: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.duoPartnerDeaths} END)`.as("partner_avg_deaths"),
+    partnerAvgAssists: sql<number>`AVG(CASE WHEN ${matches.result} != 'Remake' THEN ${matches.duoPartnerAssists} END)`.as("partner_avg_assists"),
+  };
+}
+
+/**
+ * Champion synergy counts that exclude remakes.
+ */
+export const championSynergySelect = {
+  games: sql<number>`SUM(CASE WHEN ${matches.result} != 'Remake' THEN 1 ELSE 0 END)`.as("games"),
+  wins: sql<number>`SUM(CASE WHEN ${matches.result} = 'Victory' THEN 1 ELSE 0 END)`.as("wins"),
+};
+
+/**
+ * Sidebar/layout review badge query: counts unreviewed games excluding remakes.
+ */
+export function sidebarReviewCountsSelect() {
+  return {
+    postGame: sql<number>`SUM(CASE WHEN ${matches.reviewed} = 0 AND ${matches.result} != 'Remake' AND ${matches.comment} IS NULL AND NOT EXISTS (
+      SELECT 1 FROM ${matchHighlights} WHERE ${matchHighlights.matchId} = ${matches.id}
+    ) THEN 1 ELSE 0 END)`.as("post_game"),
+    vod: sql<number>`SUM(CASE WHEN ${matches.reviewed} = 0 AND ${matches.result} != 'Remake' AND (
+      ${matches.comment} IS NOT NULL
+      OR EXISTS (SELECT 1 FROM ${matchHighlights} WHERE ${matchHighlights.matchId} = ${matches.id})
+    ) THEN 1 ELSE 0 END)`.as("vod"),
+  };
+}

--- a/src/lib/match-result.ts
+++ b/src/lib/match-result.ts
@@ -1,0 +1,82 @@
+// Centralized match result type, predicates, UI mappers, and stat helpers.
+// Single source of truth for all result-related logic across the codebase.
+
+// ─── Type ────────────────────────────────────────────────────────────────────
+
+/** Match result as stored in the database */
+export type MatchResult = "Victory" | "Defeat" | "Remake";
+
+// ─── Predicates ──────────────────────────────────────────────────────────────
+
+export function isWin(result: string): result is "Victory" {
+  return result === "Victory";
+}
+
+export function isLoss(result: string): result is "Defeat" {
+  return result === "Defeat";
+}
+
+export function isRemake(result: string): result is "Remake" {
+  return result === "Remake";
+}
+
+/** A "meaningful" game is one that isn't a remake — it counts for stats. */
+export function isMeaningful(result: string): result is "Victory" | "Defeat" {
+  return result === "Victory" || result === "Defeat";
+}
+
+// ─── Filtering ───────────────────────────────────────────────────────────────
+
+/** Filter an array of items to only those with meaningful (non-remake) results. */
+export function filterMeaningful<T extends { result: string }>(items: T[]): T[] {
+  return items.filter((item) => isMeaningful(item.result));
+}
+
+// ─── UI Mappers ──────────────────────────────────────────────────────────────
+
+/** Badge variant for match result badges (maps to Badge component variants). */
+export function resultBadgeVariant(
+  result: string
+): "default" | "secondary" | "destructive" {
+  if (isWin(result)) return "default";
+  if (isRemake(result)) return "secondary";
+  return "destructive";
+}
+
+/** Color bar class for the vertical result indicator strip. */
+export function resultBarColor(result: string): string {
+  if (isWin(result)) return "bg-win";
+  if (isRemake(result)) return "bg-muted-foreground/40";
+  return "bg-loss";
+}
+
+/** Border color class for match cards with left border. */
+export function resultBorderColor(result: string): string {
+  if (isWin(result)) return "border-l-win/60";
+  if (isRemake(result)) return "border-l-muted-foreground/40";
+  return "border-l-loss/60";
+}
+
+// ─── Stats ───────────────────────────────────────────────────────────────────
+
+/** Compute win rate as an integer percentage (0–100). Returns 0 if no games. */
+export function computeWinRate(wins: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.round((wins / total) * 100);
+}
+
+/** Compute the current streak from a list of matches (newest first). */
+export function computeStreak(
+  matches: Array<{ result: string }>
+): { type: "W" | "L"; count: number } | null {
+  const meaningful = matches.filter((m) => isMeaningful(m.result));
+  if (meaningful.length === 0) return null;
+
+  const first = meaningful[0].result;
+  let count = 0;
+  for (const m of meaningful) {
+    if (m.result === first) count++;
+    else break;
+  }
+  return { type: first === "Victory" ? "W" : "L", count };
+}


### PR DESCRIPTION
## Summary

Comprehensive refactor to centralize all match result (Victory/Defeat/Remake) logic into shared modules, fixing 12 bugs and removing duplicated code across ~20 files.

Fixes #28

## Changes

### New shared modules
- **`lib/match-result.ts`** — `MatchResult` type, predicates (`isWin`, `isLoss`, `isRemake`, `isMeaningful`), `filterMeaningful()`, UI mappers (`resultBadgeVariant`, `resultBarColor`, `resultBorderColor`), stats (`computeWinRate`, `computeStreak`)
- **`lib/match-queries.ts`** — Drizzle SQL fragments: `notRemake`, `matchStatCountsSelect`, `winLossRemakeSelect`, `avgPerformanceSelect`, `duoStatsSelect()`, `championSynergySelect`, `sidebarReviewCountsSelect()`
- **`components/result-badge.tsx`** — `<ResultBadge>` (format: short/long/raw) and `<ResultBar>` (size: sm/md/lg), both using the shared `Common` i18n namespace

### Bug fixes (12 total)
**HIGH severity (incorrect data) — 7 fixes:**
1. Sidebar review badge counted remakes as unreviewed
2. Duo stats `count()` included remakes; `losses = total - wins` counted remakes as losses
3. Duo solo comparison stats had the same count bug
4. Champion synergy `count(*)` included remakes
5. Scout average stats divided by `matchRows.length` including remakes, diluting averages
6. Scout baseline SQL included remakes in AVG calculations
7. Coaching interval stats counted remakes as losses

**MEDIUM severity (misaligned visuals) — 4 fixes:**
8. Analytics coaching bands used unfiltered indices but chart used filtered data
9. Coaching detail recent progress bar showed remakes as red
10. Schedule session page showed remakes as red bar with "Loss" label
11. Complete session page showed remakes as "Loss" badge

**Dashboard LP trend fix:**
12. LP trend now uses time-based baseline (snapshot closest to oldest of last 10 games) instead of offset-based snapshot comparison, giving consistent numbers that match analytics

### Cleanup
- Removed 83 lines of duplicated rank utilities from `analytics-client.tsx`
- Replaced 12+ inline result ternary expressions with shared `ResultBadge`/`ResultBar` components
- Removed 6 dead i18n keys from Coaching and Duo namespaces
- Analytics "Games analyzed" count now excludes remakes
- Seed script generates ~5% remakes with realistic short duration and minimal stats
- Export route uses shared `MatchResult` type
- `MatchResult` type exported from `db/schema.ts` for use across the codebase

## Files changed
- **3 new files**: `lib/match-result.ts`, `lib/match-queries.ts`, `components/result-badge.tsx`
- **20 modified files** across actions, pages, components, schema, i18n, and seed
- **Net: +437 −321 lines** (reduced total despite adding new modules)