### PR TITLE
feat: coaching cadence widget and session editing

### DIFF
--- a/.opencode/skills/pr-workflow/SKILL.md
+++ b/.opencode/skills/pr-workflow/SKILL.md
@@ -41,12 +41,13 @@ Branch naming conventions:
 ### 2. Implement the changes
 
 - Make commits on the feature branch
-- Run checks locally before pushing:
+- **MANDATORY: Run lint locally before every push.** Do NOT rely on CI as the first lint check — catch errors locally:
   ```bash
-  npm run typecheck
   npm run lint
   npm run build
   ```
+  Fix any errors before committing/pushing. Warnings from pre-existing code are acceptable, but new warnings from your changes should be fixed.
+- `npm run build` implicitly runs `tsc`, so a separate `npm run typecheck` is not required.
 
 ### 3. Write a changelog entry
 
@@ -126,7 +127,7 @@ Vercel auto-deploys on merge to main — no manual deploy step needed.
 git checkout main && git pull
 git checkout -b fix/description
 # make changes
-npm run typecheck && npm run lint
+npm run lint && npm run build
 git add -A && git commit -m "fix: description"
 # add changelog entry
 git add -A && git commit -m "docs: add changelog entry"
@@ -139,6 +140,7 @@ gh pr create --title "fix: description" --body "..."
 git checkout main && git pull
 git checkout -b feat/description
 # implement in logical commits
+npm run lint && npm run build
 # add changelog at the end
 git push -u origin feat/description
 gh pr create --title "feat: description" --body "..."
@@ -149,6 +151,7 @@ gh pr create --title "feat: description" --body "..."
 git checkout main && git pull
 git checkout -b chore/description
 # make changes
+npm run lint && npm run build
 git push -u origin chore/description
 gh pr create --title "chore: description" --body "..." --label skip-changelog
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ Before making ANY code change:
 
 Every PR must include a changelog entry (`changelog/en/*.mdx` + `changelog/es/*.mdx`) unless it's infrastructure-only — in that case add the `skip-changelog` label.
 
+**MANDATORY: Run `npm run lint` and `npm run build` locally BEFORE pushing.** Do not rely on CI as the first lint/build check — catch errors locally first.
+
 Full workflow details are in the `pr-workflow` OpenCode skill.
 <!-- END:pr-workflow-rules -->
 

--- a/changelog/en/2026-03-27-coaching-cadence-edit-session.mdx
+++ b/changelog/en/2026-03-27-coaching-cadence-edit-session.mdx
@@ -1,0 +1,11 @@
+---
+version: "1.9.0"
+date: "2026-03-27"
+title: "Coaching cadence widget & session editing"
+---
+
+### New features
+
+- **Coaching cadence widget on dashboard**: A new card shows how many days since your last completed coaching session, with a color-coded status indicator — green for "On track" (< 14 days), yellow for "Due soon" (14–21 days), and red for "Overdue" (> 21 days). Links directly to the session detail.
+
+- **Edit coaching sessions**: You can now edit any coaching session (scheduled or completed) from the detail page. Edit the coach name, date/time, VOD match, and topics. For completed sessions, you can also update duration and notes. Click the pencil icon in the session header to open the edit form.

--- a/changelog/es/2026-03-27-coaching-cadence-edit-session.mdx
+++ b/changelog/es/2026-03-27-coaching-cadence-edit-session.mdx
@@ -1,0 +1,11 @@
+---
+version: "1.9.0"
+date: "2026-03-27"
+title: "Widget de cadencia de coaching y edición de sesiones"
+---
+
+### Nuevas funcionalidades
+
+- **Widget de cadencia de coaching en el panel**: Una nueva tarjeta muestra cuántos días han pasado desde tu última sesión de coaching completada, con un indicador de estado por colores — verde para "Al día" (< 14 días), amarillo para "Próximamente" (14–21 días), y rojo para "Atrasado" (> 21 días). Enlaza directamente al detalle de la sesión.
+
+- **Editar sesiones de coaching**: Ahora puedes editar cualquier sesión de coaching (programada o completada) desde la página de detalle. Edita el nombre del coach, fecha/hora, partida VOD y temas. Para sesiones completadas, también puedes actualizar la duración y las notas. Haz clic en el icono de lápiz en la cabecera de la sesión para abrir el formulario de edición.

--- a/messages/en.json
+++ b/messages/en.json
@@ -91,7 +91,16 @@
     "noActiveActionItems": "No active action items.",
     "goalWidget": "Goal",
     "noActiveGoal": "No active goal set.",
