### PR TITLE
fix: restore LP trend indicator and add date/time picker for coaching sessions

### DIFF
--- a/changelog/en/2026-03-27-lp-trend-coaching-datetime.mdx
+++ b/changelog/en/2026-03-27-lp-trend-coaching-datetime.mdx
@@ -1,0 +1,11 @@
+---
+version: "1.8.1"
+date: "2026-03-27"
+title: "LP trend fix & coaching date/time picker"
+---
+
+### Bug fixes
+
+- **LP trend indicator restored on dashboard**: The "recently gained/lost LP" indicator was missing from the rank card after a recent refactor. The root cause was a type mismatch in a database query — a Date object was being compared against a Unix timestamp column via raw SQL. Replaced with Drizzle's type-safe `lte()` operator.
+
+- **Coaching session scheduling now includes time**: Previously only a date picker was shown, causing sessions to default to midnight UTC (which displayed as 1 AM in CET). The form now uses a full date & time picker (`datetime-local`), and coaching views display the scheduled time where relevant.

--- a/changelog/es/2026-03-27-lp-trend-coaching-datetime.mdx
+++ b/changelog/es/2026-03-27-lp-trend-coaching-datetime.mdx
@@ -1,0 +1,11 @@
+---
+version: "1.8.1"
+date: "2026-03-27"
+title: "Corrección de tendencia de LP y selector de fecha/hora en coaching"
+---
+
+### Correcciones
+
+- **Indicador de tendencia de LP restaurado en el dashboard**: El indicador de "LP ganados/perdidos recientemente" no aparecía en la tarjeta de rango tras una refactorización reciente. La causa era una incompatibilidad de tipos en una consulta a base de datos — se comparaba un objeto Date contra una columna de timestamp Unix mediante SQL directo. Se reemplazó con el operador `lte()` de Drizzle, que es seguro en tipos.
+
+- **La programación de sesiones de coaching ahora incluye hora**: Antes solo se mostraba un selector de fecha, lo que hacía que las sesiones se almacenasen a medianoche UTC (mostrándose como la 1 AM en CET). El formulario ahora usa un selector completo de fecha y hora (`datetime-local`), y las vistas de coaching muestran la hora programada donde es relevante.

--- a/messages/en.json
+++ b/messages/en.json
@@ -406,6 +406,7 @@
     "coachNameLabel": "Coach Name",
     "coachNamePlaceholder": "e.g. midlaneacademy",
     "dateLabel": "Date",
+    "dateTimeLabel": "Date & Time",
     "vodToReview": "VOD to Review",
     "vodToReviewDescription": "Optionally select the game you want to review — you can add this later.",
     "noMatchesFound": "No matches found. Import your games first.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -406,6 +406,7 @@
     "coachNameLabel": "Nombre del coach",
     "coachNamePlaceholder": "ej. midlaneacademy",
     "dateLabel": "Fecha",
+    "dateTimeLabel": "Fecha y hora",
     "vodToReview": "VOD a revisar",
     "vodToReviewDescription": "Opcionalmente selecciona la partida que quieres revisar — puedes añadirla después.",
     "noMatchesFound": "No se encontraron partidas. Importa tus partidas primero.",

