### PR TITLE
feat: matchup-specific notes

### DIFF
--- a/.opencode/skills/vercel-turso-deploy/SKILL.md
+++ b/.opencode/skills/vercel-turso-deploy/SKILL.md
@@ -134,64 +134,33 @@ Use `npm run db:pull` (production -> local) and `npm run db:push` (local -> prod
 
 ## Turso / Drizzle migration workflow
 
-When you modify `src/db/schema.ts` (add columns, create tables, change indexes, etc.), the production Turso database will NOT update automatically. **You must run the migration against production before pushing code that references new schema.**
+Migrations are **auto-applied on every Vercel deploy**. The `vercel.json` `buildCommand` runs `scripts/migrate.ts` before `next build`, which reads the Drizzle journal (`drizzle/meta/_journal.json`) and applies any pending `.sql` migration files. This is idempotent — already-applied migrations are skipped.
 
 ### Steps after any schema change
 
 1. Generate migration: `npx drizzle-kit generate`
 2. Review the generated SQL in `drizzle/XXXX_*.sql`
-3. **Apply migration against production Turso**: Create a standalone script (see "`drizzle-kit migrate` fails or hangs with dotenvx" section below) and run it via `npx @dotenvx/dotenvx run --env-file=.env.local -- npx tsx scripts/apply-migration-XXXX.ts`
-4. Verify migration succeeded (e.g., `PRAGMA table_info(tablename)`) before pushing code
+3. Apply locally: `sqlite3 ./data/lol-tracker.db < drizzle/XXXX_*.sql` (or `npx drizzle-kit push` if it works)
+4. Commit the migration files alongside your code
+5. Push / merge — the migration will be applied to production Turso automatically during the Vercel build
+
+### How `scripts/migrate.ts` works
+
+- Creates a `__drizzle_migrations` tracking table if it doesn't exist
+- Has a backfill mechanism for databases that predate the script (migrations 0000-0010 applied via the old manual approach)
+- Reads the Drizzle journal, splits each `.sql` file by `"--> statement-breakpoint"`, and executes statements sequentially
+- Skips "already exists" errors for idempotency
+- Records each applied migration in the tracking table
+- Falls back to local SQLite (`file:./data/lol-tracker.db`) if no `TURSO_DATABASE_URL` is set
+- Has a `cleanEnv()` helper to strip dotenvx banners from env vars
 
 ### `drizzle-kit migrate` fails or hangs with dotenvx
 
-`drizzle-kit migrate` reads `drizzle.config.ts` at module scope, which means env vars are consumed **before** any banner-stripping can run. When invoked via `npx @dotenvx/dotenvx run --env-file=.env.local -- npx drizzle-kit migrate`, the `TURSO_DATABASE_URL` value is corrupted by the dotenvx banner and the command fails silently or with a cryptic error.
+`drizzle-kit migrate` reads `drizzle.config.ts` at module scope, which means env vars are consumed **before** any banner-stripping can run. This is why the project uses a custom `scripts/migrate.ts` instead of the built-in Drizzle migrator.
 
-**Workaround**: Write a standalone `.ts` migration script that strips the banner itself, then run it with `npx tsx`. See `scripts/apply-migration-0006.ts` for an example. The pattern:
+### Historical: manual migration scripts
 
-```ts
-// scripts/apply-migration-XXXX.ts
-import { createClient } from "@libsql/client";
-
-function cleanEnv(key: string): string | undefined {
-  const val = process.env[key];
-  if (!val) return undefined;
-  return val.replace(/^\[dotenv@[^\]]+\][^\n]*\n/, "");
-}
-
-const db = createClient({
-  url: cleanEnv("TURSO_DATABASE_URL")!,
-  authToken: cleanEnv("TURSO_AUTH_TOKEN"),
-});
-
-async function run() {
-  // Copy statements from the generated drizzle/XXXX_*.sql file:
-  await db.execute("ALTER TABLE `matches` ADD `new_column` text");
-  console.log("Done!");
-}
-run().catch(console.error);
-```
-
-Run with:
-```bash
-npx @dotenvx/dotenvx run --env-file=.env.local -- npx tsx scripts/apply-migration-XXXX.ts
-```
-
-**Important**: Do NOT use `node --env-file` with `require('@libsql/client')` — `@libsql/client` is ESM-only and won't work with `require()`.
-
-After applying manually, the drizzle `__drizzle_migrations` table in Turso will be out of sync with the applied state. This is acceptable for this project since migrations are applied manually anyway. If needed, you can insert a record into `__drizzle_migrations` to mark it as applied.
-
-### If `.env.local` doesn't have Turso credentials
-
-Pull them with:
-```bash
-npx vercel env pull .env.local
-```
-Note: env vars are scoped to **Production** on Vercel. If `vercel env pull` returns empty values, manually copy `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` from the Vercel dashboard into `.env.local`.
-
-### Why this matters
-
-The Vercel deployment auto-builds on push but does NOT run migrations. If new code references columns/tables that don't exist in production yet, every page that touches those columns will return a 500 error.
+The `scripts/apply-migration-*.ts` files are one-off scripts from before the automated `scripts/migrate.ts` approach was adopted. They are no longer needed for new migrations but are kept for reference.
 
 ### Config
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,15 @@ This version has breaking changes — APIs, conventions, and file structure may 
 <!-- END:nextjs-agent-rules -->
 
 <!-- BEGIN:turso-migration-rules -->
-# Turso migration reminder
+# Turso migration workflow
 
-**Run migrations against production Turso BEFORE pushing code that references new schema.** Vercel does NOT run migrations on deploy.
+Migrations are **auto-applied on every Vercel deploy** via `scripts/migrate.ts` (runs before `next build` in `vercel.json`'s `buildCommand`). You do NOT need to apply migrations manually before pushing.
 
-Steps: `npx drizzle-kit generate` -> review SQL -> apply via standalone script (see `vercel-turso-deploy` skill — `drizzle-kit migrate` does NOT work with dotenvx) -> verify -> push code.
+Steps after any schema change:
+1. `npx drizzle-kit generate` — generates SQL in `drizzle/`
+2. Review the generated SQL
+3. Apply locally: `sqlite3 ./data/lol-tracker.db < drizzle/XXXX_*.sql` (or `npx drizzle-kit push` if it works)
+4. Commit the migration files alongside your code — they will be applied to production automatically on deploy
 
 Full workflow details are in the `vercel-turso-deploy` OpenCode skill.
 <!-- END:turso-migration-rules -->

--- a/changelog/en/2026-03-27-matchup-notes.mdx
+++ b/changelog/en/2026-03-27-matchup-notes.mdx
@@ -1,0 +1,13 @@
+---
+version: "2026.03.10"
+date: "2026-03-27"
+title: "Matchup-Specific Notes"
+tags: ["feature"]
+---
+
+Keep persistent notes about champion matchups, available right when you need them.
+
+- **Per-matchup notes** — write notes for any enemy champion on the Scout page. Notes persist across games and are always ready for your next encounter
+- **Champion-specific & general** — add notes specific to a champion pairing (e.g., "Yone vs Syndra") or general notes that apply regardless of who you play (e.g., "vs Syndra")
+- **Inline editing** — click any note card to edit, save, or delete. Changes save instantly with no page reload
+- **Match detail integration** — relevant matchup notes appear on match detail pages as a read-only reference, with a link back to the Scout page for editing

--- a/changelog/es/2026-03-27-matchup-notes.mdx
+++ b/changelog/es/2026-03-27-matchup-notes.mdx
@@ -1,0 +1,13 @@
+---
+version: "2026.03.10"
+date: "2026-03-27"
+title: "Notas de matchup"
+tags: ["feature"]
+---
+
+Guarda notas persistentes sobre matchups de campeones, disponibles justo cuando las necesitas.
+
+- **Notas por matchup** — escribe notas para cualquier campeón enemigo en la página de Scout. Las notas persisten entre partidas y siempre están listas para tu próximo encuentro
+- **Específicas y generales** — añade notas específicas para un emparejamiento de campeones (ej. "Yone vs Syndra") o notas generales que aplican sin importar quién juegues (ej. "vs Syndra")
+- **Edición en línea** — haz clic en cualquier tarjeta de nota para editar, guardar o eliminar. Los cambios se guardan al instante sin recargar la página
+- **Integración en detalle de partida** — las notas de matchup relevantes aparecen en las páginas de detalle de partida como referencia de solo lectura, con un enlace de vuelta a la página de Scout para editar

--- a/drizzle/0012_military_proteus.sql
+++ b/drizzle/0012_military_proteus.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `matchup_notes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` text NOT NULL,
+	`champion_name` text,
+	`matchup_champion_name` text NOT NULL,
+	`content` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `matchup_notes_user_matchup_idx` ON `matchup_notes` (`user_id`,`matchup_champion_name`);--> statement-breakpoint
+CREATE UNIQUE INDEX `matchup_notes_user_champ_matchup_unq` ON `matchup_notes` (`user_id`,`champion_name`,`matchup_champion_name`);

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1231 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7581be63-a9c4-4995-89c8-f2a43eb59714",
+  "prevId": "83e11c39-7da4-448d-9bac-37934ad2be34",
+  "tables": {
+    "coaching_action_items": {
+      "name": "coaching_action_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "action_items_user_status_idx": {
+          "name": "action_items_user_status_idx",
+          "columns": [
+            "user_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "action_items_session_idx": {
+          "name": "action_items_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coaching_action_items_session_id_coaching_sessions_id_fk": {
+          "name": "coaching_action_items_session_id_coaching_sessions_id_fk",
+          "tableFrom": "coaching_action_items",
+          "tableTo": "coaching_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coaching_action_items_user_id_users_id_fk": {
+          "name": "coaching_action_items_user_id_users_id_fk",
+          "tableFrom": "coaching_action_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coaching_session_matches": {
+      "name": "coaching_session_matches",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "coaching_session_matches_match_user_idx": {
+          "name": "coaching_session_matches_match_user_idx",
+          "columns": [
+            "match_id",
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coaching_session_matches_session_id_coaching_sessions_id_fk": {
+          "name": "coaching_session_matches_session_id_coaching_sessions_id_fk",
+          "tableFrom": "coaching_session_matches",
+          "tableTo": "coaching_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coaching_session_matches_user_id_users_id_fk": {
+          "name": "coaching_session_matches_user_id_users_id_fk",
+          "tableFrom": "coaching_session_matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "coaching_session_matches_session_id_match_id_pk": {
+          "columns": [
+            "session_id",
+            "match_id"
+          ],
+          "name": "coaching_session_matches_session_id_match_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coaching_sessions": {
+      "name": "coaching_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coach_name": {
+          "name": "coach_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scheduled'"
+        },
+        "vod_match_id": {
+          "name": "vod_match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "coaching_sessions_user_date_idx": {
+          "name": "coaching_sessions_user_date_idx",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "coaching_sessions_user_status_idx": {
+          "name": "coaching_sessions_user_status_idx",
+          "columns": [
+            "user_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coaching_sessions_user_id_users_id_fk": {
+          "name": "coaching_sessions_user_id_users_id_fk",
+          "tableFrom": "coaching_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "goals": {
+      "name": "goals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_tier": {
+          "name": "target_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_division": {
+          "name": "target_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_tier": {
+          "name": "start_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_division": {
+          "name": "start_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_lp": {
+          "name": "start_lp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "achieved_at": {
+          "name": "achieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "goals_user_status_idx": {
+          "name": "goals_user_status_idx",
+          "columns": [
+            "user_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invites": {
+      "name": "invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_users_id_fk": {
+          "name": "invites_created_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_used_by_users_id_fk": {
+          "name": "invites_used_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "match_highlights": {
+      "name": "match_highlights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "match_highlights_match_user_idx": {
+          "name": "match_highlights_match_user_idx",
+          "columns": [
+            "match_id",
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "match_highlights_user_idx": {
+          "name": "match_highlights_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "match_highlights_user_id_users_id_fk": {
+          "name": "match_highlights_user_id_users_id_fk",
+          "tableFrom": "match_highlights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matches": {
+      "name": "matches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "odometer": {
+          "name": "odometer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_date": {
+          "name": "game_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "champion_id": {
+          "name": "champion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "champion_name": {
+          "name": "champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rune_keystone_id": {
+          "name": "rune_keystone_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rune_keystone_name": {
+          "name": "rune_keystone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matchup_champion_id": {
+          "name": "matchup_champion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matchup_champion_name": {
+          "name": "matchup_champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cs": {
+          "name": "cs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cs_per_min": {
+          "name": "cs_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "game_duration_seconds": {
+          "name": "game_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gold_earned": {
+          "name": "gold_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "vision_score": {
+          "name": "vision_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "review_notes": {
+          "name": "review_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_skipped_reason": {
+          "name": "review_skipped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vod_url": {
+          "name": "vod_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "queue_id": {
+          "name": "queue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_match_json": {
+          "name": "raw_match_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_puuid": {
+          "name": "duo_partner_puuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_champion_name": {
+          "name": "duo_partner_champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_kills": {
+          "name": "duo_partner_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_deaths": {
+          "name": "duo_partner_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_assists": {
+          "name": "duo_partner_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "matches_user_game_date_idx": {
+          "name": "matches_user_game_date_idx",
+          "columns": [
+            "user_id",
+            "game_date"
+          ],
+          "isUnique": false
+        },
+        "matches_user_reviewed_idx": {
+          "name": "matches_user_reviewed_idx",
+          "columns": [
+            "user_id",
+            "reviewed"
+          ],
+          "isUnique": false
+        },
+        "matches_user_duo_partner_idx": {
+          "name": "matches_user_duo_partner_idx",
+          "columns": [
+            "user_id",
+            "duo_partner_puuid"
+          ],
+          "isUnique": false
+        },
+        "matches_user_odometer_unq": {
+          "name": "matches_user_odometer_unq",
+          "columns": [
+            "user_id",
+            "odometer"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "matches_user_id_users_id_fk": {
+          "name": "matches_user_id_users_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "matches_id_user_id_pk": {
+          "columns": [
+            "id",
+            "user_id"
+          ],
+          "name": "matches_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matchup_notes": {
+      "name": "matchup_notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "champion_name": {
+          "name": "champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matchup_champion_name": {
+          "name": "matchup_champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "matchup_notes_user_matchup_idx": {
+          "name": "matchup_notes_user_matchup_idx",
+          "columns": [
+            "user_id",
+            "matchup_champion_name"
+          ],
+          "isUnique": false
+        },
+        "matchup_notes_user_champ_matchup_unq": {
+          "name": "matchup_notes_user_champ_matchup_unq",
+          "columns": [
+            "user_id",
+            "champion_name",
+            "matchup_champion_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "matchup_notes_user_id_users_id_fk": {
+          "name": "matchup_notes_user_id_users_id_fk",
+          "tableFrom": "matchup_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_snapshots": {
+      "name": "rank_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lp": {
+          "name": "lp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "rank_snapshots_user_captured_idx": {
+          "name": "rank_snapshots_user_captured_idx",
+          "columns": [
+            "user_id",
+            "captured_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rank_snapshots_user_id_users_id_fk": {
+          "name": "rank_snapshots_user_id_users_id_fk",
+          "tableFrom": "rank_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "riot_game_name": {
+          "name": "riot_game_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "riot_tag_line": {
+          "name": "riot_tag_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "puuid": {
+          "name": "puuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summoner_id": {
+          "name": "summoner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_user_id": {
+          "name": "duo_partner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'en-GB'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "columns": [
+            "discord_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1774532978430,
       "tag": "0011_silent_phantom_reporter",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1774606197573,
+      "tag": "0012_military_proteus",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -253,6 +253,26 @@
       "failedToLoadReport": "Couldn't load the scouting report. Please try again."
     }
   },
+  "MatchupNotes": {
+    "sectionTitle": "Matchup Notes",
+    "generalNoteTitle": "vs {enemy}",
+    "specificNoteTitle": "{champion} vs {enemy}",
+    "addNotes": "Add notes...",
+    "editTooltip": "Edit note",
+    "save": "Save",
+    "cancel": "Cancel",
+    "placeholder": "Write your notes about this matchup...",
+    "savedAt": "Updated {date}",
+    "viewInScout": "View in Scout",
+    "readOnlyTitle": "Your Notes",
+    "noNotes": "No matchup notes yet. Use the Scout page to add notes.",
+    "toasts": {
+      "saved": "Matchup note saved.",
+      "deleted": "Matchup note deleted.",
+      "saveError": "Failed to save matchup note.",
+      "deleteError": "Failed to delete matchup note."
+    }
+  },
   "Analytics": {
     "pageTitle": "Analytics",
     "gamesAnalyzed": "{count, plural, one {# game} other {# games}} analyzed.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -253,6 +253,26 @@
       "failedToLoadReport": "No se pudo cargar el informe de scouting. Inténtalo de nuevo."
     }
   },
+  "MatchupNotes": {
+    "sectionTitle": "Notas de matchup",
+    "generalNoteTitle": "vs {enemy}",
+    "specificNoteTitle": "{champion} vs {enemy}",
+    "addNotes": "Añadir notas...",
+    "editTooltip": "Editar nota",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "placeholder": "Escribe tus notas sobre este matchup...",
+    "savedAt": "Actualizado {date}",
+    "viewInScout": "Ver en Scout",
+    "readOnlyTitle": "Tus notas",
+    "noNotes": "Sin notas de matchup aún. Usa la página de Scout para añadir notas.",
+    "toasts": {
+      "saved": "Nota de matchup guardada.",
+      "deleted": "Nota de matchup eliminada.",
+      "saveError": "Error al guardar la nota de matchup.",
+      "deleteError": "Error al eliminar la nota de matchup."
+    }
+  },
   "Analytics": {
     "pageTitle": "Estadísticas",
     "gamesAnalyzed": "{count, plural, one {# partida} other {# partidas}} analizadas.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lol-tracker",
-  "version": "2026.03.9",
+  "version": "2026.03.10",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(app)/matches/[id]/match-detail-client.tsx
+++ b/src/app/(app)/matches/[id]/match-detail-client.tsx
@@ -42,6 +42,8 @@ import type { RiotMatchParticipant } from "@/lib/riot-api";
 import { getKeystoneIconUrl } from "@/lib/riot-api";
 import { ChampionLink } from "@/components/champion-link";
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
+import { ReadOnlyMatchupNotes } from "@/app/(app)/scout/matchup-notes";
+import type { MatchupNoteData } from "@/app/actions/matchup-notes";
 
 /** Slim participant — only fields needed for the match detail view */
 type SlimParticipant = Pick<
@@ -77,6 +79,7 @@ interface MatchDetailClientProps {
     date: Date;
   }>;
   highlights: HighlightItem[];
+  matchupNotes: MatchupNoteData[];
   ddragonVersion: string;
   userPuuid: string;
 }
@@ -185,6 +188,7 @@ export function MatchDetailClient({
   participants,
   linkedSessions,
   highlights,
+  matchupNotes,
   ddragonVersion,
   userPuuid,
 }: MatchDetailClientProps) {
@@ -386,6 +390,20 @@ export function MatchDetailClient({
           </CardHeader>
           <CardContent>
             <HighlightsDisplay highlights={highlights} />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Matchup Notes — read-only reference */}
+      {matchupNotes.length > 0 && match.matchupChampionName && (
+        <Card className="surface-glow">
+          <CardContent className="pt-5">
+            <ReadOnlyMatchupNotes
+              notes={matchupNotes}
+              matchupChampionName={match.matchupChampionName}
+              yourChampionName={match.championName}
+              locale={locale}
+            />
           </CardContent>
         </Card>
       )}

--- a/src/app/(app)/matches/[id]/page.tsx
+++ b/src/app/(app)/matches/[id]/page.tsx
@@ -6,6 +6,7 @@ import { getLatestVersion } from "@/lib/riot-api";
 import { notFound } from "next/navigation";
 import { MatchDetailClient } from "./match-detail-client";
 import type { RiotMatch } from "@/lib/riot-api";
+import { getMatchupNotesForMatch } from "@/app/actions/matchup-notes";
 
 /** Slim participant shape — only the fields used by the client component */
 function slimParticipants(raw: RiotMatch) {
@@ -87,7 +88,7 @@ export default async function MatchDetailPage({
   const { rawMatchJson: _rawJson, ...matchForClient } = match;
 
   // These are independent — run in parallel (ddragonVersion already started above)
-  const [ddragonVersion, linkedSessions, highlights] = await Promise.all([
+  const [ddragonVersion, linkedSessions, highlights, matchupNotesData] = await Promise.all([
     ddragonVersionPromise,
     db
       .select({
@@ -113,6 +114,9 @@ export default async function MatchDetailPage({
           eq(matchHighlights.userId, user.id),
         )
       ),
+    match.matchupChampionName
+      ? getMatchupNotesForMatch(match.championName, match.matchupChampionName)
+      : Promise.resolve([]),
   ]);
 
   const highlightItems = highlights.map((h) => ({
@@ -127,6 +131,7 @@ export default async function MatchDetailPage({
       participants={participants}
       linkedSessions={linkedSessions}
       highlights={highlightItems}
+      matchupNotes={matchupNotesData}
       ddragonVersion={ddragonVersion}
       userPuuid={matchPuuid}
     />

--- a/src/app/(app)/scout/matchup-notes.tsx
+++ b/src/app/(app)/scout/matchup-notes.tsx
@@ -13,23 +13,58 @@ import {
 } from "@/app/actions/matchup-notes";
 import { formatDate } from "@/lib/format";
 
-// ─── Note Editor Panel (shown when bubble is open) ──────────────────────────
+// ─── Trigger Button (inline in header) ──────────────────────────────────────
 
-function NoteEditorPanel({
-  note,
-  championName,
-  matchupChampionName,
-  locale,
-  onSaved,
-  onClose,
-}: {
+interface MatchupNotesTriggerProps {
+  hasNote: boolean;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+export function MatchupNotesTrigger({
+  hasNote,
+  isOpen,
+  onToggle,
+}: MatchupNotesTriggerProps) {
+  const t = useTranslations("MatchupNotes");
+
+  return (
+    <button
+      onClick={onToggle}
+      className={`relative p-1.5 rounded-md transition-colors ${
+        isOpen
+          ? "text-gold bg-gold/10"
+          : "text-muted-foreground hover:text-foreground hover:bg-surface-elevated"
+      }`}
+      title={t("sectionTitle")}
+    >
+      <MessageSquareText className="h-4 w-4" />
+      {hasNote && !isOpen && (
+        <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-gold" />
+      )}
+    </button>
+  );
+}
+
+// ─── Editor Panel (rendered below header, outside flex) ─────────────────────
+
+interface MatchupNotesPanelProps {
   note: MatchupNoteData | null;
   championName: string | null;
   matchupChampionName: string;
   locale: string;
   onSaved: () => void;
   onClose: () => void;
-}) {
+}
+
+export function MatchupNotesPanel({
+  note,
+  championName,
+  matchupChampionName,
+  locale,
+  onSaved,
+  onClose,
+}: MatchupNotesPanelProps) {
   const t = useTranslations("MatchupNotes");
   const [isEditing, setIsEditing] = useState(!note?.content);
   const [content, setContent] = useState(note?.content ?? "");
@@ -46,7 +81,6 @@ function NoteEditorPanel({
         toast.success(content.trim() ? t("toasts.saved") : t("toasts.deleted"));
         setIsEditing(false);
         onSaved();
-        // Close if saved empty (deleted)
         if (!content.trim()) onClose();
       } else {
         toast.error(result.error ?? t("toasts.saveError"));
@@ -81,7 +115,7 @@ function NoteEditorPanel({
 
   if (isEditing) {
     return (
-      <div className="rounded-lg border border-border/40 bg-surface-elevated p-3 space-y-2 mt-3">
+      <div className="rounded-lg border border-border/40 bg-surface-elevated p-3 space-y-2">
         <Textarea
           value={content}
           onChange={(e) => setContent(e.target.value)}
@@ -120,7 +154,7 @@ function NoteEditorPanel({
   // Read mode — show content, click to edit
   return (
     <div
-      className="rounded-lg border border-border/40 bg-surface-elevated p-3 mt-3 cursor-pointer hover:border-border/60 transition-colors"
+      className="rounded-lg border border-border/40 bg-surface-elevated p-3 cursor-pointer hover:border-border/60 transition-colors"
       onClick={() => setIsEditing(true)}
       role="button"
       tabIndex={0}
@@ -136,65 +170,21 @@ function NoteEditorPanel({
   );
 }
 
-// ─── Matchup Notes Bubble (for Scout page header) ───────────────────────────
+// ─── Helper: pick the active note from the list ─────────────────────────────
 
-interface MatchupNotesBubbleProps {
-  notes: MatchupNoteData[];
-  matchupChampionName: string;
-  yourChampionName?: string;
-  locale: string;
-  onNotesChanged?: () => void;
-}
-
-export function MatchupNotesBubble({
-  notes,
-  matchupChampionName,
-  yourChampionName,
-  locale,
-  onNotesChanged,
-}: MatchupNotesBubbleProps) {
-  const t = useTranslations("MatchupNotes");
-  const [isOpen, setIsOpen] = useState(false);
-
+export function pickActiveNote(
+  notes: MatchupNoteData[],
+  yourChampionName?: string
+): { activeNote: MatchupNoteData | null; activeChampionName: string | null } {
   const generalNote = notes.find((n) => n.championName === null) ?? null;
   const specificNote = yourChampionName
     ? notes.find((n) => n.championName === yourChampionName) ?? null
     : null;
 
-  // Pick the active note based on champion selection
-  const activeNote = yourChampionName ? specificNote : generalNote;
-  const activeChampionName = yourChampionName ?? null;
-  const hasNote = !!activeNote?.content;
-
-  const handleSaved = useCallback(() => {
-    onNotesChanged?.();
-  }, [onNotesChanged]);
-
-  return (
-    <div>
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="relative p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-surface-elevated transition-colors"
-        title={t("sectionTitle")}
-      >
-        <MessageSquareText className="h-4 w-4" />
-        {hasNote && (
-          <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-gold" />
-        )}
-      </button>
-
-      {isOpen && (
-        <NoteEditorPanel
-          note={activeNote}
-          championName={activeChampionName}
-          matchupChampionName={matchupChampionName}
-          locale={locale}
-          onSaved={handleSaved}
-          onClose={() => setIsOpen(false)}
-        />
-      )}
-    </div>
-  );
+  return {
+    activeNote: yourChampionName ? specificNote : generalNote,
+    activeChampionName: yourChampionName ?? null,
+  };
 }
 
 // ─── Read-Only Matchup Notes (for Match Detail page) ────────────────────────

--- a/src/app/(app)/scout/matchup-notes.tsx
+++ b/src/app/(app)/scout/matchup-notes.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition, useCallback } from "react";
 import { useTranslations } from "next-intl";
-import { Pencil, StickyNote, Trash2 } from "lucide-react";
+import { MessageSquareText, Pencil, Trash2, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
@@ -13,25 +13,32 @@ import {
 } from "@/app/actions/matchup-notes";
 import { formatDate } from "@/lib/format";
 
-// ─── Single Note Card ───────────────────────────────────────────────────────
+// ─── Inline Note Editor ─────────────────────────────────────────────────────
 
-function NoteCard({
+function InlineNoteEditor({
   note,
   title,
   championName,
   matchupChampionName,
   locale,
+  onSaved,
+  defaultExpanded,
 }: {
   note: MatchupNoteData | null;
   title: string;
   championName: string | null;
   matchupChampionName: string;
   locale: string;
+  onSaved: () => void;
+  defaultExpanded?: boolean;
 }) {
   const t = useTranslations("MatchupNotes");
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded ?? false);
   const [isEditing, setIsEditing] = useState(false);
   const [content, setContent] = useState(note?.content ?? "");
   const [isSaving, startSaveTransition] = useTransition();
+
+  const hasContent = !!note?.content;
 
   const handleSave = useCallback(() => {
     startSaveTransition(async () => {
@@ -43,11 +50,12 @@ function NoteCard({
       if (result.success) {
         toast.success(content.trim() ? t("toasts.saved") : t("toasts.deleted"));
         setIsEditing(false);
+        onSaved();
       } else {
         toast.error(result.error ?? t("toasts.saveError"));
       }
     });
-  }, [championName, matchupChampionName, content, t]);
+  }, [championName, matchupChampionName, content, t, onSaved]);
 
   const handleDelete = useCallback(() => {
     if (!note) return;
@@ -57,34 +65,32 @@ function NoteCard({
         toast.success(t("toasts.deleted"));
         setContent("");
         setIsEditing(false);
+        onSaved();
       } else {
         toast.error(t("toasts.deleteError"));
       }
     });
-  }, [note, t]);
+  }, [note, t, onSaved]);
 
   const handleCancel = useCallback(() => {
     setContent(note?.content ?? "");
     setIsEditing(false);
   }, [note]);
 
+  // Editing mode — inline textarea
   if (isEditing) {
     return (
-      <div className="rounded-lg border border-border/50 bg-surface-elevated p-3 space-y-3">
-        <p className="text-sm font-medium">{title}</p>
+      <div className="space-y-2">
+        <p className="text-xs font-medium text-muted-foreground">{title}</p>
         <Textarea
           value={content}
           onChange={(e) => setContent(e.target.value)}
           placeholder={t("placeholder")}
-          className="min-h-24"
+          className="min-h-20 text-sm"
           autoFocus
         />
         <div className="flex items-center gap-2">
-          <Button
-            size="sm"
-            onClick={handleSave}
-            disabled={isSaving}
-          >
+          <Button size="sm" onClick={handleSave} disabled={isSaving}>
             {t("save")}
           </Button>
           <Button
@@ -111,42 +117,66 @@ function NoteCard({
     );
   }
 
+  // Collapsed — just a clickable row
+  if (!isExpanded && hasContent) {
+    return (
+      <button
+        className="flex items-center gap-2 w-full text-left group"
+        onClick={() => setIsExpanded(true)}
+      >
+        <ChevronDown className="h-3 w-3 text-muted-foreground -rotate-90 transition-transform group-hover:rotate-0" />
+        <span className="text-xs font-medium text-muted-foreground truncate flex-1">
+          {title}
+        </span>
+        <span className="text-[10px] text-muted-foreground/60">
+          {formatDate(note!.updatedAt, locale)}
+        </span>
+      </button>
+    );
+  }
+
+  // Expanded or empty — show content + edit trigger
   return (
-    <div
-      className="rounded-lg border border-border/50 bg-surface-elevated p-3 group cursor-pointer hover:border-border transition-colors"
-      onClick={() => setIsEditing(true)}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") setIsEditing(true);
-      }}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <p className="text-sm font-medium">{title}</p>
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
         <button
-          className="opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
-          onClick={(e) => {
-            e.stopPropagation();
-            setIsEditing(true);
-          }}
+          className="flex items-center gap-2 text-left group"
+          onClick={() => hasContent && setIsExpanded(false)}
+        >
+          {hasContent && (
+            <ChevronDown className="h-3 w-3 text-muted-foreground transition-transform" />
+          )}
+          <span className="text-xs font-medium text-muted-foreground">
+            {title}
+          </span>
+        </button>
+        <button
+          className="text-muted-foreground/50 hover:text-foreground transition-colors"
+          onClick={() => setIsEditing(true)}
           title={t("editTooltip")}
         >
-          <Pencil className="h-3.5 w-3.5" />
+          <Pencil className="h-3 w-3" />
         </button>
       </div>
-      {note?.content ? (
-        <>
-          <p className="text-sm text-muted-foreground mt-1 whitespace-pre-wrap">
-            {note.content}
-          </p>
-          <p className="text-[10px] text-muted-foreground/70 mt-2">
-            {t("savedAt", { date: formatDate(note.updatedAt, locale) })}
-          </p>
-        </>
+      {hasContent ? (
+        <div
+          className="text-sm text-muted-foreground whitespace-pre-wrap pl-5 cursor-pointer hover:text-foreground transition-colors"
+          onClick={() => setIsEditing(true)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") setIsEditing(true);
+          }}
+        >
+          {note!.content}
+        </div>
       ) : (
-        <p className="text-sm text-muted-foreground/50 italic mt-1">
+        <button
+          className="text-xs text-muted-foreground/40 italic hover:text-muted-foreground transition-colors pl-5"
+          onClick={() => setIsEditing(true)}
+        >
           {t("addNotes")}
-        </p>
+        </button>
       )}
     </div>
   );
@@ -159,6 +189,7 @@ interface MatchupNotesSectionProps {
   matchupChampionName: string;
   yourChampionName?: string;
   locale: string;
+  onNotesChanged?: () => void;
 }
 
 export function MatchupNotesSection({
@@ -166,6 +197,7 @@ export function MatchupNotesSection({
   matchupChampionName,
   yourChampionName,
   locale,
+  onNotesChanged,
 }: MatchupNotesSectionProps) {
   const t = useTranslations("MatchupNotes");
 
@@ -174,17 +206,26 @@ export function MatchupNotesSection({
     ? notes.find((n) => n.championName === yourChampionName) ?? null
     : null;
 
+  const handleSaved = useCallback(() => {
+    onNotesChanged?.();
+  }, [onNotesChanged]);
+
+  const hasAnyNote = !!generalNote?.content || !!specificNote?.content;
+
   return (
-    <div className="space-y-3">
-      <h3 className="text-sm font-medium flex items-center gap-2">
-        <StickyNote className="h-4 w-4 text-gold" />
+    <div className="space-y-2">
+      <h3 className="text-xs font-medium flex items-center gap-1.5 text-muted-foreground">
+        <MessageSquareText className="h-3.5 w-3.5 text-gold" />
         {t("sectionTitle")}
+        {hasAnyNote && (
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-gold" />
+        )}
       </h3>
 
-      <div className="space-y-2">
-        {/* Champion-specific note (only when Your Champion is selected) */}
+      <div className="space-y-2 rounded-lg border border-border/30 bg-surface-elevated/50 p-3">
+        {/* Champion-specific note — shown prominently when Your Champion is set */}
         {yourChampionName && (
-          <NoteCard
+          <InlineNoteEditor
             note={specificNote}
             title={t("specificNoteTitle", {
               champion: yourChampionName,
@@ -193,16 +234,25 @@ export function MatchupNotesSection({
             championName={yourChampionName}
             matchupChampionName={matchupChampionName}
             locale={locale}
+            onSaved={handleSaved}
+            defaultExpanded
           />
         )}
 
-        {/* General note (always shown) */}
-        <NoteCard
+        {/* Separator between notes when both are shown */}
+        {yourChampionName && (
+          <div className="border-t border-border/20" />
+        )}
+
+        {/* General note — secondary (collapsed by default) when specific note exists */}
+        <InlineNoteEditor
           note={generalNote}
           title={t("generalNoteTitle", { enemy: matchupChampionName })}
           championName={null}
           matchupChampionName={matchupChampionName}
           locale={locale}
+          onSaved={handleSaved}
+          defaultExpanded={!yourChampionName}
         />
       </div>
     </div>
@@ -232,10 +282,10 @@ export function ReadOnlyMatchupNotes({
   const specificNote = notes.find((n) => n.championName === yourChampionName);
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <h3 className="text-sm font-medium flex items-center gap-2">
-          <StickyNote className="h-4 w-4 text-gold" />
+        <h3 className="text-xs font-medium flex items-center gap-1.5 text-muted-foreground">
+          <MessageSquareText className="h-3.5 w-3.5 text-gold" />
           {t("readOnlyTitle")}
         </h3>
         <a
@@ -246,33 +296,37 @@ export function ReadOnlyMatchupNotes({
         </a>
       </div>
 
-      <div className="space-y-2">
+      <div className="space-y-2 rounded-lg border border-border/30 bg-surface-elevated/50 p-3">
         {specificNote && (
-          <div className="rounded-lg border border-border/50 bg-surface-elevated p-3">
+          <div>
             <p className="text-xs font-medium text-muted-foreground">
               {t("specificNoteTitle", {
                 champion: yourChampionName,
                 enemy: matchupChampionName,
               })}
             </p>
-            <p className="text-sm mt-1 whitespace-pre-wrap">
+            <p className="text-sm mt-1 whitespace-pre-wrap pl-0">
               {specificNote.content}
             </p>
-            <p className="text-[10px] text-muted-foreground/70 mt-2">
+            <p className="text-[10px] text-muted-foreground/60 mt-1">
               {t("savedAt", { date: formatDate(specificNote.updatedAt, locale) })}
             </p>
           </div>
         )}
 
+        {specificNote && generalNote && (
+          <div className="border-t border-border/20" />
+        )}
+
         {generalNote && (
-          <div className="rounded-lg border border-border/50 bg-surface-elevated p-3">
+          <div>
             <p className="text-xs font-medium text-muted-foreground">
               {t("generalNoteTitle", { enemy: matchupChampionName })}
             </p>
-            <p className="text-sm mt-1 whitespace-pre-wrap">
+            <p className="text-sm mt-1 whitespace-pre-wrap pl-0">
               {generalNote.content}
             </p>
-            <p className="text-[10px] text-muted-foreground/70 mt-2">
+            <p className="text-[10px] text-muted-foreground/60 mt-1">
               {t("savedAt", { date: formatDate(generalNote.updatedAt, locale) })}
             </p>
           </div>

--- a/src/app/(app)/scout/matchup-notes.tsx
+++ b/src/app/(app)/scout/matchup-notes.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState, useTransition, useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { Pencil, StickyNote, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
+import {
+  upsertMatchupNote,
+  deleteMatchupNote,
+  type MatchupNoteData,
+} from "@/app/actions/matchup-notes";
+import { formatDate } from "@/lib/format";
+
+// ─── Single Note Card ───────────────────────────────────────────────────────
+
+function NoteCard({
+  note,
+  title,
+  championName,
+  matchupChampionName,
+  locale,
+}: {
+  note: MatchupNoteData | null;
+  title: string;
+  championName: string | null;
+  matchupChampionName: string;
+  locale: string;
+}) {
+  const t = useTranslations("MatchupNotes");
+  const [isEditing, setIsEditing] = useState(false);
+  const [content, setContent] = useState(note?.content ?? "");
+  const [isSaving, startSaveTransition] = useTransition();
+
+  const handleSave = useCallback(() => {
+    startSaveTransition(async () => {
+      const result = await upsertMatchupNote(
+        championName,
+        matchupChampionName,
+        content
+      );
+      if (result.success) {
+        toast.success(content.trim() ? t("toasts.saved") : t("toasts.deleted"));
+        setIsEditing(false);
+      } else {
+        toast.error(result.error ?? t("toasts.saveError"));
+      }
+    });
+  }, [championName, matchupChampionName, content, t]);
+
+  const handleDelete = useCallback(() => {
+    if (!note) return;
+    startSaveTransition(async () => {
+      const result = await deleteMatchupNote(note.id);
+      if (result.success) {
+        toast.success(t("toasts.deleted"));
+        setContent("");
+        setIsEditing(false);
+      } else {
+        toast.error(t("toasts.deleteError"));
+      }
+    });
+  }, [note, t]);
+
+  const handleCancel = useCallback(() => {
+    setContent(note?.content ?? "");
+    setIsEditing(false);
+  }, [note]);
+
+  if (isEditing) {
+    return (
+      <div className="rounded-lg border border-border/50 bg-surface-elevated p-3 space-y-3">
+        <p className="text-sm font-medium">{title}</p>
+        <Textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder={t("placeholder")}
+          className="min-h-24"
+          autoFocus
+        />
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={isSaving}
+          >
+            {t("save")}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={handleCancel}
+            disabled={isSaving}
+          >
+            {t("cancel")}
+          </Button>
+          {note && (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="ml-auto text-destructive hover:text-destructive"
+              onClick={handleDelete}
+              disabled={isSaving}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="rounded-lg border border-border/50 bg-surface-elevated p-3 group cursor-pointer hover:border-border transition-colors"
+      onClick={() => setIsEditing(true)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") setIsEditing(true);
+      }}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm font-medium">{title}</p>
+        <button
+          className="opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsEditing(true);
+          }}
+          title={t("editTooltip")}
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      {note?.content ? (
+        <>
+          <p className="text-sm text-muted-foreground mt-1 whitespace-pre-wrap">
+            {note.content}
+          </p>
+          <p className="text-[10px] text-muted-foreground/70 mt-2">
+            {t("savedAt", { date: formatDate(note.updatedAt, locale) })}
+          </p>
+        </>
+      ) : (
+        <p className="text-sm text-muted-foreground/50 italic mt-1">
+          {t("addNotes")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ─── Matchup Notes Section (for Scout page) ─────────────────────────────────
+
+interface MatchupNotesSectionProps {
+  notes: MatchupNoteData[];
+  matchupChampionName: string;
+  yourChampionName?: string;
+  locale: string;
+}
+
+export function MatchupNotesSection({
+  notes,
+  matchupChampionName,
+  yourChampionName,
+  locale,
+}: MatchupNotesSectionProps) {
+  const t = useTranslations("MatchupNotes");
+
+  const generalNote = notes.find((n) => n.championName === null) ?? null;
+  const specificNote = yourChampionName
+    ? notes.find((n) => n.championName === yourChampionName) ?? null
+    : null;
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium flex items-center gap-2">
+        <StickyNote className="h-4 w-4 text-gold" />
+        {t("sectionTitle")}
+      </h3>
+
+      <div className="space-y-2">
+        {/* Champion-specific note (only when Your Champion is selected) */}
+        {yourChampionName && (
+          <NoteCard
+            note={specificNote}
+            title={t("specificNoteTitle", {
+              champion: yourChampionName,
+              enemy: matchupChampionName,
+            })}
+            championName={yourChampionName}
+            matchupChampionName={matchupChampionName}
+            locale={locale}
+          />
+        )}
+
+        {/* General note (always shown) */}
+        <NoteCard
+          note={generalNote}
+          title={t("generalNoteTitle", { enemy: matchupChampionName })}
+          championName={null}
+          matchupChampionName={matchupChampionName}
+          locale={locale}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── Read-Only Matchup Notes (for Match Detail page) ────────────────────────
+
+interface ReadOnlyMatchupNotesProps {
+  notes: MatchupNoteData[];
+  matchupChampionName: string;
+  yourChampionName: string;
+  locale: string;
+}
+
+export function ReadOnlyMatchupNotes({
+  notes,
+  matchupChampionName,
+  yourChampionName,
+  locale,
+}: ReadOnlyMatchupNotesProps) {
+  const t = useTranslations("MatchupNotes");
+
+  if (notes.length === 0) return null;
+
+  const generalNote = notes.find((n) => n.championName === null);
+  const specificNote = notes.find((n) => n.championName === yourChampionName);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium flex items-center gap-2">
+          <StickyNote className="h-4 w-4 text-gold" />
+          {t("readOnlyTitle")}
+        </h3>
+        <a
+          href={`/scout?enemy=${encodeURIComponent(matchupChampionName)}&your=${encodeURIComponent(yourChampionName)}`}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {t("viewInScout")}
+        </a>
+      </div>
+
+      <div className="space-y-2">
+        {specificNote && (
+          <div className="rounded-lg border border-border/50 bg-surface-elevated p-3">
+            <p className="text-xs font-medium text-muted-foreground">
+              {t("specificNoteTitle", {
+                champion: yourChampionName,
+                enemy: matchupChampionName,
+              })}
+            </p>
+            <p className="text-sm mt-1 whitespace-pre-wrap">
+              {specificNote.content}
+            </p>
+            <p className="text-[10px] text-muted-foreground/70 mt-2">
+              {t("savedAt", { date: formatDate(specificNote.updatedAt, locale) })}
+            </p>
+          </div>
+        )}
+
+        {generalNote && (
+          <div className="rounded-lg border border-border/50 bg-surface-elevated p-3">
+            <p className="text-xs font-medium text-muted-foreground">
+              {t("generalNoteTitle", { enemy: matchupChampionName })}
+            </p>
+            <p className="text-sm mt-1 whitespace-pre-wrap">
+              {generalNote.content}
+            </p>
+            <p className="text-[10px] text-muted-foreground/70 mt-2">
+              {t("savedAt", { date: formatDate(generalNote.updatedAt, locale) })}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/scout/matchup-notes.tsx
+++ b/src/app/(app)/scout/matchup-notes.tsx
@@ -210,7 +210,9 @@ export function MatchupNotesSection({
     onNotesChanged?.();
   }, [onNotesChanged]);
 
-  const hasAnyNote = !!generalNote?.content || !!specificNote?.content;
+  const hasAnyNote = yourChampionName
+    ? !!specificNote?.content
+    : !!generalNote?.content;
 
   return (
     <div className="space-y-2">
@@ -223,8 +225,8 @@ export function MatchupNotesSection({
       </h3>
 
       <div className="space-y-2 rounded-lg border border-border/30 bg-surface-elevated/50 p-3">
-        {/* Champion-specific note — shown prominently when Your Champion is set */}
-        {yourChampionName && (
+        {yourChampionName ? (
+          /* Champion-specific note only when Your Champion is set */
           <InlineNoteEditor
             note={specificNote}
             title={t("specificNoteTitle", {
@@ -237,23 +239,18 @@ export function MatchupNotesSection({
             onSaved={handleSaved}
             defaultExpanded
           />
+        ) : (
+          /* General note only when Any Champion is selected */
+          <InlineNoteEditor
+            note={generalNote}
+            title={t("generalNoteTitle", { enemy: matchupChampionName })}
+            championName={null}
+            matchupChampionName={matchupChampionName}
+            locale={locale}
+            onSaved={handleSaved}
+            defaultExpanded
+          />
         )}
-
-        {/* Separator between notes when both are shown */}
-        {yourChampionName && (
-          <div className="border-t border-border/20" />
-        )}
-
-        {/* General note — secondary (collapsed by default) when specific note exists */}
-        <InlineNoteEditor
-          note={generalNote}
-          title={t("generalNoteTitle", { enemy: matchupChampionName })}
-          championName={null}
-          matchupChampionName={matchupChampionName}
-          locale={locale}
-          onSaved={handleSaved}
-          defaultExpanded={!yourChampionName}
-        />
       </div>
     </div>
   );

--- a/src/app/(app)/scout/matchup-notes.tsx
+++ b/src/app/(app)/scout/matchup-notes.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition, useCallback } from "react";
 import { useTranslations } from "next-intl";
-import { MessageSquareText, Pencil, Trash2, ChevronDown } from "lucide-react";
+import { MessageSquareText, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
@@ -13,32 +13,27 @@ import {
 } from "@/app/actions/matchup-notes";
 import { formatDate } from "@/lib/format";
 
-// ─── Inline Note Editor ─────────────────────────────────────────────────────
+// ─── Note Editor Panel (shown when bubble is open) ──────────────────────────
 
-function InlineNoteEditor({
+function NoteEditorPanel({
   note,
-  title,
   championName,
   matchupChampionName,
   locale,
   onSaved,
-  defaultExpanded,
+  onClose,
 }: {
   note: MatchupNoteData | null;
-  title: string;
   championName: string | null;
   matchupChampionName: string;
   locale: string;
   onSaved: () => void;
-  defaultExpanded?: boolean;
+  onClose: () => void;
 }) {
   const t = useTranslations("MatchupNotes");
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded ?? false);
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(!note?.content);
   const [content, setContent] = useState(note?.content ?? "");
   const [isSaving, startSaveTransition] = useTransition();
-
-  const hasContent = !!note?.content;
 
   const handleSave = useCallback(() => {
     startSaveTransition(async () => {
@@ -51,11 +46,13 @@ function InlineNoteEditor({
         toast.success(content.trim() ? t("toasts.saved") : t("toasts.deleted"));
         setIsEditing(false);
         onSaved();
+        // Close if saved empty (deleted)
+        if (!content.trim()) onClose();
       } else {
         toast.error(result.error ?? t("toasts.saveError"));
       }
     });
-  }, [championName, matchupChampionName, content, t, onSaved]);
+  }, [championName, matchupChampionName, content, t, onSaved, onClose]);
 
   const handleDelete = useCallback(() => {
     if (!note) return;
@@ -66,22 +63,25 @@ function InlineNoteEditor({
         setContent("");
         setIsEditing(false);
         onSaved();
+        onClose();
       } else {
         toast.error(t("toasts.deleteError"));
       }
     });
-  }, [note, t, onSaved]);
+  }, [note, t, onSaved, onClose]);
 
   const handleCancel = useCallback(() => {
     setContent(note?.content ?? "");
-    setIsEditing(false);
-  }, [note]);
+    if (note?.content) {
+      setIsEditing(false);
+    } else {
+      onClose();
+    }
+  }, [note, onClose]);
 
-  // Editing mode — inline textarea
   if (isEditing) {
     return (
-      <div className="space-y-2">
-        <p className="text-xs font-medium text-muted-foreground">{title}</p>
+      <div className="rounded-lg border border-border/40 bg-surface-elevated p-3 space-y-2 mt-3">
         <Textarea
           value={content}
           onChange={(e) => setContent(e.target.value)}
@@ -117,74 +117,28 @@ function InlineNoteEditor({
     );
   }
 
-  // Collapsed — just a clickable row
-  if (!isExpanded && hasContent) {
-    return (
-      <button
-        className="flex items-center gap-2 w-full text-left group"
-        onClick={() => setIsExpanded(true)}
-      >
-        <ChevronDown className="h-3 w-3 text-muted-foreground -rotate-90 transition-transform group-hover:rotate-0" />
-        <span className="text-xs font-medium text-muted-foreground truncate flex-1">
-          {title}
-        </span>
-        <span className="text-[10px] text-muted-foreground/60">
-          {formatDate(note!.updatedAt, locale)}
-        </span>
-      </button>
-    );
-  }
-
-  // Expanded or empty — show content + edit trigger
+  // Read mode — show content, click to edit
   return (
-    <div className="space-y-1">
-      <div className="flex items-center justify-between">
-        <button
-          className="flex items-center gap-2 text-left group"
-          onClick={() => hasContent && setIsExpanded(false)}
-        >
-          {hasContent && (
-            <ChevronDown className="h-3 w-3 text-muted-foreground transition-transform" />
-          )}
-          <span className="text-xs font-medium text-muted-foreground">
-            {title}
-          </span>
-        </button>
-        <button
-          className="text-muted-foreground/50 hover:text-foreground transition-colors"
-          onClick={() => setIsEditing(true)}
-          title={t("editTooltip")}
-        >
-          <Pencil className="h-3 w-3" />
-        </button>
-      </div>
-      {hasContent ? (
-        <div
-          className="text-sm text-muted-foreground whitespace-pre-wrap pl-5 cursor-pointer hover:text-foreground transition-colors"
-          onClick={() => setIsEditing(true)}
-          role="button"
-          tabIndex={0}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") setIsEditing(true);
-          }}
-        >
-          {note!.content}
-        </div>
-      ) : (
-        <button
-          className="text-xs text-muted-foreground/40 italic hover:text-muted-foreground transition-colors pl-5"
-          onClick={() => setIsEditing(true)}
-        >
-          {t("addNotes")}
-        </button>
-      )}
+    <div
+      className="rounded-lg border border-border/40 bg-surface-elevated p-3 mt-3 cursor-pointer hover:border-border/60 transition-colors"
+      onClick={() => setIsEditing(true)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") setIsEditing(true);
+      }}
+    >
+      <p className="text-sm whitespace-pre-wrap">{note!.content}</p>
+      <p className="text-[10px] text-muted-foreground/50 mt-1.5">
+        {t("savedAt", { date: formatDate(note!.updatedAt, locale) })}
+      </p>
     </div>
   );
 }
 
-// ─── Matchup Notes Section (for Scout page) ─────────────────────────────────
+// ─── Matchup Notes Bubble (for Scout page header) ───────────────────────────
 
-interface MatchupNotesSectionProps {
+interface MatchupNotesBubbleProps {
   notes: MatchupNoteData[];
   matchupChampionName: string;
   yourChampionName?: string;
@@ -192,66 +146,53 @@ interface MatchupNotesSectionProps {
   onNotesChanged?: () => void;
 }
 
-export function MatchupNotesSection({
+export function MatchupNotesBubble({
   notes,
   matchupChampionName,
   yourChampionName,
   locale,
   onNotesChanged,
-}: MatchupNotesSectionProps) {
+}: MatchupNotesBubbleProps) {
   const t = useTranslations("MatchupNotes");
+  const [isOpen, setIsOpen] = useState(false);
 
   const generalNote = notes.find((n) => n.championName === null) ?? null;
   const specificNote = yourChampionName
     ? notes.find((n) => n.championName === yourChampionName) ?? null
     : null;
 
+  // Pick the active note based on champion selection
+  const activeNote = yourChampionName ? specificNote : generalNote;
+  const activeChampionName = yourChampionName ?? null;
+  const hasNote = !!activeNote?.content;
+
   const handleSaved = useCallback(() => {
     onNotesChanged?.();
   }, [onNotesChanged]);
 
-  const hasAnyNote = yourChampionName
-    ? !!specificNote?.content
-    : !!generalNote?.content;
-
   return (
-    <div className="space-y-2">
-      <h3 className="text-xs font-medium flex items-center gap-1.5 text-muted-foreground">
-        <MessageSquareText className="h-3.5 w-3.5 text-gold" />
-        {t("sectionTitle")}
-        {hasAnyNote && (
-          <span className="inline-block h-1.5 w-1.5 rounded-full bg-gold" />
+    <div>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="relative p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-surface-elevated transition-colors"
+        title={t("sectionTitle")}
+      >
+        <MessageSquareText className="h-4 w-4" />
+        {hasNote && (
+          <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-gold" />
         )}
-      </h3>
+      </button>
 
-      <div className="space-y-2 rounded-lg border border-border/30 bg-surface-elevated/50 p-3">
-        {yourChampionName ? (
-          /* Champion-specific note only when Your Champion is set */
-          <InlineNoteEditor
-            note={specificNote}
-            title={t("specificNoteTitle", {
-              champion: yourChampionName,
-              enemy: matchupChampionName,
-            })}
-            championName={yourChampionName}
-            matchupChampionName={matchupChampionName}
-            locale={locale}
-            onSaved={handleSaved}
-            defaultExpanded
-          />
-        ) : (
-          /* General note only when Any Champion is selected */
-          <InlineNoteEditor
-            note={generalNote}
-            title={t("generalNoteTitle", { enemy: matchupChampionName })}
-            championName={null}
-            matchupChampionName={matchupChampionName}
-            locale={locale}
-            onSaved={handleSaved}
-            defaultExpanded
-          />
-        )}
-      </div>
+      {isOpen && (
+        <NoteEditorPanel
+          note={activeNote}
+          championName={activeChampionName}
+          matchupChampionName={matchupChampionName}
+          locale={locale}
+          onSaved={handleSaved}
+          onClose={() => setIsOpen(false)}
+        />
+      )}
     </div>
   );
 }
@@ -302,7 +243,7 @@ export function ReadOnlyMatchupNotes({
                 enemy: matchupChampionName,
               })}
             </p>
-            <p className="text-sm mt-1 whitespace-pre-wrap pl-0">
+            <p className="text-sm mt-1 whitespace-pre-wrap">
               {specificNote.content}
             </p>
             <p className="text-[10px] text-muted-foreground/60 mt-1">
@@ -320,7 +261,7 @@ export function ReadOnlyMatchupNotes({
             <p className="text-xs font-medium text-muted-foreground">
               {t("generalNoteTitle", { enemy: matchupChampionName })}
             </p>
-            <p className="text-sm mt-1 whitespace-pre-wrap pl-0">
+            <p className="text-sm mt-1 whitespace-pre-wrap">
               {generalNote.content}
             </p>
             <p className="text-[10px] text-muted-foreground/60 mt-1">

--- a/src/app/(app)/scout/scout-client.tsx
+++ b/src/app/(app)/scout/scout-client.tsx
@@ -9,6 +9,11 @@ import {
   getMatchupReport,
   type MatchupReport,
 } from "@/app/actions/live";
+import {
+  getMatchupNotes,
+  type MatchupNoteData,
+} from "@/app/actions/matchup-notes";
+import { MatchupNotesSection } from "./matchup-notes";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Progress } from "@/components/ui/progress";
@@ -69,10 +74,14 @@ function ScoutingReport({
   report,
   ddragonVersion,
   locale,
+  matchupNotes,
+  yourChampionName,
 }: {
   report: MatchupReport;
   ddragonVersion: string;
   locale: string;
+  matchupNotes: MatchupNoteData[];
+  yourChampionName?: string;
 }) {
   const { record, runeBreakdown, avgStats, overallAvgStats, duoPairs, games } = report;
   const t = useTranslations("Scout");
@@ -117,6 +126,16 @@ function ScoutingReport({
           )}
         </div>
       </div>
+
+      <Separator />
+
+      {/* Matchup Notes */}
+      <MatchupNotesSection
+        notes={matchupNotes}
+        matchupChampionName={report.matchupChampionName}
+        yourChampionName={yourChampionName}
+        locale={locale}
+      />
 
       <Separator />
 
@@ -375,6 +394,7 @@ export function ScoutClient({
   const [yourChampion, setYourChampion] = useState<string>(initialYourChampion);
   const [enemyChampion, setEnemyChampion] = useState<string>(initialEnemyChampion);
   const [report, setReport] = useState<MatchupReport | null>(null);
+  const [matchupNotesList, setMatchupNotesList] = useState<MatchupNoteData[]>([]);
   const [isLoadingReport, startReportTransition] = useTransition();
 
   // Sync URL params -> local state when browser back/forward navigation occurs
@@ -393,6 +413,7 @@ export function ScoutClient({
         loadReport(urlEnemy, urlYour || undefined);
       } else {
         setReport(null);
+        setMatchupNotesList([]);
       }
     }
     // Only react to searchParams changes (browser navigation)
@@ -433,12 +454,17 @@ export function ScoutClient({
     (enemy: string, yours?: string) => {
       if (!enemy) {
         setReport(null);
+        setMatchupNotesList([]);
         return;
       }
       startReportTransition(async () => {
         try {
-          const result = await getMatchupReport(enemy, yours || undefined);
+          const [result, notes] = await Promise.all([
+            getMatchupReport(enemy, yours || undefined),
+            getMatchupNotes(enemy, yours || undefined),
+          ]);
           setReport(result);
+          setMatchupNotesList(notes);
         } catch {
           toast.error(t("toasts.failedToLoadReport"));
         }
@@ -525,23 +551,39 @@ export function ScoutClient({
 
       {/* Scouting report */}
       {!isLoadingReport && report && (
-        <ScoutingReport report={report} ddragonVersion={ddragonVersion} locale={locale} />
+        <ScoutingReport
+          report={report}
+          ddragonVersion={ddragonVersion}
+          locale={locale}
+          matchupNotes={matchupNotesList}
+          yourChampionName={yourChampion || undefined}
+        />
       )}
 
       {/* No historical data state */}
       {!isLoadingReport && !report && enemyChampion && (
-        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-12 text-center">
-          <Swords className="h-8 w-8 text-muted-foreground mb-2" />
-          <p className="text-muted-foreground">
-            {yourChampion
-              ? t("noGamesFoundAsChampion", { yourChampion, enemyChampion })
-              : t("noGamesFound", { enemyChampion })}
-          </p>
-          {yourChampion && (
-            <p className="text-sm text-muted-foreground mt-1">
-              {t("clearYourChampionHint")}
+        <div className="space-y-6">
+          <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-12 text-center">
+            <Swords className="h-8 w-8 text-muted-foreground mb-2" />
+            <p className="text-muted-foreground">
+              {yourChampion
+                ? t("noGamesFoundAsChampion", { yourChampion, enemyChampion })
+                : t("noGamesFound", { enemyChampion })}
             </p>
-          )}
+            {yourChampion && (
+              <p className="text-sm text-muted-foreground mt-1">
+                {t("clearYourChampionHint")}
+              </p>
+            )}
+          </div>
+
+          {/* Still show matchup notes even without match history */}
+          <MatchupNotesSection
+            notes={matchupNotesList}
+            matchupChampionName={enemyChampion}
+            yourChampionName={yourChampion || undefined}
+            locale={locale}
+          />
         </div>
       )}
 

--- a/src/app/(app)/scout/scout-client.tsx
+++ b/src/app/(app)/scout/scout-client.tsx
@@ -555,14 +555,16 @@ export function ScoutClient({
   );
 
   /** Re-fetch only notes (called after save/delete) */
-  const refreshNotes = useCallback(async () => {
+  const refreshNotes = useCallback(() => {
     if (!enemyChampion) return;
-    try {
-      const notes = await getMatchupNotes(enemyChampion, yourChampion || undefined);
-      setMatchupNotesList(notes);
-    } catch {
-      // silent — the notes just won't refresh
-    }
+    startReportTransition(async () => {
+      try {
+        const notes = await getMatchupNotes(enemyChampion, yourChampion || undefined);
+        setMatchupNotesList(notes);
+      } catch {
+        // silent — the notes just won't refresh
+      }
+    });
   }, [enemyChampion, yourChampion]);
 
   // Auto-load report on mount if initial champions are provided via URL params

--- a/src/app/(app)/scout/scout-client.tsx
+++ b/src/app/(app)/scout/scout-client.tsx
@@ -76,12 +76,14 @@ function ScoutingReport({
   locale,
   matchupNotes,
   yourChampionName,
+  onNotesChanged,
 }: {
   report: MatchupReport;
   ddragonVersion: string;
   locale: string;
   matchupNotes: MatchupNoteData[];
   yourChampionName?: string;
+  onNotesChanged?: () => void;
 }) {
   const { record, runeBreakdown, avgStats, overallAvgStats, duoPairs, games } = report;
   const t = useTranslations("Scout");
@@ -100,13 +102,33 @@ function ScoutingReport({
     <div className="space-y-6">
       {/* Header: Record summary */}
       <div className="flex items-center gap-4">
-        <ChampionIcon
-          championName={report.matchupChampionName}
-          version={ddragonVersion}
-          size={56}
-        />
+        {yourChampionName ? (
+          <div className="flex items-center gap-2">
+            <ChampionIcon
+              championName={yourChampionName}
+              version={ddragonVersion}
+              size={48}
+            />
+            <span className="text-muted-foreground text-sm font-medium">{t("vs")}</span>
+            <ChampionIcon
+              championName={report.matchupChampionName}
+              version={ddragonVersion}
+              size={48}
+            />
+          </div>
+        ) : (
+          <ChampionIcon
+            championName={report.matchupChampionName}
+            version={ddragonVersion}
+            size={56}
+          />
+        )}
         <div>
-          <h2 className="text-xl font-bold">{t("vs")} {report.matchupChampionName}</h2>
+          <h2 className="text-xl font-bold">
+            {yourChampionName
+              ? `${yourChampionName} ${t("vs")} ${report.matchupChampionName}`
+              : `${t("vs")} ${report.matchupChampionName}`}
+          </h2>
           <div className="flex items-center gap-3 mt-1">
             <span className="text-lg font-mono">
               <span className="text-win">{record.wins}W</span>{" "}
@@ -135,6 +157,7 @@ function ScoutingReport({
         matchupChampionName={report.matchupChampionName}
         yourChampionName={yourChampionName}
         locale={locale}
+        onNotesChanged={onNotesChanged}
       />
 
       <Separator />
@@ -473,6 +496,17 @@ export function ScoutClient({
     [t]
   );
 
+  /** Re-fetch only notes (called after save/delete) */
+  const refreshNotes = useCallback(async () => {
+    if (!enemyChampion) return;
+    try {
+      const notes = await getMatchupNotes(enemyChampion, yourChampion || undefined);
+      setMatchupNotesList(notes);
+    } catch {
+      // silent — the notes just won't refresh
+    }
+  }, [enemyChampion, yourChampion]);
+
   // Auto-load report on mount if initial champions are provided via URL params
   useEffect(() => {
     if (initialEnemyChampion) {
@@ -557,6 +591,7 @@ export function ScoutClient({
           locale={locale}
           matchupNotes={matchupNotesList}
           yourChampionName={yourChampion || undefined}
+          onNotesChanged={refreshNotes}
         />
       )}
 
@@ -583,6 +618,7 @@ export function ScoutClient({
             matchupChampionName={enemyChampion}
             yourChampionName={yourChampion || undefined}
             locale={locale}
+            onNotesChanged={refreshNotes}
           />
         </div>
       )}

--- a/src/app/(app)/scout/scout-client.tsx
+++ b/src/app/(app)/scout/scout-client.tsx
@@ -13,7 +13,7 @@ import {
   getMatchupNotes,
   type MatchupNoteData,
 } from "@/app/actions/matchup-notes";
-import { MatchupNotesSection } from "./matchup-notes";
+import { MatchupNotesBubble } from "./matchup-notes";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Progress } from "@/components/ui/progress";
@@ -123,12 +123,21 @@ function ScoutingReport({
             size={56}
           />
         )}
-        <div>
-          <h2 className="text-xl font-bold">
-            {yourChampionName
-              ? `${yourChampionName} ${t("vs")} ${report.matchupChampionName}`
-              : `${t("vs")} ${report.matchupChampionName}`}
-          </h2>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h2 className="text-xl font-bold">
+              {yourChampionName
+                ? `${yourChampionName} ${t("vs")} ${report.matchupChampionName}`
+                : `${t("vs")} ${report.matchupChampionName}`}
+            </h2>
+            <MatchupNotesBubble
+              notes={matchupNotes}
+              matchupChampionName={report.matchupChampionName}
+              yourChampionName={yourChampionName}
+              locale={locale}
+              onNotesChanged={onNotesChanged}
+            />
+          </div>
           <div className="flex items-center gap-3 mt-1">
             <span className="text-lg font-mono">
               <span className="text-win">{record.wins}W</span>{" "}
@@ -148,17 +157,6 @@ function ScoutingReport({
           )}
         </div>
       </div>
-
-      <Separator />
-
-      {/* Matchup Notes */}
-      <MatchupNotesSection
-        notes={matchupNotes}
-        matchupChampionName={report.matchupChampionName}
-        yourChampionName={yourChampionName}
-        locale={locale}
-        onNotesChanged={onNotesChanged}
-      />
 
       <Separator />
 
@@ -612,8 +610,8 @@ export function ScoutClient({
             )}
           </div>
 
-          {/* Still show matchup notes even without match history */}
-          <MatchupNotesSection
+          {/* Still allow adding notes even without match history */}
+          <MatchupNotesBubble
             notes={matchupNotesList}
             matchupChampionName={enemyChampion}
             yourChampionName={yourChampion || undefined}

--- a/src/app/(app)/scout/scout-client.tsx
+++ b/src/app/(app)/scout/scout-client.tsx
@@ -13,7 +13,7 @@ import {
   getMatchupNotes,
   type MatchupNoteData,
 } from "@/app/actions/matchup-notes";
-import { MatchupNotesBubble } from "./matchup-notes";
+import { MatchupNotesTrigger, MatchupNotesPanel, pickActiveNote } from "./matchup-notes";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Progress } from "@/components/ui/progress";
@@ -87,6 +87,10 @@ function ScoutingReport({
 }) {
   const { record, runeBreakdown, avgStats, overallAvgStats, duoPairs, games } = report;
   const t = useTranslations("Scout");
+  const [notesOpen, setNotesOpen] = useState(false);
+
+  const { activeNote, activeChampionName } = pickActiveNote(matchupNotes, yourChampionName);
+  const hasNote = !!activeNote?.content;
 
   // Compute matchup KDA ratio for comparison
   const matchupKdaRatio =
@@ -101,61 +105,75 @@ function ScoutingReport({
   return (
     <div className="space-y-6">
       {/* Header: Record summary */}
-      <div className="flex items-center gap-4">
-        {yourChampionName ? (
-          <div className="flex items-center gap-2">
-            <ChampionIcon
-              championName={yourChampionName}
-              version={ddragonVersion}
-              size={48}
-            />
-            <span className="text-muted-foreground text-sm font-medium">{t("vs")}</span>
+      <div>
+        <div className="flex items-center gap-4">
+          {yourChampionName ? (
+            <div className="flex items-center gap-2">
+              <ChampionIcon
+                championName={yourChampionName}
+                version={ddragonVersion}
+                size={48}
+              />
+              <span className="text-muted-foreground text-sm font-medium">{t("vs")}</span>
+              <ChampionIcon
+                championName={report.matchupChampionName}
+                version={ddragonVersion}
+                size={48}
+              />
+            </div>
+          ) : (
             <ChampionIcon
               championName={report.matchupChampionName}
               version={ddragonVersion}
-              size={48}
+              size={56}
             />
-          </div>
-        ) : (
-          <ChampionIcon
-            championName={report.matchupChampionName}
-            version={ddragonVersion}
-            size={56}
-          />
-        )}
-        <div className="flex-1">
-          <div className="flex items-center gap-2">
-            <h2 className="text-xl font-bold">
-              {yourChampionName
-                ? `${yourChampionName} ${t("vs")} ${report.matchupChampionName}`
-                : `${t("vs")} ${report.matchupChampionName}`}
-            </h2>
-            <MatchupNotesBubble
-              notes={matchupNotes}
-              matchupChampionName={report.matchupChampionName}
-              yourChampionName={yourChampionName}
-              locale={locale}
-              onNotesChanged={onNotesChanged}
-            />
-          </div>
-          <div className="flex items-center gap-3 mt-1">
-            <span className="text-lg font-mono">
-              <span className="text-win">{record.wins}W</span>{" "}
-              <span className="text-loss">{record.losses}L</span>
-            </span>
-            <Badge
-              variant={record.winRate >= 50 ? "default" : "destructive"}
-              className="text-sm"
-            >
-              {record.winRate}%
-            </Badge>
-          </div>
-          {report.lastPlayed && (
-            <p className="text-xs text-muted-foreground mt-1">
-              {t("lastPlayed", { date: formatDate(report.lastPlayed, locale) })}
-            </p>
           )}
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <h2 className="text-xl font-bold">
+                {yourChampionName
+                  ? `${yourChampionName} ${t("vs")} ${report.matchupChampionName}`
+                  : `${t("vs")} ${report.matchupChampionName}`}
+              </h2>
+              <MatchupNotesTrigger
+                hasNote={hasNote}
+                isOpen={notesOpen}
+                onToggle={() => setNotesOpen(!notesOpen)}
+              />
+            </div>
+            <div className="flex items-center gap-3 mt-1">
+              <span className="text-lg font-mono">
+                <span className="text-win">{record.wins}W</span>{" "}
+                <span className="text-loss">{record.losses}L</span>
+              </span>
+              <Badge
+                variant={record.winRate >= 50 ? "default" : "destructive"}
+                className="text-sm"
+              >
+                {record.winRate}%
+              </Badge>
+            </div>
+            {report.lastPlayed && (
+              <p className="text-xs text-muted-foreground mt-1">
+                {t("lastPlayed", { date: formatDate(report.lastPlayed, locale) })}
+              </p>
+            )}
+          </div>
         </div>
+
+        {/* Notes panel — renders below the header row */}
+        {notesOpen && (
+          <div className="mt-3">
+            <MatchupNotesPanel
+              note={activeNote}
+              championName={activeChampionName}
+              matchupChampionName={report.matchupChampionName}
+              locale={locale}
+              onSaved={() => onNotesChanged?.()}
+              onClose={() => setNotesOpen(false)}
+            />
+          </div>
+        )}
       </div>
 
       <Separator />
@@ -396,6 +414,48 @@ function StatCell({
   );
 }
 
+// ─── Standalone Notes Bubble (for no-data state) ────────────────────────────
+
+function NoDataNotesBubble({
+  notes,
+  matchupChampionName,
+  yourChampionName,
+  locale,
+  onNotesChanged,
+}: {
+  notes: MatchupNoteData[];
+  matchupChampionName: string;
+  yourChampionName?: string;
+  locale: string;
+  onNotesChanged?: () => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { activeNote, activeChampionName } = pickActiveNote(notes, yourChampionName);
+  const hasNote = !!activeNote?.content;
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <MatchupNotesTrigger
+        hasNote={hasNote}
+        isOpen={isOpen}
+        onToggle={() => setIsOpen(!isOpen)}
+      />
+      {isOpen && (
+        <div className="w-full">
+          <MatchupNotesPanel
+            note={activeNote}
+            championName={activeChampionName}
+            matchupChampionName={matchupChampionName}
+            locale={locale}
+            onSaved={() => onNotesChanged?.()}
+            onClose={() => setIsOpen(false)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── Main Scout Client ──────────────────────────────────────────────────────
 
 export function ScoutClient({
@@ -611,7 +671,7 @@ export function ScoutClient({
           </div>
 
           {/* Still allow adding notes even without match history */}
-          <MatchupNotesBubble
+          <NoDataNotesBubble
             notes={matchupNotesList}
             matchupChampionName={enemyChampion}
             yourChampionName={yourChampion || undefined}

--- a/src/app/actions/matchup-notes.ts
+++ b/src/app/actions/matchup-notes.ts
@@ -1,0 +1,176 @@
+"use server";
+
+import { db } from "@/db";
+import { matchupNotes } from "@/db/schema";
+import { eq, and, isNull } from "drizzle-orm";
+import { requireUser } from "@/lib/session";
+import { revalidateTag } from "next/cache";
+import { scoutTag } from "@/lib/cache";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface MatchupNoteData {
+  id: number;
+  championName: string | null;
+  matchupChampionName: string;
+  content: string;
+  updatedAt: Date;
+  createdAt: Date;
+}
+
+// ─── Queries ────────────────────────────────────────────────────────────────
+
+/**
+ * Get matchup notes for a given enemy champion.
+ * Returns both general notes (championName = null) and champion-specific notes.
+ */
+export async function getMatchupNotes(
+  matchupChampionName: string,
+  championName?: string
+): Promise<MatchupNoteData[]> {
+  const user = await requireUser();
+
+  const conditions = [
+    eq(matchupNotes.userId, user.id),
+    eq(matchupNotes.matchupChampionName, matchupChampionName),
+  ];
+
+  const rows = await db
+    .select()
+    .from(matchupNotes)
+    .where(and(...conditions))
+    .orderBy(matchupNotes.championName); // null (general) sorts first
+
+  // If a specific champion is selected, return both general + that champion's note
+  // If no champion, return only general notes
+  const filtered = championName
+    ? rows.filter((r) => r.championName === null || r.championName === championName)
+    : rows.filter((r) => r.championName === null);
+
+  return filtered.map((r) => ({
+    id: r.id,
+    championName: r.championName,
+    matchupChampionName: r.matchupChampionName,
+    content: r.content,
+    updatedAt: r.updatedAt,
+    createdAt: r.createdAt,
+  }));
+}
+
+/**
+ * Get matchup notes for a match detail page.
+ * Returns notes relevant to the given champion vs enemy matchup.
+ */
+export async function getMatchupNotesForMatch(
+  championName: string,
+  matchupChampionName: string
+): Promise<MatchupNoteData[]> {
+  const user = await requireUser();
+
+  const rows = await db
+    .select()
+    .from(matchupNotes)
+    .where(
+      and(
+        eq(matchupNotes.userId, user.id),
+        eq(matchupNotes.matchupChampionName, matchupChampionName),
+      )
+    )
+    .orderBy(matchupNotes.championName);
+
+  // Return both general notes and notes specific to this champion
+  const filtered = rows.filter(
+    (r) => r.championName === null || r.championName === championName
+  );
+
+  return filtered.map((r) => ({
+    id: r.id,
+    championName: r.championName,
+    matchupChampionName: r.matchupChampionName,
+    content: r.content,
+    updatedAt: r.updatedAt,
+    createdAt: r.createdAt,
+  }));
+}
+
+// ─── Mutations ──────────────────────────────────────────────────────────────
+
+/**
+ * Upsert a matchup note. If content is empty/blank, deletes the note instead.
+ * Uses ON CONFLICT (userId, championName, matchupChampionName) DO UPDATE.
+ */
+export async function upsertMatchupNote(
+  championName: string | null,
+  matchupChampionName: string,
+  content: string
+): Promise<{ success: boolean; error?: string }> {
+  const user = await requireUser();
+  const trimmed = content.trim();
+
+  if (!matchupChampionName.trim()) {
+    return { success: false, error: "Enemy champion is required." };
+  }
+
+  // If content is empty, delete the note
+  if (!trimmed) {
+    // Find and delete the matching note
+    const conditions = [
+      eq(matchupNotes.userId, user.id),
+      eq(matchupNotes.matchupChampionName, matchupChampionName),
+    ];
+    if (championName) {
+      conditions.push(eq(matchupNotes.championName, championName));
+    } else {
+      conditions.push(isNull(matchupNotes.championName));
+    }
+
+    await db.delete(matchupNotes).where(and(...conditions));
+    revalidateTag(scoutTag(user.id), "max");
+    return { success: true };
+  }
+
+  // Upsert: insert or update on conflict
+  const now = new Date();
+  await db
+    .insert(matchupNotes)
+    .values({
+      userId: user.id,
+      championName: championName || null,
+      matchupChampionName,
+      content: trimmed,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        matchupNotes.userId,
+        matchupNotes.championName,
+        matchupNotes.matchupChampionName,
+      ],
+      set: {
+        content: trimmed,
+        updatedAt: now,
+      },
+    });
+
+  revalidateTag(scoutTag(user.id), "max");
+  return { success: true };
+}
+
+/**
+ * Delete a matchup note by ID (ownership-checked).
+ */
+export async function deleteMatchupNote(
+  id: number
+): Promise<{ success: boolean; error?: string }> {
+  const user = await requireUser();
+
+  await db
+    .delete(matchupNotes)
+    .where(
+      and(eq(matchupNotes.id, id), eq(matchupNotes.userId, user.id))
+    );
+
+  revalidateTag(scoutTag(user.id), "max");
+  return { success: true };
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -232,6 +232,31 @@ export const goals = sqliteTable("goals", {
   index("goals_user_status_idx").on(table.userId, table.status),
 ]);
 
+// ─── Matchup Notes ──────────────────────────────────────────────────────────
+
+export const matchupNotes = sqliteTable("matchup_notes", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  championName: text("champion_name"), // null = general note for this enemy
+  matchupChampionName: text("matchup_champion_name").notNull(), // the enemy champion
+  content: text("content").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  unique("matchup_notes_user_champ_matchup_unq").on(
+    table.userId,
+    table.championName,
+    table.matchupChampionName
+  ),
+  index("matchup_notes_user_matchup_idx").on(table.userId, table.matchupChampionName),
+]);
+
 // ─── Type Exports ────────────────────────────────────────────────────────────
 
 export type Match = typeof matches.$inferSelect;
@@ -241,3 +266,4 @@ export type RankSnapshot = typeof rankSnapshots.$inferSelect;
 export type CoachingSession = typeof coachingSessions.$inferSelect;
 export type CoachingActionItem = typeof coachingActionItems.$inferSelect;
 export type Goal = typeof goals.$inferSelect;
+export type MatchupNote = typeof matchupNotes.$inferSelect;


### PR DESCRIPTION
## Summary

- Add persistent per-champion-matchup notes on the Scout page — both champion-specific ("Yone vs Syndra") and general ("vs Syndra") note types
- Inline editing with read/edit modes, auto-save on upsert, and delete support
- Read-only matchup notes reference on match detail pages with "View in Scout" link
- Notes are available even when no match history exists for a matchup

## Details

**Data model:** New `matchup_notes` table with unique constraint on `(userId, championName, matchupChampionName)`. A null `championName` represents a general note for that enemy.

**Server actions:** `upsertMatchupNote` (ON CONFLICT DO UPDATE, deletes on empty content), `deleteMatchupNote` (ownership-checked), `getMatchupNotes`, `getMatchupNotesForMatch`. All mutations invalidate `scoutTag(userId)`.

**Scout page:** "Matchup Notes" section between record summary and rune performance. When "Your Champion" is selected, shows both champion-specific and general note cards. Also shown in the "no match history" state.

**Match detail page:** Read-only card after highlights section, showing relevant notes for the champion vs opponent pairing.

**i18n:** `MatchupNotes` namespace in EN and ES.

**Docs:** Updated `AGENTS.md` and `vercel-turso-deploy` skill to reflect that migrations are auto-applied on deploy via `scripts/migrate.ts`.

Fixes #8