### PR TITLE
feat: changelog improvements — CalVer, tags, filter, pagination

### DIFF
--- a/.opencode/skills/pr-workflow/SKILL.md
+++ b/.opencode/skills/pr-workflow/SKILL.md
@@ -61,20 +61,25 @@ changelog/es/YYYY-MM-DD-slug.mdx
 Frontmatter format:
 ```yaml
 ---
-version: "X.Y.Z"
+version: "YYYY.MM.N"
 date: "YYYY-MM-DD"
 title: "Human-readable title"
+tags: ["feature"]
 ---
 ```
 
 Body uses standard Markdown: **bold**, lists, `### headings`.
 
-Version bumping:
-- **Patch** (X.Y.Z+1): bug fixes, small polish
-- **Minor** (X.Y+1.0): new features, significant changes
-- **Major** (X+1.0.0): breaking changes (unlikely for this project)
+Version scheme — **CalVer** (`YYYY.MM.N`):
+- `YYYY` = calendar year (e.g. 2026)
+- `MM` = calendar month, zero-padded (e.g. 03)
+- `N` = sequential release number within that month, starting at 1
 
-To determine the next version, check the latest `version` in `changelog/en/` files.
+To determine the next version, check the latest `version` in `changelog/en/` files and increment `N`. If the month changed, reset `N` to 1.
+
+Available tags: `feature`, `fix`, `improvement`, `refactor`. Every entry must have at least one tag.
+
+Also update `package.json` `version` to match the latest CalVer version.
 
 If the PR is purely infrastructure (CI, skills, config) and has no user-facing changes, skip the changelog and add the `skip-changelog` label to the PR instead.
 
@@ -96,7 +101,7 @@ Fixes #N
 <!-- Use "Relates to #N" if the PR partially addresses but doesn't fully close an issue. -->
 
 ## Changelog
-- Version X.Y.Z: <what changed for users>
+- Version YYYY.MM.N: <what changed for users>
 ```
 
 **Issue linking is mandatory.** Before creating a PR, check `gh issue list` for related issues. If the PR resolves one or more issues, include `Fixes #N` (one per line) in the PR body. If it partially addresses an issue, use `Relates to #N` instead.

--- a/changelog/en/2025-03-15-rank-journey-and-coaching.mdx
+++ b/changelog/en/2025-03-15-rank-journey-and-coaching.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.2.0"
+version: "2025.03.1"
 date: "2025-03-15"
 title: "Rank Journey & Coaching Tools"
+tags: ["feature"]
 ---
 
 ### Rank Journey

--- a/changelog/en/2025-03-20-review-page-and-polish.mdx
+++ b/changelog/en/2025-03-20-review-page-and-polish.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.3.0"
+version: "2025.03.2"
 date: "2025-03-20"
 title: "Review Page & Visual Polish"
+tags: ["feature"]
 ---
 
 A brand new **Review page** brings all your post-game analysis into one place:

--- a/changelog/en/2025-03-25-auto-sync-and-i18n.mdx
+++ b/changelog/en/2025-03-25-auto-sync-and-i18n.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.4.0"
+version: "2025.03.3"
 date: "2025-03-25"
 title: "Auto-sync & Multi-language Support"
+tags: ["feature"]
 ---
 
 Your matches now **sync automatically** — no more clicking the sync button every time you play.

--- a/changelog/en/2026-03-25-light-mode.mdx
+++ b/changelog/en/2026-03-25-light-mode.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.5.0"
+version: "2026.03.1"
 date: "2026-03-25"
 title: "Light Mode & Theme Toggle"
+tags: ["feature"]
 ---
 
 The app now supports **light mode** alongside the original dark theme.

--- a/changelog/en/2026-03-26-centralize-match-result.mdx
+++ b/changelog/en/2026-03-26-centralize-match-result.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.8.0"
+version: "2026.03.6"
 date: "2026-03-26"
 title: "Centralized Match Result Handling"
+tags: ["refactor"]
 ---
 
 Major refactor to centralize all match result logic (Victory/Defeat/Remake) into shared helpers, fixing 12 bugs and removing duplicated code across the codebase.

--- a/changelog/en/2026-03-26-csv-export.mdx
+++ b/changelog/en/2026-03-26-csv-export.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.6.0"
+version: "2026.03.2"
 date: "2026-03-26"
 title: "CSV Export for Match History"