--- a/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
+++ b/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
@@ -189,13 +189,13 @@ export function CoachingDetailClient({
     ? JSON.parse(session.topics)
     : [];
 
-  const dateStr = formatDate(session.date, locale, "long");
+  const isScheduled = session.status === "scheduled";
+
+  const dateStr = formatDate(session.date, locale, isScheduled ? "datetime" : "long");
 
   const completedCount = actionItems.filter(
     (i) => i.status === "completed"
   ).length;
-
-  const isScheduled = session.status === "scheduled";
 
   // Collect action item topics for highlighting in progress matches
   const actionItemTopics = useMemo(

--- a/src/app/(app)/coaching/[id]/complete/complete-session-client.tsx
+++ b/src/app/(app)/coaching/[id]/complete/complete-session-client.tsx
@@ -92,7 +92,7 @@ export function CompleteSessionClient({
   const [newActionDesc, setNewActionDesc] = useState("");
   const [newActionTopic, setNewActionTopic] = useState("");
 
-  const dateStr = formatDate(session.date, locale, "long");
+  const dateStr = formatDate(session.date, locale, "datetime");
 
   const highlights: HighlightItem[] = vodHighlights.map((h) => ({
     type: h.type,

--- a/src/app/(app)/coaching/coaching-hub-client.tsx
+++ b/src/app/(app)/coaching/coaching-hub-client.tsx
@@ -177,7 +177,7 @@ export function CoachingHubClient({
           </div>
           <div className="space-y-3">
             {scheduledSessions.map((session) => {
-              const dateStr = formatDate(session.date, locale, "medium");
+              const dateStr = formatDate(session.date, locale, "datetime-short");
               const vodMatch = session.vodMatchId
                 ? vodMatchMap[session.vodMatchId]
                 : null;

--- a/src/app/(app)/coaching/new/schedule-session-client.tsx
+++ b/src/app/(app)/coaching/new/schedule-session-client.tsx
@@ -62,7 +62,13 @@ export function ScheduleSessionClient({
   const [isPending, startTransition] = useTransition();
 
   const [coachName, setCoachName] = useState("");
-  const [date, setDate] = useState(new Date().toISOString().split("T")[0]);
+  // Default to the next full hour in local time (format required by datetime-local: "YYYY-MM-DDTHH:MM")
+  const [date, setDate] = useState(() => {
+    const now = new Date();
+    now.setHours(now.getHours() + 1, 0, 0, 0);
+    const pad = (n: number) => n.toString().padStart(2, "0");
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`;
+  });
   const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null);
   const [focusAreas, setFocusAreas] = useState<string[]>([]);
   const [customTopic, setCustomTopic] = useState("");
@@ -191,10 +197,10 @@ export function ScheduleSessionClient({
               )}
             </div>
             <div className="space-y-2">
-              <Label htmlFor="date">{t("dateLabel")}</Label>
+              <Label htmlFor="date">{t("dateTimeLabel")}</Label>
               <Input
                 id="date"
-                type="date"
+                type="datetime-local"
                 value={date}
                 onChange={(e) => setDate(e.target.value)}
               />

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -7,7 +7,7 @@ import {
   coachingSessions,
   goals,
 } from "@/db/schema";
-import { eq, desc, and, count, sql, asc } from "drizzle-orm";
+import { eq, desc, and, count, sql, asc, lte } from "drizzle-orm";
 import { requireUser } from "@/lib/session";
 import { getLatestVersion } from "@/lib/riot-api";
 import { toCumulativeLP } from "@/lib/rank";
@@ -151,7 +151,7 @@ export default async function DashboardPage() {
     const baseline = await db.query.rankSnapshots.findFirst({
       where: and(
         eq(rankSnapshots.userId, user.id),
-        sql`${rankSnapshots.capturedAt} <= ${oldestGameDate}`
+        lte(rankSnapshots.capturedAt, oldestGameDate)
       ),
       orderBy: desc(rankSnapshots.capturedAt),
     }) ?? await db.query.rankSnapshots.findFirst({


### PR DESCRIPTION
## Summary
- **Fix LP trend indicator** (#34): The dashboard rank card's "recently gained/lost LP" indicator was always null after the centralization refactor. Root cause: a raw `sql` template literal compared a JS `Date` (serialized as ISO string) against an integer column (Unix seconds), causing SQLite type affinity to match all rows. Replaced with Drizzle's type-safe `lte()` operator.
- **Add date/time picker for coaching sessions** (#29): Scheduling form used `<input type="date">` which stored midnight UTC, displaying as 1 AM in CET. Switched to `datetime-local` so users can pick a specific time. Updated coaching hub, detail, and complete views to display the time.

Fixes #34
Fixes #29

## Changelog
- Version 1.8.1: Restore LP trend indicator on dashboard rank card; add date & time picker for coaching session scheduling