-    "setGoal": "Set a goal"
+    "setGoal": "Set a goal",
+    "lastCoaching": "Last Coaching",
+    "today": "Today",
+    "daysAgo": "{days, plural, one {# day} other {# days}} ago",
+    "cadence": {
+      "good": "On track",
+      "warning": "Due soon",
+      "overdue": "Overdue"
+    },
+    "noCompletedSessions": "No completed sessions yet."
   },
   "Matches": {
     "heading": "Matches",
@@ -375,6 +384,39 @@
       "topicRequired": "Please select at least one topic covered.",
       "sessionCompleted": "Coaching session completed!",
       "completeError": "Failed to complete session."
+    }
+  },
+  "EditSession": {
+    "title": "Edit Coaching Session",
+    "subtitle": "Update session details.",
+    "sessionDetails": "Session Details",
+    "coachNameLabel": "Coach Name",
+    "coachNamePlaceholder": "e.g. Coach Kim",
+    "dateTimeLabel": "Date & Time",
+    "vodToReview": "VOD / Match to Review",
+    "vodToReviewDescription": "Select a game to review during the session.",
+    "noMatchesFound": "No recent matches found.",
+    "vs": "vs",
+    "notesBadge": "{count, plural, one {# note} other {# notes}}",
+    "matchPreviewLabel": "{championName} vs {matchupChampionName} — {result}",
+    "noHighlights": "No highlights or lowlights recorded for this match.",
+    "focusAreas": "Focus Areas",
+    "focusAreasDescription": "Topics you want to focus on during the session.",
+    "topicsCovered": "Topics Covered",
+    "topicsCoveredDescription": "Topics that were covered during the session.",
+    "customTopicPlaceholder": "Custom topic...",
+    "addButton": "Add",
+    "sessionNotesTitle": "Session Details",
+    "durationLabel": "Duration (minutes)",
+    "durationPlaceholder": "60",
+    "sessionNotesLabel": "Session Notes",
+    "sessionNotesPlaceholder": "Key takeaways, what the coach said, areas to focus on...",
+    "cancelButton": "Cancel",
+    "saveChangesButton": "Save Changes",
+    "toasts": {
+      "coachNameRequired": "Please enter a coach name.",
+      "sessionUpdated": "Session updated successfully!",
+      "updateError": "Failed to update session."
     }
   },
   "ActionItems": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -91,7 +91,16 @@
     "noActiveActionItems": "No hay tareas activas.",
     "goalWidget": "Objetivo",
     "noActiveGoal": "Sin objetivo activo.",