+tags: ["feature"]
 ---
 
 You can now **export your match history as a CSV file** directly from the Matches page.

--- a/changelog/en/2026-03-26-goal-tracking.mdx
+++ b/changelog/en/2026-03-26-goal-tracking.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.7.0"
+version: "2026.03.3"
 date: "2026-03-26"
 title: "Goal Setting with Progress Tracking"
+tags: ["feature"]
 ---
 
 Set rank-based goals and track your progress over time.

--- a/changelog/en/2026-03-26-remake-detection.mdx
+++ b/changelog/en/2026-03-26-remake-detection.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.7.1"
+version: "2026.03.4"
 date: "2026-03-26"
 title: "Remake Detection"
+tags: ["fix"]
 ---
 
 Games that ended as **remakes** (early surrenders before 5 minutes) are now correctly identified and excluded from your stats.

--- a/changelog/en/2026-03-26-remake-review-dashboard.mdx
+++ b/changelog/en/2026-03-26-remake-review-dashboard.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.7.2"
+version: "2026.03.5"
 date: "2026-03-26"
 title: "Remake Cleanup: Review & Dashboard"
+tags: ["fix"]
 ---
 
 Follow-up fixes to the remake detection feature.

--- a/changelog/en/2026-03-27-changelog-improvements.mdx
+++ b/changelog/en/2026-03-27-changelog-improvements.mdx
@@ -1,0 +1,14 @@
+---
+version: "2026.03.9"
+date: "2026-03-27"
+title: "Changelog Improvements"
+tags: ["improvement"]
+---
+
+The changelog page gets a major upgrade with better navigation and organization.
+
+- **CalVer versioning** — versions now use a calendar-based scheme (`YYYY.MM.N`) instead of semver, making it easier to see when a release was made
+- **Tag badges** — each entry is tagged as Feature, Fix, Improvement, or Refactor with a colored badge
+- **Filter by tag** — click a tag in the filter bar to show only entries of that type
+- **Pagination** — entries are now paginated (5 per page) with Previous/Next navigation, keeping the page fast as the changelog grows
+- **Content review** — fixed missing accent marks in Spanish translations and normalized title casing across all entries

--- a/changelog/en/2026-03-27-coaching-cadence-edit-session.mdx
+++ b/changelog/en/2026-03-27-coaching-cadence-edit-session.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.9.0"
+version: "2026.03.8"
 date: "2026-03-27"
-title: "Coaching cadence widget & session editing"
+title: "Coaching Cadence Widget & Session Editing"
+tags: ["feature"]
 ---
 
 ### New features

--- a/changelog/en/2026-03-27-lp-trend-coaching-datetime.mdx
+++ b/changelog/en/2026-03-27-lp-trend-coaching-datetime.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.8.1"
+version: "2026.03.7"
 date: "2026-03-27"
-title: "LP trend fix & coaching date/time picker"
+title: "LP Trend Fix & Coaching Date/Time Picker"
+tags: ["fix"]
 ---
 
 ### Bug fixes

--- a/changelog/es/2025-03-15-rank-journey-and-coaching.mdx
+++ b/changelog/es/2025-03-15-rank-journey-and-coaching.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.2.0"
+version: "2025.03.1"
 date: "2025-03-15"
 title: "Viaje de Rango y herramientas de Coaching"
+tags: ["feature"]
 ---
 
 ### Viaje de Rango

--- a/changelog/es/2025-03-20-review-page-and-polish.mdx
+++ b/changelog/es/2025-03-20-review-page-and-polish.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.3.0"
+version: "2025.03.2"
 date: "2025-03-20"
 title: "Página de Revisión y mejoras visuales"
+tags: ["feature"]
 ---
 
 Una nueva **página de Revisión** centraliza todo tu análisis post-partida:

--- a/changelog/es/2025-03-25-auto-sync-and-i18n.mdx
+++ b/changelog/es/2025-03-25-auto-sync-and-i18n.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.4.0"
+version: "2025.03.3"
 date: "2025-03-25"
 title: "Sincronización automática y soporte multilingüe"
+tags: ["feature"]
 ---
 
 Tus partidas ahora se **sincronizan automáticamente** — ya no necesitas pulsar el botón de sincronización cada vez que juegas.

--- a/changelog/es/2026-03-25-light-mode.mdx
+++ b/changelog/es/2026-03-25-light-mode.mdx
@@ -1,12 +1,13 @@
 ---
-version: "1.5.0"
+version: "2026.03.1"
 date: "2026-03-25"
 title: "Modo Claro y Selector de Tema"
+tags: ["feature"]
 ---
 
 La app ahora soporta **modo claro** junto al tema oscuro original.
 
 - **Selector de tema** en la barra lateral para cambiar entre Oscuro, Claro y Sistema (sigue la preferencia de tu SO)
-- **Todos los graficos y analiticas** adaptan sus colores al tema activo — sin graficos deslavados
-- **Todas las paginas** usan colores adaptados al tema para victorias, derrotas, rachas, marcadores de coaching y mas
+- **Todos los gráficos y analíticas** adaptan sus colores al tema activo — sin gráficos deslavados
+- **Todas las páginas** usan colores adaptados al tema para victorias, derrotas, rachas, marcadores de coaching y más
 - **Changelog, brillos y degradados** respetan el tema actual

--- a/changelog/es/2026-03-26-centralize-match-result.mdx
+++ b/changelog/es/2026-03-26-centralize-match-result.mdx
@@ -1,17 +1,18 @@
 ---
-version: "1.8.0"
+version: "2026.03.6"
 date: "2026-03-26"
 title: "Manejo Centralizado de Resultados de Partida"
+tags: ["refactor"]
 ---
 
-Refactorizacion mayor para centralizar toda la logica de resultados de partida (Victoria/Derrota/Remake) en helpers compartidos, corrigiendo 12 bugs y eliminando codigo duplicado en todo el proyecto.
+Refactorización mayor para centralizar toda la lógica de resultados de partida (Victoria/Derrota/Remake) en helpers compartidos, corrigiendo 12 bugs y eliminando código duplicado en todo el proyecto.
 
-- **Los remakes ya no cuentan como derrotas** — las estadisticas de duo, intervalos de coaching, conteos de revision en la barra lateral y promedios de scout ahora excluyen correctamente los remakes en lugar de contarlos silenciosamente como derrotas
-- **Bandas del grafico de coaching corregidas** — los marcadores de sesiones de coaching en el grafico de win rate ahora se alinean correctamente con los datos filtrados sin remakes
-- **Tendencia de LP mejorada** — la tendencia de LP del dashboard ahora usa la captura de rango mas cercana a la partida mas antigua de tus ultimas 10, dando numeros consistentes con la pagina de analiticas
-- **Conteo de "partidas analizadas" corregido** — el encabezado de la pagina de analiticas ahora muestra solo partidas significativas (sin remakes)
-- **Componentes UI compartidos** — nuevos componentes `ResultBadge` y `ResultBar` reemplazan mas de 12 expresiones ternarias dispersas con renderizado consistente que maneja remakes
-- **Utilidades de rango duplicadas eliminadas** — la pagina de analiticas ya no mantiene su propia copia de funciones de calculo de LP/rango
-- **Claves i18n muertas eliminadas** — se eliminaron claves de traduccion de resultados no utilizadas de los namespaces Coaching y Duo en favor del namespace compartido Common
-- **Los datos de seed generan remakes** — el script de seed ahora produce ~5% de remakes con duracion corta realista y estadisticas minimas
-- **Ruta de exportacion tipada** — la ruta de exportacion CSV ahora usa el tipo compartido `MatchResult`
+- **Los remakes ya no cuentan como derrotas** — las estadísticas de duo, intervalos de coaching, conteos de revisión en la barra lateral y promedios de scout ahora excluyen correctamente los remakes en lugar de contarlos silenciosamente como derrotas
+- **Bandas del gráfico de coaching corregidas** — los marcadores de sesiones de coaching en el gráfico de win rate ahora se alinean correctamente con los datos filtrados sin remakes
+- **Tendencia de LP mejorada** — la tendencia de LP del dashboard ahora usa la captura de rango más cercana a la partida más antigua de tus últimas 10, dando números consistentes con la página de analíticas
+- **Conteo de "partidas analizadas" corregido** — el encabezado de la página de analíticas ahora muestra solo partidas significativas (sin remakes)
+- **Componentes UI compartidos** — nuevos componentes `ResultBadge` y `ResultBar` reemplazan más de 12 expresiones ternarias dispersas con renderizado consistente que maneja remakes
+- **Utilidades de rango duplicadas eliminadas** — la página de analíticas ya no mantiene su propia copia de funciones de cálculo de LP/rango
+- **Claves i18n muertas eliminadas** — se eliminaron claves de traducción de resultados no utilizadas de los namespaces Coaching y Duo en favor del namespace compartido Common
+- **Los datos de seed generan remakes** — el script de seed ahora produce ~5% de remakes con duración corta realista y estadísticas mínimas
+- **Ruta de exportación tipada** — la ruta de exportación CSV ahora usa el tipo compartido `MatchResult`