-    "setGoal": "Establecer objetivo"
+    "setGoal": "Establecer objetivo",
+    "lastCoaching": "Último coaching",
+    "today": "Hoy",
+    "daysAgo": "Hace {days, plural, one {# día} other {# días}}",
+    "cadence": {
+      "good": "Al día",
+      "warning": "Próximamente",
+      "overdue": "Atrasado"
+    },
+    "noCompletedSessions": "Sin sesiones completadas aún."
   },
   "Matches": {
     "heading": "Partidas",
@@ -375,6 +384,39 @@
       "topicRequired": "Selecciona al menos un tema tratado.",
       "sessionCompleted": "¡Sesión de coaching completada!",
       "completeError": "Error al completar la sesión."
+    }
+  },
+  "EditSession": {
+    "title": "Editar sesión de coaching",
+    "subtitle": "Actualiza los detalles de la sesión.",
+    "sessionDetails": "Detalles de la sesión",
+    "coachNameLabel": "Nombre del coach",
+    "coachNamePlaceholder": "ej. Coach Kim",
+    "dateTimeLabel": "Fecha y hora",
+    "vodToReview": "VOD / Partida a revisar",
+    "vodToReviewDescription": "Selecciona una partida para revisar durante la sesión.",
+    "noMatchesFound": "No se encontraron partidas recientes.",
+    "vs": "vs",
+    "notesBadge": "{count, plural, one {# nota} other {# notas}}",
+    "matchPreviewLabel": "{championName} vs {matchupChampionName} — {result}",
+    "noHighlights": "Sin highlights ni lowlights registrados para esta partida.",
+    "focusAreas": "Áreas de enfoque",
+    "focusAreasDescription": "Temas en los que quieres enfocarte durante la sesión.",
+    "topicsCovered": "Temas tratados",
+    "topicsCoveredDescription": "Temas que se trataron durante la sesión.",
+    "customTopicPlaceholder": "Tema personalizado...",
+    "addButton": "Añadir",
+    "sessionNotesTitle": "Detalles de la sesión",
+    "durationLabel": "Duración (minutos)",
+    "durationPlaceholder": "60",
+    "sessionNotesLabel": "Notas de sesión",
+    "sessionNotesPlaceholder": "Puntos clave, lo que dijo el coach, áreas en las que enfocarse...",
+    "cancelButton": "Cancelar",
+    "saveChangesButton": "Guardar cambios",
+    "toasts": {
+      "coachNameRequired": "Introduce el nombre del coach.",
+      "sessionUpdated": "¡Sesión actualizada correctamente!",
+      "updateError": "Error al actualizar la sesión."
     }
   },
   "ActionItems": {

--- a/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
+++ b/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
@@ -42,6 +42,7 @@ import {
   CalendarCheck,
   TrendingUp,
   Swords,
+  Pencil,
 } from "lucide-react";
 import type { CoachingSession, CoachingActionItem } from "@/db/schema";
 
@@ -288,6 +289,11 @@ export function CoachingDetailClient({
             )}
           </p>
         </div>
+        <Link href={`/coaching/${session.id}/edit`}>
+          <Button variant="ghost" size="icon">
+            <Pencil className="h-4 w-4" />
+          </Button>
+        </Link>
         <Button
           variant="ghost"
           size="icon"

--- a/src/app/(app)/coaching/[id]/edit/edit-session-client.tsx
+++ b/src/app/(app)/coaching/[id]/edit/edit-session-client.tsx
@@ -1,0 +1,479 @@
+"use client";
+
+import { useState, useTransition, useMemo } from "react";
+import { useSession } from "next-auth/react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { updateCoachingSession } from "@/app/actions/coaching";
+import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { ResultBar } from "@/components/result-badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { toast } from "sonner";
+import { getChampionIconUrl } from "@/lib/riot-api";
+import { PREDEFINED_TOPICS } from "@/lib/topics";
+import { HighlightsDisplay, type HighlightItem } from "@/components/highlights-editor";
+import {
+  Loader2,
+  ArrowLeft,
+  Video,
+  Check,
+  Calendar,
+  Clock,
+  X,
+} from "lucide-react";
+import Link from "next/link";
+import Image from "next/image";
+import type { CoachingSession } from "@/db/schema";
+
+interface MatchSummary {
+  id: string;
+  gameDate: Date;
+  championName: string;
+  result: string;
+  matchupChampionName: string | null;
+  kills: number;
+  deaths: number;
+  assists: number;
+  vodUrl: string | null;
+}
+
+interface EditSessionClientProps {
+  session: CoachingSession;
+  recentMatches: MatchSummary[];
+  ddragonVersion: string;
+  highlightsByMatch: Record<
+    string,
+    Array<{ type: "highlight" | "lowlight"; text: string; topic: string | null }>
+  >;
+  previousCoaches: string[];
+}
+
+/** Convert a Date to the YYYY-MM-DDTHH:MM format for datetime-local input */
+function toDatetimeLocalValue(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function EditSessionClient({
+  session,
+  recentMatches,
+  ddragonVersion,
+  highlightsByMatch,
+  previousCoaches,
+}: EditSessionClientProps) {
+  const router = useRouter();
+  const { data: authSession } = useSession();
+  const locale = authSession?.user?.locale ?? DEFAULT_LOCALE;
+  const t = useTranslations("EditSession");
+  const tCommon = useTranslations("Common");
+  const [isPending, startTransition] = useTransition();
+
+  const isCompleted = session.status === "completed";
+
+  // Pre-fill form state from existing session
+  const [coachName, setCoachName] = useState(session.coachName);
+  const [date, setDate] = useState(() => toDatetimeLocalValue(session.date));
+  const [selectedMatchId, setSelectedMatchId] = useState<string | null>(
+    session.vodMatchId ?? null
+  );
+
+  const initialTopics: string[] = session.topics
+    ? JSON.parse(session.topics)
+    : [];
+  const [topics, setTopics] = useState<string[]>(initialTopics);
+  const [customTopic, setCustomTopic] = useState("");
+  const [showCoachSuggestions, setShowCoachSuggestions] = useState(false);
+
+  // Completed-only fields
+  const [duration, setDuration] = useState(
+    session.durationMinutes?.toString() ?? ""
+  );
+  const [notes, setNotes] = useState(session.notes ?? "");
+
+  const filteredCoaches = useMemo(() => {
+    if (!coachName.trim()) return previousCoaches;
+    return previousCoaches.filter((c) =>
+      c.toLowerCase().includes(coachName.toLowerCase())
+    );
+  }, [coachName, previousCoaches]);
+
+  function selectMatch(id: string) {
+    setSelectedMatchId((prev) => (prev === id ? null : id));
+  }
+
+  function toggleTopic(topic: string) {
+    setTopics((prev) =>
+      prev.includes(topic) ? prev.filter((t) => t !== topic) : [...prev, topic]
+    );
+  }
+
+  function addCustomTopic() {
+    if (customTopic && !topics.includes(customTopic)) {
+      setTopics((prev) => [...prev, customTopic]);
+      setCustomTopic("");
+    }
+  }
+
+  // Selected match details for preview
+  const selectedMatch = selectedMatchId
+    ? recentMatches.find((m) => m.id === selectedMatchId)
+    : null;
+  const selectedMatchHighlights: HighlightItem[] = selectedMatchId
+    ? (highlightsByMatch[selectedMatchId] || []).map((h) => ({
+        type: h.type,
+        text: h.text,
+        topic: h.topic || undefined,
+      }))
+    : [];
+
+  function handleSubmit() {
+    if (!coachName.trim()) {
+      toast.error(t("toasts.coachNameRequired"));
+      return;
+    }
+
+    startTransition(async () => {
+      try {
+        const result = await updateCoachingSession(session.id, {
+          coachName: coachName.trim(),
+          date: new Date(date).toISOString(),
+          vodMatchId: selectedMatchId,
+          topics: topics.length > 0 ? topics : undefined,
+          ...(isCompleted && {
+            durationMinutes: duration ? parseInt(duration) : null,
+            notes: notes || null,
+          }),
+        });
+
+        if (result && "error" in result) {
+          toast.error(result.error);
+          return;
+        }
+
+        toast.success(t("toasts.sessionUpdated"));
+        router.push(`/coaching/${session.id}`);
+      } catch {
+        toast.error(t("toasts.updateError"));
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Link href={`/coaching/${session.id}`}>
+          <Button variant="ghost" size="icon">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-gradient-gold">
+            {t("title")}
+          </h1>
+          <p className="text-muted-foreground">
+            {t("subtitle")}
+          </p>
+        </div>
+      </div>
+
+      {/* Session Details */}
+      <Card className="surface-glow">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Calendar className="h-4 w-4 text-gold" />
+            {t("sessionDetails")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2 relative">
+              <Label htmlFor="coach">{t("coachNameLabel")}</Label>
+              <Input
+                id="coach"
+                placeholder={t("coachNamePlaceholder")}
+                value={coachName}
+                onChange={(e) => setCoachName(e.target.value)}
+                onFocus={() => setShowCoachSuggestions(true)}
+                onBlur={() => {
+                  setTimeout(() => setShowCoachSuggestions(false), 150);
+                }}
+                autoComplete="off"
+              />
+              {showCoachSuggestions && filteredCoaches.length > 0 && (
+                <div className="absolute z-10 top-full mt-1 w-full rounded-md border border-border bg-popover shadow-md">
+                  {filteredCoaches.map((name) => (
+                    <button
+                      key={name}
+                      type="button"
+                      className="w-full text-left px-3 py-2 text-sm hover:bg-accent transition-colors"
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        setCoachName(name);
+                        setShowCoachSuggestions(false);
+                      }}
+                    >
+                      {name}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="date">{t("dateTimeLabel")}</Label>
+              <Input
+                id="date"
+                type="datetime-local"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* VOD / Match to Review */}
+      <Card className="surface-glow">
+        <CardHeader>
+          <CardTitle>{t("vodToReview")}</CardTitle>
+          <CardDescription>
+            {t("vodToReviewDescription")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {recentMatches.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {t("noMatchesFound")}
+            </p>
+          ) : (
+            <div className="space-y-1 max-h-60 overflow-y-auto">
+              {recentMatches.map((match) => {
+                const isSelected = selectedMatchId === match.id;
+                const dateStr = formatDate(match.gameDate, locale, "short-compact");
+                const matchHL = highlightsByMatch[match.id];
+                const hasHighlights = matchHL && matchHL.length > 0;
+                return (
+                  <button
+                    key={match.id}
+                    type="button"
+                    className={`flex items-center gap-2 sm:gap-3 flex-wrap sm:flex-nowrap rounded-lg p-2 w-full text-left transition-colors ${
+                      isSelected
+                        ? "bg-gold/10 border border-gold/30"
+                        : "hover:bg-accent border border-transparent"
+                    }`}
+                    onClick={() => selectMatch(match.id)}
+                  >
+                    <div
+                      className={`w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0 ${
+                        isSelected
+                          ? "border-gold bg-gold text-black"
+                          : "border-muted-foreground/30"
+                      }`}
+                    >
+                      {isSelected && <Check className="h-3 w-3" />}
+                    </div>
+                    <ResultBar result={match.result} size="sm" />
+                    <span className="text-sm font-medium inline-flex items-center gap-1.5">
+                      <Image
+                        src={getChampionIconUrl(ddragonVersion, match.championName)}
+                        alt={match.championName}
+                        width={20}
+                        height={20}
+                        className="rounded"
+                      />
+                      {match.championName}
+                    </span>
+                    <span className="text-xs text-muted-foreground inline-flex items-center gap-1">
+                      {t("vs")}
+                      {match.matchupChampionName ? (
+                        <>
+                          <Image
+                            src={getChampionIconUrl(ddragonVersion, match.matchupChampionName)}
+                            alt={match.matchupChampionName}
+                            width={16}
+                            height={16}
+                            className="rounded"
+                          />
+                          {match.matchupChampionName}
+                        </>
+                      ) : (
+                        "?"
+                      )}
+                    </span>
+                    <div className="flex items-center gap-1.5 ml-auto shrink-0">
+                      {hasHighlights && (
+                        <Badge
+                          variant="secondary"
+                          className="text-[10px] px-1.5 py-0"
+                        >
+                          {t("notesBadge", { count: matchHL.length })}
+                        </Badge>
+                      )}
+                      {match.vodUrl && (
+                        <Video className="h-3.5 w-3.5 text-electric/70" />
+                      )}
+                    </div>
+                    <span className="text-xs font-mono text-muted-foreground shrink-0">
+                      {match.kills}/{match.deaths}/{match.assists}
+                    </span>
+                    <span className="text-xs text-muted-foreground shrink-0">
+                      {dateStr}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Preview of selected match highlights + VOD */}
+          {selectedMatch && (
+            <div className="rounded-lg border border-border/50 bg-surface-elevated p-3 space-y-3">
+              <p className="text-xs font-medium text-muted-foreground">
+                {t("matchPreviewLabel", {
+                  championName: selectedMatch.championName,
+                  matchupChampionName: selectedMatch.matchupChampionName || "?",
+                  result: selectedMatch.result === "Victory" ? tCommon("resultW") : selectedMatch.result === "Remake" ? tCommon("resultR") : tCommon("resultL"),
+                })}
+              </p>
+
+              {selectedMatch.vodUrl && (
+                <div className="flex items-center gap-2">
+                  <Video className="h-3.5 w-3.5 text-electric" />
+                  <a
+                    href={selectedMatch.vodUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-electric hover:underline truncate"
+                  >
+                    {selectedMatch.vodUrl}
+                  </a>
+                </div>
+              )}
+
+              {selectedMatchHighlights.length > 0 ? (
+                <HighlightsDisplay highlights={selectedMatchHighlights} />
+              ) : (
+                <p className="text-xs text-muted-foreground italic">
+                  {t("noHighlights")}
+                </p>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Topics */}
+      <Card className="surface-glow">
+        <CardHeader>
+          <CardTitle>{isCompleted ? t("topicsCovered") : t("focusAreas")}</CardTitle>
+          <CardDescription>
+            {isCompleted ? t("topicsCoveredDescription") : t("focusAreasDescription")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex flex-wrap gap-2">
+            {PREDEFINED_TOPICS.map((topic) => (
+              <Badge
+                key={topic}
+                variant={topics.includes(topic) ? "default" : "secondary"}
+                className="cursor-pointer"
+                onClick={() => toggleTopic(topic)}
+              >
+                {topic}
+              </Badge>
+            ))}
+            {topics
+              .filter(
+                (t) => !(PREDEFINED_TOPICS as readonly string[]).includes(t)
+              )
+              .map((topic) => (
+                <Badge
+                  key={topic}
+                  variant="default"
+                  className="cursor-pointer"
+                  onClick={() => toggleTopic(topic)}
+                >
+                  {topic}
+                  <X className="ml-1 h-3 w-3" />
+                </Badge>
+              ))}
+          </div>
+          <div className="flex gap-2">
+            <Input
+              placeholder={t("customTopicPlaceholder")}
+              value={customTopic}
+              onChange={(e) => setCustomTopic(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addCustomTopic();
+                }
+              }}
+              className="max-w-xs"
+            />
+            <Button variant="outline" size="sm" onClick={addCustomTopic}>
+              {t("addButton")}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Duration & Notes — only for completed sessions */}
+      {isCompleted && (
+        <Card className="surface-glow">
+          <CardHeader>
+            <CardTitle>{t("sessionNotesTitle")}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="duration" className="flex items-center gap-1.5">
+                <Clock className="h-3.5 w-3.5" />
+                {t("durationLabel")}
+              </Label>
+              <Input
+                id="duration"
+                type="number"
+                placeholder={t("durationPlaceholder")}
+                value={duration}
+                onChange={(e) => setDuration(e.target.value)}
+                className="max-w-32"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="notes">{t("sessionNotesLabel")}</Label>
+              <Textarea
+                id="notes"
+                placeholder={t("sessionNotesPlaceholder")}
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                rows={5}
+              />
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Submit */}
+      <div className="flex justify-end gap-3">
+        <Link href={`/coaching/${session.id}`}>
+          <Button variant="outline">{t("cancelButton")}</Button>
+        </Link>
+        <Button onClick={handleSubmit} disabled={isPending}>
+          {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {t("saveChangesButton")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/coaching/[id]/edit/loading.tsx
+++ b/src/app/(app)/coaching/[id]/edit/loading.tsx
@@ -1,0 +1,77 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export default function EditSessionLoading() {
+  return (
+    <div className="space-y-6 max-w-3xl">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-9 w-9 rounded-md" />
+        <div className="space-y-2">
+          <Skeleton className="h-7 w-48" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+      </div>
+
+      {/* Session Details */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-32" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-9 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-9 w-full" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* VOD */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="h-4 w-64" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-1">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Topics */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="h-4 w-64" />
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-6 w-24 rounded-full" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Duration/Notes (for completed) */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-32" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Skeleton className="h-9 w-32" />
+          <Skeleton className="h-28 w-full" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(app)/coaching/[id]/edit/page.tsx
+++ b/src/app/(app)/coaching/[id]/edit/page.tsx
@@ -1,0 +1,98 @@
+import { db } from "@/db";
+import {
+  coachingSessions,
+  matches,
+  matchHighlights,
+} from "@/db/schema";
+import { eq, and, desc, inArray } from "drizzle-orm";
+import { requireUser } from "@/lib/session";
+import { notFound } from "next/navigation";
+import { getLatestVersion } from "@/lib/riot-api";
+import { EditSessionClient } from "./edit-session-client";
+
+export default async function EditCoachingSessionPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const user = await requireUser();
+  const sessionId = parseInt(id);
+
+  if (isNaN(sessionId)) notFound();
+
+  const session = await db.query.coachingSessions.findFirst({
+    where: and(
+      eq(coachingSessions.id, sessionId),
+      eq(coachingSessions.userId, user.id)
+    ),
+  });
+
+  if (!session) notFound();
+
+  const [recentMatches, ddragonVersion, previousCoaches] = await Promise.all([
+    db.query.matches.findMany({
+      where: eq(matches.userId, user.id),
+      orderBy: desc(matches.gameDate),
+      limit: 50,
+      columns: {
+        id: true,
+        gameDate: true,
+        championName: true,
+        result: true,
+        matchupChampionName: true,
+        kills: true,
+        deaths: true,
+        assists: true,
+        vodUrl: true,
+      },
+    }),
+    getLatestVersion(),
+    db
+      .selectDistinct({ coachName: coachingSessions.coachName })
+      .from(coachingSessions)
+      .where(eq(coachingSessions.userId, user.id)),
+  ]);
+
+  // Fetch highlights for match picker preview
+  const matchIds = recentMatches.map((m) => m.id);
+  const allHighlights =
+    matchIds.length > 0
+      ? await db.query.matchHighlights.findMany({
+          where: inArray(matchHighlights.matchId, matchIds),
+          columns: {
+            matchId: true,
+            type: true,
+            text: true,
+            topic: true,
+          },
+        })
+      : [];
+
+  const highlightsByMatch: Record<
+    string,
+    Array<{
+      type: "highlight" | "lowlight";
+      text: string;
+      topic: string | null;
+    }>
+  > = {};
+  for (const h of allHighlights) {
+    if (!highlightsByMatch[h.matchId]) highlightsByMatch[h.matchId] = [];
+    highlightsByMatch[h.matchId].push({
+      type: h.type as "highlight" | "lowlight",
+      text: h.text,
+      topic: h.topic,
+    });
+  }
+
+  return (
+    <EditSessionClient
+      session={session}
+      recentMatches={recentMatches}
+      ddragonVersion={ddragonVersion}
+      highlightsByMatch={highlightsByMatch}
+      previousCoaches={previousCoaches.map((c) => c.coachName)}
+    />
+  );
+}

--- a/src/app/(app)/dashboard/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/dashboard-client.tsx
@@ -24,6 +24,7 @@ import {
   AlertCircle,
   Calendar,
   Target,
+  GraduationCap,
 } from "lucide-react";
 import type { RankSnapshot, CoachingActionItem, Goal, MatchResult } from "@/db/schema";
 import { getKeystoneIconUrlByName, getChampionIconUrl } from "@/lib/riot-api";
@@ -73,6 +74,12 @@ interface UpcomingSession {
   vodMatchId: string | null;
 }
 
+interface LastCompletedSession {
+  id: number;
+  coachName: string;
+  date: Date;
+}
+
 interface DashboardClientProps {
   user: {
     name?: string | null;
@@ -87,6 +94,7 @@ interface DashboardClientProps {
   actionItems: CoachingActionItem[];
   upcomingSession: UpcomingSession | null;
   activeGoal: Goal | null;
+  lastCompletedSession: LastCompletedSession | null;
   currentRank: { tier: string; division: string | null; lp: number } | null;
   ddragonVersion: string;
 }
@@ -127,6 +135,7 @@ export function DashboardClient({
   actionItems,
   upcomingSession,
   activeGoal,
+  lastCompletedSession,
   currentRank,
   ddragonVersion,
 }: DashboardClientProps) {
@@ -448,6 +457,72 @@ export function DashboardClient({
               </CardHeader>
               <CardContent>
                 <p className="text-sm text-muted-foreground">{t("noCoachingSessions")}</p>
+                <Link href="/coaching/new" className="inline-block mt-2">
+                  <Button variant="outline" size="sm">{t("scheduleOne")}</Button>
+                </Link>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Last Coaching Session — cadence indicator */}
+          {lastCompletedSession ? (() => {
+            const daysSince = Math.floor(
+              (Date.now() - lastCompletedSession.date.getTime()) / (1000 * 60 * 60 * 24)
+            );
+            const cadence: "good" | "warning" | "overdue" =
+              daysSince < 14 ? "good" : daysSince <= 21 ? "warning" : "overdue";
+            const cadenceColors = {
+              good: "text-win",
+              warning: "text-warning",
+              overdue: "text-loss",
+            };
+            const borderColors = {
+              good: "border-win/20",
+              warning: "border-warning/20",
+              overdue: "border-loss/20",
+            };
+            const badgeClasses = {
+              good: "bg-win/20 text-win border-win/30",
+              warning: "bg-warning/20 text-warning border-warning/30",
+              overdue: "bg-loss/20 text-loss border-loss/30",
+            };
+            return (
+              <Card className={`surface-glow ${borderColors[cadence]}`}>
+                <CardHeader className="flex flex-row items-center justify-between pb-2">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <GraduationCap className={`h-4 w-4 ${cadenceColors[cadence]}`} />
+                    {t("lastCoaching")}
+                  </CardTitle>
+                  <Link href={`/coaching/${lastCompletedSession.id}`}>
+                    <Button variant="ghost" size="sm">
+                      {t("view")}
+                      <ChevronRight className="ml-1 h-3 w-3" />
+                    </Button>
+                  </Link>
+                </CardHeader>
+                <CardContent>
+                  <p className={`text-lg font-bold ${cadenceColors[cadence]}`}>
+                    {daysSince === 0 ? t("today") : t("daysAgo", { days: daysSince })}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {lastCompletedSession.coachName}
+                  </p>
+                  <Badge className={`mt-2 text-xs ${badgeClasses[cadence]}`}>
+                    {t(`cadence.${cadence}`)}
+                  </Badge>
+                </CardContent>
+              </Card>
+            );
+          })() : (
+            <Card className="surface-glow border-border/50">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <GraduationCap className="h-4 w-4 text-muted-foreground" />
+                  {t("lastCoaching")}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">{t("noCompletedSessions")}</p>
                 <Link href="/coaching/new" className="inline-block mt-2">
                   <Button variant="outline" size="sm">{t("scheduleOne")}</Button>
                 </Link>

--- a/src/app/(app)/dashboard/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/dashboard-client.tsx
@@ -476,8 +476,8 @@ export function DashboardClient({
             </Card>
           )}
 
-          {/* Last Coaching Session — cadence indicator */}
-          {lastCompletedSession && coachingCadence && daysSinceLastCoaching !== null ? (() => {
+          {/* Last Coaching Session — cadence indicator (hidden when there's an upcoming session) */}
+          {!upcomingSession && lastCompletedSession && coachingCadence && daysSinceLastCoaching !== null ? (() => {
             const cadenceColors = {
               good: "text-win",
               warning: "text-warning",
@@ -520,7 +520,7 @@ export function DashboardClient({
                 </CardContent>
               </Card>
             );
-          })() : (
+          })() : !upcomingSession ? (
             <Card className="surface-glow border-border/50">
               <CardHeader className="pb-2">
                 <CardTitle className="text-base flex items-center gap-2">
@@ -535,7 +535,7 @@ export function DashboardClient({
                 </Link>
               </CardContent>
             </Card>
-          )}
+          ) : null}
 
           {/* Goal Widget */}
           {activeGoal && currentRank ? (() => {

--- a/src/app/(app)/dashboard/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/dashboard-client.tsx
@@ -95,6 +95,7 @@ interface DashboardClientProps {
   upcomingSession: UpcomingSession | null;
   activeGoal: Goal | null;
   lastCompletedSession: LastCompletedSession | null;
+  daysSinceLastCoaching: number | null;
   currentRank: { tier: string; division: string | null; lp: number } | null;
   ddragonVersion: string;
 }
@@ -136,6 +137,7 @@ export function DashboardClient({
   upcomingSession,
   activeGoal,
   lastCompletedSession,
+  daysSinceLastCoaching,
   currentRank,
   ddragonVersion,
 }: DashboardClientProps) {
@@ -145,6 +147,16 @@ export function DashboardClient({
   const isLinked = !!user.puuid;
   const streak = getStreak(recentMatches);
   const rankInfo = getRankDisplay(latestRank);
+
+  // Coaching cadence
+  const coachingCadence: "good" | "warning" | "overdue" | null =
+    daysSinceLastCoaching !== null
+      ? daysSinceLastCoaching < 14
+        ? "good"
+        : daysSinceLastCoaching <= 21
+          ? "warning"
+          : "overdue"
+      : null;
 
   // Session stats (last 10 games, excluding remakes)
   const sessionGames = recentMatches.filter((m) => m.result !== "Remake");
@@ -465,12 +477,7 @@ export function DashboardClient({
           )}
 
           {/* Last Coaching Session — cadence indicator */}
-          {lastCompletedSession ? (() => {
-            const daysSince = Math.floor(
-              (Date.now() - lastCompletedSession.date.getTime()) / (1000 * 60 * 60 * 24)
-            );
-            const cadence: "good" | "warning" | "overdue" =
-              daysSince < 14 ? "good" : daysSince <= 21 ? "warning" : "overdue";
+          {lastCompletedSession && coachingCadence && daysSinceLastCoaching !== null ? (() => {
             const cadenceColors = {
               good: "text-win",
               warning: "text-warning",
@@ -487,10 +494,10 @@ export function DashboardClient({
               overdue: "bg-loss/20 text-loss border-loss/30",
             };
             return (
-              <Card className={`surface-glow ${borderColors[cadence]}`}>
+              <Card className={`surface-glow ${borderColors[coachingCadence]}`}>
                 <CardHeader className="flex flex-row items-center justify-between pb-2">
                   <CardTitle className="text-base flex items-center gap-2">
-                    <GraduationCap className={`h-4 w-4 ${cadenceColors[cadence]}`} />
+                    <GraduationCap className={`h-4 w-4 ${cadenceColors[coachingCadence]}`} />
                     {t("lastCoaching")}
                   </CardTitle>
                   <Link href={`/coaching/${lastCompletedSession.id}`}>
@@ -501,14 +508,14 @@ export function DashboardClient({
                   </Link>
                 </CardHeader>
                 <CardContent>
-                  <p className={`text-lg font-bold ${cadenceColors[cadence]}`}>
-                    {daysSince === 0 ? t("today") : t("daysAgo", { days: daysSince })}
+                  <p className={`text-lg font-bold ${cadenceColors[coachingCadence]}`}>
+                    {daysSinceLastCoaching === 0 ? t("today") : t("daysAgo", { days: daysSinceLastCoaching })}
                   </p>
                   <p className="text-sm text-muted-foreground">
                     {lastCompletedSession.coachName}
                   </p>
-                  <Badge className={`mt-2 text-xs ${badgeClasses[cadence]}`}>
-                    {t(`cadence.${cadence}`)}
+                  <Badge className={`mt-2 text-xs ${badgeClasses[coachingCadence]}`}>
+                    {t(`cadence.${coachingCadence}`)}
                   </Badge>
                 </CardContent>
               </Card>

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -26,6 +26,7 @@ export default async function DashboardPage() {
     matchStats,
     upcomingSession,
     activeGoal,
+    lastCompletedSession,
   ] = await Promise.all([
     getLatestVersion(),
 
@@ -127,6 +128,20 @@ export default async function DashboardPage() {
     db.query.goals.findFirst({
       where: and(eq(goals.userId, user.id), eq(goals.status, "active")),
     }),
+
+    // Last completed coaching session (for "days since" widget)
+    db.query.coachingSessions.findFirst({
+      where: and(
+        eq(coachingSessions.userId, user.id),
+        eq(coachingSessions.status, "completed")
+      ),
+      orderBy: desc(coachingSessions.date),
+      columns: {
+        id: true,
+        coachName: true,
+        date: true,
+      },
+    }),
   ]);
 
   const latestRankOrUndef = latestRank ?? null;
@@ -182,6 +197,7 @@ export default async function DashboardPage() {
       actionItems={[...inProgressActionItems, ...activeActionItems]}
       upcomingSession={upcomingSession ?? null}
       activeGoal={activeGoal ?? null}
+      lastCompletedSession={lastCompletedSession ?? null}
       currentRank={latestRankOrUndef?.tier ? {
         tier: latestRankOrUndef.tier,
         division: latestRankOrUndef.division,

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -198,6 +198,13 @@ export default async function DashboardPage() {
       upcomingSession={upcomingSession ?? null}
       activeGoal={activeGoal ?? null}
       lastCompletedSession={lastCompletedSession ?? null}
+      daysSinceLastCoaching={
+        lastCompletedSession
+          ? Math.floor(
+              (Date.now() - lastCompletedSession.date.getTime()) / (1000 * 60 * 60 * 24)
+            )
+          : null
+      }
       currentRank={latestRankOrUndef?.tier ? {
         tier: latestRankOrUndef.tier,
         division: latestRankOrUndef.division,

--- a/src/app/actions/coaching.ts
+++ b/src/app/actions/coaching.ts
@@ -120,7 +120,76 @@ export async function completeCoachingSession(
   return { success: true };
 }
 
-// ─── Update / Delete session ─────────────────────────────────────────────────
+// ─── Update / Edit session ───────────────────────────────────────────────────
+
+export async function updateCoachingSession(
+  sessionId: number,
+  data: {
+    coachName: string;
+    date: string; // ISO string
+    vodMatchId?: string | null;
+    topics?: string[];
+    // Only for completed sessions:
+    durationMinutes?: number | null;
+    notes?: string | null;
+  }
+) {
+  const user = await requireUser();
+
+  const session = await db.query.coachingSessions.findFirst({
+    where: and(
+      eq(coachingSessions.id, sessionId),
+      eq(coachingSessions.userId, user.id)
+    ),
+  });
+
+  if (!session) {
+    return { error: "Session not found." };
+  }
+
+  // Update session fields
+  await db
+    .update(coachingSessions)
+    .set({
+      coachName: data.coachName,
+      date: new Date(data.date),
+      vodMatchId: data.vodMatchId ?? null,
+      topics: data.topics?.length ? JSON.stringify(data.topics) : null,
+      ...(session.status === "completed" && {
+        durationMinutes: data.durationMinutes ?? null,
+        notes: data.notes ?? null,
+      }),
+      updatedAt: new Date(),
+    })
+    .where(eq(coachingSessions.id, sessionId));
+
+  // Update VOD match link: delete old link, insert new if provided
+  await db
+    .delete(coachingSessionMatches)
+    .where(
+      and(
+        eq(coachingSessionMatches.sessionId, sessionId),
+        eq(coachingSessionMatches.userId, user.id)
+      )
+    );
+
+  if (data.vodMatchId) {
+    await db.insert(coachingSessionMatches).values({
+      sessionId,
+      matchId: data.vodMatchId,
+      userId: user.id,
+    });
+  }
+
+  revalidatePath("/coaching");
+  revalidatePath(`/coaching/${sessionId}`);
+  revalidatePath("/dashboard");
+  invalidateCoachingCaches(user.id);
+
+  return { success: true };
+}
+
+// ─── Delete session ──────────────────────────────────────────────────────────
 
 export async function deleteCoachingSession(sessionId: number) {
   const user = await requireUser();


### PR DESCRIPTION
## Summary

- **Coaching cadence widget** (#31): Dashboard now shows a card with days since last completed coaching session, with color-coded status (green = on track < 14d, yellow = due soon 14–21d, red = overdue > 21d)
- **Edit coaching sessions** (#30): New edit page accessible via pencil icon on session detail. Supports editing coach name, date/time, VOD match, and topics for all sessions, plus duration and notes for completed sessions
- `updateCoachingSession` server action with proper VOD match link management (delete old, insert new)

Fixes #30
Fixes #31