--- a/changelog/es/2026-03-26-csv-export.mdx
+++ b/changelog/es/2026-03-26-csv-export.mdx
@@ -1,11 +1,12 @@
 ---
-version: "1.6.0"
+version: "2026.03.2"
 date: "2026-03-26"
 title: "Exportar historial de partidas en CSV"
+tags: ["feature"]
 ---
 
-Ahora puedes **exportar tu historial de partidas como archivo CSV** directamente desde la pagina de Partidas.
+Ahora puedes **exportar tu historial de partidas como archivo CSV** directamente desde la página de Partidas.
 
-- **Boton "Exportar CSV"** en la esquina superior derecha de la pagina de Partidas
-- **Respeta los filtros activos** — exporta solo victorias, un campeon especifico, partidas revisadas o resultados de busqueda
-- **Todos los campos clave** incluidos: fecha, resultado, campeon, matchup, runa clave, KDA, CS, oro, puntuacion de vision, duracion, estado de revision, notas y companero de duo
+- **Botón "Exportar CSV"** en la esquina superior derecha de la página de Partidas
+- **Respeta los filtros activos** — exporta solo victorias, un campeón específico, partidas revisadas o resultados de búsqueda
+- **Todos los campos clave** incluidos: fecha, resultado, campeón, matchup, runa clave, KDA, CS, oro, puntuación de visión, duración, estado de revisión, notas y compañero de duo

--- a/changelog/es/2026-03-26-goal-tracking.mdx
+++ b/changelog/es/2026-03-26-goal-tracking.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.7.0"
+version: "2026.03.3"
 date: "2026-03-26"
 title: "Objetivos con seguimiento de progreso"
+tags: ["feature"]
 ---
 
 Establece objetivos de rango y sigue tu progreso a lo largo del tiempo.

--- a/changelog/es/2026-03-26-remake-detection.mdx
+++ b/changelog/es/2026-03-26-remake-detection.mdx
@@ -1,12 +1,13 @@
 ---
-version: "1.7.1"
+version: "2026.03.4"
 date: "2026-03-26"
-title: "Deteccion de Remakes"
+title: "Detección de Remakes"
+tags: ["fix"]
 ---
 
-Las partidas que terminaron como **remakes** (rendiciones tempranas antes de 5 minutos) ahora se identifican correctamente y se excluyen de tus estadisticas.
+Las partidas que terminaron como **remakes** (rendiciones tempranas antes de 5 minutos) ahora se identifican correctamente y se excluyen de tus estadísticas.
 
-- **Deteccion automatica** durante la sincronizacion — los remakes muestran una insignia gris "R" en lugar de victoria/derrota
-- **Excluidos de todas las estadisticas** — win rates, rachas, estadisticas de matchup, estadisticas de duo y progreso de coaching ya no cuentan los remakes
-- **Filtrable** — usa la opcion "Remakes" en el filtro de resultado en la pagina de Partidas
+- **Detección automática** durante la sincronización — los remakes muestran una insignia gris "R" en lugar de victoria/derrota
+- **Excluidos de todas las estadísticas** — win rates, rachas, estadísticas de matchup, estadísticas de duo y progreso de coaching ya no cuentan los remakes
+- **Filtrable** — usa la opción "Remakes" en el filtro de resultado en la página de Partidas
 - **Script de backfill incluido** — ejecuta `npx tsx scripts/backfill-remakes.ts` para corregir retroactivamente las partidas existentes

--- a/changelog/es/2026-03-26-remake-review-dashboard.mdx
+++ b/changelog/es/2026-03-26-remake-review-dashboard.mdx
@@ -1,12 +1,13 @@
 ---
-version: "1.7.2"
+version: "2026.03.5"
 date: "2026-03-26"
-title: "Limpieza de Remakes: Revision y Dashboard"
+title: "Limpieza de Remakes: Revisión y Dashboard"
+tags: ["fix"]
 ---
 
-Correcciones de seguimiento a la funcion de deteccion de remakes.
+Correcciones de seguimiento a la función de detección de remakes.
 
-- **Remakes excluidos de la revision** — las partidas remake ya no aparecen en las colas de Post-Game ni de Revision de VOD
-- **Dashboard actualizado** — los remakes muestran una insignia gris "R" en las partidas recientes y se excluyen de los calculos de KDA/CS promedio
-- **Conteos de revision corregidos** — los conteos de partidas sin revisar y pendientes de VOD ya no incluyen remakes
-- **Orden del changelog corregido** — la entrada de deteccion de remakes ahora aparece correctamente como la ultima version (v1.7.1)
+- **Remakes excluidos de la revisión** — las partidas remake ya no aparecen en las colas de Post-Game ni de Revisión de VOD
+- **Dashboard actualizado** — los remakes muestran una insignia gris "R" en las partidas recientes y se excluyen de los cálculos de KDA/CS promedio
+- **Conteos de revisión corregidos** — los conteos de partidas sin revisar y pendientes de VOD ya no incluyen remakes
+- **Orden del changelog corregido** — la entrada de detección de remakes ahora aparece correctamente como la última versión (v1.7.1)

--- a/changelog/es/2026-03-27-changelog-improvements.mdx
+++ b/changelog/es/2026-03-27-changelog-improvements.mdx
@@ -1,0 +1,14 @@
+---
+version: "2026.03.9"
+date: "2026-03-27"
+title: "Mejoras en el Changelog"
+tags: ["improvement"]
+---
+
+La página de novedades recibe una mejora importante con mejor navegación y organización.
+
+- **Versionado CalVer** — las versiones ahora usan un esquema basado en calendario (`YYYY.MM.N`) en lugar de semver, facilitando ver cuándo se hizo cada lanzamiento
+- **Etiquetas de categoría** — cada entrada está etiquetada como Funcionalidad, Corrección, Mejora o Refactorización con una insignia de color
+- **Filtrar por etiqueta** — haz clic en una etiqueta en la barra de filtros para mostrar solo las entradas de ese tipo
+- **Paginación** — las entradas ahora están paginadas (5 por página) con navegación Anterior/Siguiente, manteniendo la página rápida a medida que crece el changelog
+- **Revisión de contenido** — corregidas tildes faltantes en las traducciones al español y normalizado el uso de mayúsculas en los títulos

--- a/changelog/es/2026-03-27-coaching-cadence-edit-session.mdx
+++ b/changelog/es/2026-03-27-coaching-cadence-edit-session.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.9.0"
+version: "2026.03.8"
 date: "2026-03-27"
 title: "Widget de cadencia de coaching y edición de sesiones"
+tags: ["feature"]
 ---
 
 ### Nuevas funcionalidades

--- a/changelog/es/2026-03-27-lp-trend-coaching-datetime.mdx
+++ b/changelog/es/2026-03-27-lp-trend-coaching-datetime.mdx
@@ -1,7 +1,8 @@
 ---
-version: "1.8.1"
+version: "2026.03.7"
 date: "2026-03-27"
 title: "Corrección de tendencia de LP y selector de fecha/hora en coaching"
+tags: ["fix"]
 ---
 
 ### Correcciones

--- a/messages/en.json
+++ b/messages/en.json
@@ -598,7 +598,20 @@
   "Changelog": {
     "title": "What's New",
     "subtitle": "Latest updates and improvements to LoL Tracker",
-    "empty": "No updates yet. Check back soon!"
+    "empty": "No updates yet. Check back soon!",
+    "noFilterResults": "No entries match this filter.",
+    "filterAll": "All",
+    "filterFeature": "Features",
+    "filterFix": "Fixes",
+    "filterImprovement": "Improvements",
+    "filterRefactor": "Refactors",
+    "tagFeature": "Feature",
+    "tagFix": "Fix",
+    "tagImprovement": "Improvement",
+    "tagRefactor": "Refactor",
+    "previousPage": "Previous",
+    "nextPage": "Next",
+    "pageIndicator": "Page {current} of {total}"
   },
   "Common": {
     "resultW": "W",

--- a/messages/es.json
+++ b/messages/es.json
@@ -598,7 +598,20 @@
   "Changelog": {
     "title": "Novedades",
     "subtitle": "Últimas actualizaciones y mejoras de LoL Tracker",
-    "empty": "Aún no hay actualizaciones. ¡Vuelve pronto!"
+    "empty": "Aún no hay actualizaciones. ¡Vuelve pronto!",
+    "noFilterResults": "No hay entradas que coincidan con este filtro.",
+    "filterAll": "Todas",
+    "filterFeature": "Funcionalidades",
+    "filterFix": "Correcciones",
+    "filterImprovement": "Mejoras",
+    "filterRefactor": "Refactorizaciones",
+    "tagFeature": "Funcionalidad",
+    "tagFix": "Corrección",
+    "tagImprovement": "Mejora",
+    "tagRefactor": "Refactorización",
+    "previousPage": "Anterior",
+    "nextPage": "Siguiente",
+    "pageIndicator": "Página {current} de {total}"
   },
   "Common": {
     "resultW": "V",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lol-tracker",
-  "version": "0.1.0",
+  "version": "2026.03.9",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(app)/changelog/changelog-filter.tsx
+++ b/src/app/(app)/changelog/changelog-filter.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import type { ChangelogTag } from "@/lib/changelog";
+
+const TAGS: (ChangelogTag | "all")[] = [
+  "all",
+  "feature",
+  "fix",
+  "improvement",
+  "refactor",
+];
+
+const TAG_FILTER_KEYS: Record<
+  "all" | ChangelogTag,
+  "filterAll" | "filterFeature" | "filterFix" | "filterImprovement" | "filterRefactor"
+> = {
+  all: "filterAll",
+  feature: "filterFeature",
+  fix: "filterFix",
+  improvement: "filterImprovement",
+  refactor: "filterRefactor",
+};
+
+export function ChangelogFilter({
+  activeTag,
+}: {
+  activeTag: ChangelogTag | undefined;
+}) {
+  const router = useRouter();
+  const t = useTranslations("Changelog");
+
+  function handleFilter(tag: ChangelogTag | "all") {
+    if (tag === "all") {
+      router.push("/changelog", { scroll: false });
+    } else {
+      router.push(`/changelog?tag=${tag}`, { scroll: false });
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {TAGS.map((tag) => {
+        const isActive =
+          tag === "all" ? !activeTag : activeTag === tag;
+        return (
+          <Button
+            key={tag}
+            variant={isActive ? "default" : "outline"}
+            size="sm"
+            onClick={() => handleFilter(tag)}
+            className={isActive ? "" : "text-muted-foreground"}
+          >
+            {t(TAG_FILTER_KEYS[tag])}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(app)/changelog/changelog-pagination.tsx
+++ b/src/app/(app)/changelog/changelog-pagination.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { ChangelogTag } from "@/lib/changelog";
+import { cn } from "@/lib/utils";
+
+function buildPageUrl(page: number, activeTag: ChangelogTag | undefined): string {
+  const sp = new URLSearchParams();
+  if (activeTag) sp.set("tag", activeTag);
+  if (page > 1) sp.set("page", String(page));
+  const qs = sp.toString();
+  return `/changelog${qs ? `?${qs}` : ""}`;
+}
+
+export function ChangelogPagination({
+  currentPage,
+  totalPages,
+  activeTag,
+}: {
+  currentPage: number;
+  totalPages: number;
+  activeTag: ChangelogTag | undefined;
+}) {
+  const t = useTranslations("Changelog");
+
+  return (
+    <div className="flex items-center justify-center gap-4 pt-2">
+      {currentPage > 1 ? (
+        <Link
+          href={buildPageUrl(currentPage - 1, activeTag)}
+          className={cn(buttonVariants({ variant: "outline", size: "sm" }))}
+        >
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          {t("previousPage")}
+        </Link>
+      ) : (
+        <Button variant="outline" size="sm" disabled>
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          {t("previousPage")}
+        </Button>
+      )}
+
+      <span className="text-sm text-muted-foreground">
+        {t("pageIndicator", { current: currentPage, total: totalPages })}
+      </span>
+
+      {currentPage < totalPages ? (
+        <Link
+          href={buildPageUrl(currentPage + 1, activeTag)}
+          className={cn(buttonVariants({ variant: "outline", size: "sm" }))}
+        >
+          {t("nextPage")}
+          <ChevronRight className="h-4 w-4 ml-1" />
+        </Link>
+      ) : (
+        <Button variant="outline" size="sm" disabled>
+          {t("nextPage")}
+          <ChevronRight className="h-4 w-4 ml-1" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/changelog/page.tsx
+++ b/src/app/(app)/changelog/page.tsx
@@ -1,5 +1,5 @@
 import { getLocale } from "next-intl/server";
-import { getChangelogEntries } from "@/lib/changelog";
+import { getChangelogEntries, type ChangelogTag } from "@/lib/changelog";
 import { compileMDX } from "next-mdx-remote/rsc";
 import { getTranslations } from "next-intl/server";
 import {
@@ -11,17 +11,64 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Sparkles } from "lucide-react";
 import { ChangelogSeenMarker } from "./changelog-seen-marker";
+import { ChangelogFilter } from "./changelog-filter";
+import { ChangelogPagination } from "./changelog-pagination";
 
-export default async function ChangelogRoute() {
+const ENTRIES_PER_PAGE = 5;
+const VALID_TAGS: ChangelogTag[] = ["feature", "fix", "improvement", "refactor"];
+
+const TAG_STYLES: Record<ChangelogTag, string> = {
+  feature:
+    "bg-blue-500/10 text-blue-400 border-blue-500/30",
+  fix: "bg-red-500/10 text-red-400 border-red-500/30",
+  improvement:
+    "bg-green-500/10 text-green-400 border-green-500/30",
+  refactor:
+    "bg-purple-500/10 text-purple-400 border-purple-500/30",
+};
+
+export default async function ChangelogRoute({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
   const locale = await getLocale();
-  const entries = await getChangelogEntries(locale);
   const t = await getTranslations("Changelog");
+
+  // Parse tag filter
+  const tagParam = typeof params.tag === "string" ? params.tag : undefined;
+  const activeTag =
+    tagParam && VALID_TAGS.includes(tagParam as ChangelogTag)
+      ? (tagParam as ChangelogTag)
+      : undefined;
+
+  // Get entries (optionally filtered by tag)
+  const allEntries = await getChangelogEntries(locale, activeTag);
+
+  // Parse page
+  const page = Math.max(
+    1,
+    parseInt(String(params.page ?? "1"), 10) || 1
+  );
+  const totalPages = Math.max(1, Math.ceil(allEntries.length / ENTRIES_PER_PAGE));
+  const currentPage = Math.min(page, totalPages);
+  const startIndex = (currentPage - 1) * ENTRIES_PER_PAGE;
+  const pageEntries = allEntries.slice(
+    startIndex,
+    startIndex + ENTRIES_PER_PAGE
+  );
+
+  // We need the unfiltered latest version for the "seen" marker
+  const unfilteredEntries = activeTag
+    ? await getChangelogEntries(locale)
+    : allEntries;
 
   return (
     <div className="space-y-6">
       {/* Mark latest version as seen (client-side localStorage) */}
-      {entries.length > 0 && (
-        <ChangelogSeenMarker version={entries[0].version} />
+      {unfilteredEntries.length > 0 && (
+        <ChangelogSeenMarker version={unfilteredEntries[0].version} />
       )}
 
       <div>
@@ -31,22 +78,29 @@ export default async function ChangelogRoute() {
         <p className="text-muted-foreground mt-1">{t("subtitle")}</p>
       </div>
 
-      {entries.length === 0 ? (
-        <p className="text-muted-foreground">{t("empty")}</p>
+      {/* Tag filter bar */}
+      <ChangelogFilter activeTag={activeTag} />
+
+      {allEntries.length === 0 ? (
+        <p className="text-muted-foreground">
+          {activeTag ? t("noFilterResults") : t("empty")}
+        </p>
       ) : (
         <div className="space-y-6">
           {await Promise.all(
-            entries.map(async (entry, index) => {
+            pageEntries.map(async (entry, index) => {
               const { content } = await compileMDX({
                 source: entry.source,
                 options: { parseFrontmatter: false },
               });
 
+              const isNewest = currentPage === 1 && index === 0 && !activeTag;
+
               return (
                 <Card
                   key={entry.slug}
                   className={
-                    index === 0
+                    isNewest
                       ? "border-gold/30 surface-glow"
                       : "border-border/50"
                   }
@@ -56,12 +110,12 @@ export default async function ChangelogRoute() {
                       <Badge
                         variant="outline"
                         className={
-                          index === 0
+                          isNewest
                             ? "border-gold/50 text-gold"
                             : "border-border text-muted-foreground"
                         }
                       >
-                        {index === 0 && (
+                        {isNewest && (
                           <Sparkles className="h-3 w-3 mr-1" />
                         )}
                         v{entry.version}
@@ -73,6 +127,15 @@ export default async function ChangelogRoute() {
                           day: "numeric",
                         })}
                       </span>
+                      {entry.tags.map((tag) => (
+                        <Badge
+                          key={tag}
+                          variant="outline"
+                          className={`text-xs ${TAG_STYLES[tag]}`}
+                        >
+                          {t(`tag${tag.charAt(0).toUpperCase()}${tag.slice(1)}` as "tagFeature" | "tagFix" | "tagImprovement" | "tagRefactor")}
+                        </Badge>
+                      ))}
                     </div>
                     <CardTitle className="text-xl mt-2">
                       {entry.title}
@@ -84,6 +147,15 @@ export default async function ChangelogRoute() {
                 </Card>
               );
             })
+          )}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <ChangelogPagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              activeTag={activeTag}
+            />
           )}
         </div>
       )}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,21 +1,40 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+export type ChangelogTag = "feature" | "fix" | "improvement" | "refactor";
+
 export interface ChangelogEntry {
   slug: string;
   version: string;
   date: string;
   title: string;
+  tags: ChangelogTag[];
   /** Raw MDX source (without frontmatter) */
   source: string;
 }
 
 /**
+ * Compare two CalVer version strings (YYYY.MM.N) numerically.
+ * Returns negative if a < b, positive if a > b, 0 if equal.
+ */
+function compareCalVer(a: string, b: string): number {
+  const aParts = a.split(".").map(Number);
+  const bParts = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
  * Read all changelog MDX files for a given locale, sorted newest-first.
  * Falls back to "en" if no files exist for the requested locale.
+ * Optionally filter by tag.
  */
 export async function getChangelogEntries(
-  locale: string
+  locale: string,
+  tag?: ChangelogTag
 ): Promise<ChangelogEntry[]> {
   const changelogDir = path.join(process.cwd(), "changelog", locale);
 
@@ -25,7 +44,7 @@ export async function getChangelogEntries(
   } catch {
     // Fallback to English if locale directory doesn't exist
     if (locale !== "en") {
-      return getChangelogEntries("en");
+      return getChangelogEntries("en", tag);
     }
     return [];
   }
@@ -55,6 +74,21 @@ export async function getChangelogEntries(
         }
       }
 
+      // Parse tags array: tags: ["feature", "fix"]
+      let tags: ChangelogTag[] = [];
+      const tagsLine = frontmatterBlock
+        .split("\n")
+        .find((l) => l.startsWith("tags:"));
+      if (tagsLine) {
+        const tagsMatch = tagsLine.match(/\[([^\]]*)\]/);
+        if (tagsMatch) {
+          tags = tagsMatch[1]
+            .split(",")
+            .map((t) => t.trim().replace(/["']/g, ""))
+            .filter((t): t is ChangelogTag => t.length > 0);
+        }
+      }
+
       if (!meta.version || !meta.date || !meta.title) return null;
 
       const slug = filename.replace(/\.mdx$/, "");
@@ -64,18 +98,26 @@ export async function getChangelogEntries(
         version: meta.version,
         date: meta.date,
         title: meta.title,
+        tags,
         source,
       } satisfies ChangelogEntry;
     })
   );
 
-  // Filter nulls and sort newest-first by date, then by version as tiebreaker
-  return entries
+  // Filter nulls and sort newest-first by date, then by CalVer version as tiebreaker
+  let result = entries
     .filter((e): e is ChangelogEntry => e !== null)
     .sort(
       (a, b) =>
-        b.date.localeCompare(a.date) || b.version.localeCompare(a.version)
+        b.date.localeCompare(a.date) || compareCalVer(b.version, a.version)
     );
+
+  // Apply tag filter if specified
+  if (tag) {
+    result = result.filter((e) => e.tags.includes(tag));
+  }
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adopt **CalVer versioning** (`YYYY.MM.N`) — re-versioned all 22 existing changelog entries, replaced string-based sort with numeric CalVer comparison
- Add **tag system** — each entry tagged as `feature`, `fix`, `improvement`, or `refactor` with colored badges and a filter bar
- Add **server-side pagination** (5 entries per page) with Previous/Next navigation and tag-aware query params
- **Content review** — fixed missing Spanish accent marks in 5 files, normalized title casing across all entries
- Updated `package.json` version to `2026.03.9` and pr-workflow skill to document CalVer convention

Fixes #33

## Changelog
- Version 2026.03.9: Changelog page now has CalVer versioning, tag badges with filtering, and pagination