### PR TITLE
feat: AI-powered matchup and post-game insights (Gemini)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ RIOT_API_KEY=
 TURSO_DATABASE_URL=
 TURSO_AUTH_TOKEN=
 
+# Google Gemini AI — https://aistudio.google.com/apikey
+# Used for AI-powered insights (matchup advice, post-game analysis)
+# Free tier: 15 req/min, 1M tokens/day
+GOOGLE_GENERATIVE_AI_API_KEY=
+
 # ─── Demo / Preview Mode ─────────────────────────────────────────────────────
 # Set to "true" to enable demo mode:
 #   - Fake auth (no Discord OAuth required)

--- a/changelog/en/2026-03-27-ai-insights.mdx
+++ b/changelog/en/2026-03-27-ai-insights.mdx
@@ -1,0 +1,13 @@
+---
+version: "2026.03.11"
+date: "2026-03-27"
+title: "AI-Powered Insights"
+tags: ["feature"]
+---
+
+Get personalized coaching advice powered by Google Gemini AI, right where you need it.
+
+- **Matchup insights** — on the Scout page, generate AI advice tailored to your matchup history, rune performance, and personal notes
+- **Post-game analysis** — on any match detail page, get an AI review of your performance with actionable tips based on your stats, highlights, and goals
+- **Smart caching** — insights are stored in the database so you only pay for a generation once per matchup or match. Regenerate anytime with one click
+- **Daily limit** — 10 AI generations per day to stay within the free tier. Cached results don't count against the limit

--- a/changelog/es/2026-03-27-ai-insights.mdx
+++ b/changelog/es/2026-03-27-ai-insights.mdx
@@ -1,0 +1,13 @@
+---
+version: "2026.03.11"
+date: "2026-03-27"
+title: "Análisis con IA"
+tags: ["feature"]
+---
+
+Recibe consejos de coaching personalizados con Google Gemini AI, justo donde los necesitas.
+
+- **Análisis de matchup** — en la página de Scout, genera consejos de IA adaptados a tu historial de matchup, rendimiento con runas y notas personales
+- **Análisis post-partida** — en cualquier página de detalle de partida, obtén una revisión de IA de tu rendimiento con consejos prácticos basados en tus estadísticas, highlights y objetivos
+- **Caché inteligente** — los análisis se almacenan en la base de datos para que solo se generen una vez por matchup o partida. Regenera en cualquier momento con un clic
+- **Límite diario** — 10 generaciones de IA por día para mantenerse dentro del nivel gratuito. Los resultados en caché no cuentan contra el límite

--- a/drizzle/0013_bouncy_ezekiel.sql
+++ b/drizzle/0013_bouncy_ezekiel.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `ai_insights` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` text NOT NULL,
+	`type` text NOT NULL,
+	`context_key` text NOT NULL,
+	`content` text NOT NULL,
+	`model` text NOT NULL,
+	`prompt_tokens` integer,
+	`completion_tokens` integer,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `ai_insights_user_created_idx` ON `ai_insights` (`user_id`,`created_at`);--> statement-breakpoint
+CREATE UNIQUE INDEX `ai_insights_user_type_context_unq` ON `ai_insights` (`user_id`,`type`,`context_key`);

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1336 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1a40d117-df52-48d8-8765-2d2730faaf75",
+  "prevId": "7581be63-a9c4-4995-89c8-f2a43eb59714",
+  "tables": {
+    "ai_insights": {
+      "name": "ai_insights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_insights_user_created_idx": {
+          "name": "ai_insights_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "ai_insights_user_type_context_unq": {
+          "name": "ai_insights_user_type_context_unq",
+          "columns": [
+            "user_id",
+            "type",
+            "context_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ai_insights_user_id_users_id_fk": {
+          "name": "ai_insights_user_id_users_id_fk",
+          "tableFrom": "ai_insights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coaching_action_items": {
+      "name": "coaching_action_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "action_items_user_status_idx": {
+          "name": "action_items_user_status_idx",
+          "columns": [
+            "user_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "action_items_session_idx": {
+          "name": "action_items_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coaching_action_items_session_id_coaching_sessions_id_fk": {
+          "name": "coaching_action_items_session_id_coaching_sessions_id_fk",
+          "tableFrom": "coaching_action_items",
+          "tableTo": "coaching_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coaching_action_items_user_id_users_id_fk": {
+          "name": "coaching_action_items_user_id_users_id_fk",
+          "tableFrom": "coaching_action_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coaching_session_matches": {
+      "name": "coaching_session_matches",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "coaching_session_matches_match_user_idx": {
+          "name": "coaching_session_matches_match_user_idx",
+          "columns": [
+            "match_id",
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coaching_session_matches_session_id_coaching_sessions_id_fk": {
+          "name": "coaching_session_matches_session_id_coaching_sessions_id_fk",
+          "tableFrom": "coaching_session_matches",
+          "tableTo": "coaching_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coaching_session_matches_user_id_users_id_fk": {
+          "name": "coaching_session_matches_user_id_users_id_fk",
+          "tableFrom": "coaching_session_matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "coaching_session_matches_session_id_match_id_pk": {
+          "columns": [
+            "session_id",
+            "match_id"
+          ],
+          "name": "coaching_session_matches_session_id_match_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coaching_sessions": {
+      "name": "coaching_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coach_name": {
+          "name": "coach_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scheduled'"
+        },
+        "vod_match_id": {
+          "name": "vod_match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "coaching_sessions_user_date_idx": {
+          "name": "coaching_sessions_user_date_idx",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "coaching_sessions_user_status_idx": {
+          "name": "coaching_sessions_user_status_idx",
+          "columns": [
+            "user_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coaching_sessions_user_id_users_id_fk": {
+          "name": "coaching_sessions_user_id_users_id_fk",
+          "tableFrom": "coaching_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "goals": {
+      "name": "goals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_tier": {
+          "name": "target_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_division": {
+          "name": "target_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_tier": {
+          "name": "start_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_division": {
+          "name": "start_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_lp": {
+          "name": "start_lp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "achieved_at": {
+          "name": "achieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "goals_user_status_idx": {
+          "name": "goals_user_status_idx",
+          "columns": [
+            "user_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invites": {
+      "name": "invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_users_id_fk": {
+          "name": "invites_created_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_used_by_users_id_fk": {
+          "name": "invites_used_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "match_highlights": {
+      "name": "match_highlights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "match_highlights_match_user_idx": {
+          "name": "match_highlights_match_user_idx",
+          "columns": [
+            "match_id",
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "match_highlights_user_idx": {
+          "name": "match_highlights_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "match_highlights_user_id_users_id_fk": {
+          "name": "match_highlights_user_id_users_id_fk",
+          "tableFrom": "match_highlights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matches": {
+      "name": "matches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "odometer": {
+          "name": "odometer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_date": {
+          "name": "game_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "champion_id": {
+          "name": "champion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "champion_name": {
+          "name": "champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rune_keystone_id": {
+          "name": "rune_keystone_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rune_keystone_name": {
+          "name": "rune_keystone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matchup_champion_id": {
+          "name": "matchup_champion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matchup_champion_name": {
+          "name": "matchup_champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cs": {
+          "name": "cs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cs_per_min": {
+          "name": "cs_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "game_duration_seconds": {
+          "name": "game_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gold_earned": {
+          "name": "gold_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "vision_score": {
+          "name": "vision_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "review_notes": {
+          "name": "review_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_skipped_reason": {
+          "name": "review_skipped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vod_url": {
+          "name": "vod_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "queue_id": {
+          "name": "queue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_match_json": {
+          "name": "raw_match_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_puuid": {
+          "name": "duo_partner_puuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_champion_name": {
+          "name": "duo_partner_champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_kills": {
+          "name": "duo_partner_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_deaths": {
+          "name": "duo_partner_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_assists": {
+          "name": "duo_partner_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "matches_user_game_date_idx": {
+          "name": "matches_user_game_date_idx",
+          "columns": [
+            "user_id",
+            "game_date"
+          ],
+          "isUnique": false
+        },
+        "matches_user_reviewed_idx": {
+          "name": "matches_user_reviewed_idx",
+          "columns": [
+            "user_id",
+            "reviewed"
+          ],
+          "isUnique": false
+        },
+        "matches_user_duo_partner_idx": {
+          "name": "matches_user_duo_partner_idx",
+          "columns": [
+            "user_id",
+            "duo_partner_puuid"
+          ],
+          "isUnique": false
+        },
+        "matches_user_odometer_unq": {
+          "name": "matches_user_odometer_unq",
+          "columns": [
+            "user_id",
+            "odometer"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "matches_user_id_users_id_fk": {
+          "name": "matches_user_id_users_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "matches_id_user_id_pk": {
+          "columns": [
+            "id",
+            "user_id"
+          ],
+          "name": "matches_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matchup_notes": {
+      "name": "matchup_notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "champion_name": {
+          "name": "champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matchup_champion_name": {
+          "name": "matchup_champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "matchup_notes_user_matchup_idx": {
+          "name": "matchup_notes_user_matchup_idx",
+          "columns": [
+            "user_id",
+            "matchup_champion_name"
+          ],
+          "isUnique": false
+        },
+        "matchup_notes_user_champ_matchup_unq": {
+          "name": "matchup_notes_user_champ_matchup_unq",
+          "columns": [
+            "user_id",
+            "champion_name",
+            "matchup_champion_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "matchup_notes_user_id_users_id_fk": {
+          "name": "matchup_notes_user_id_users_id_fk",
+          "tableFrom": "matchup_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_snapshots": {
+      "name": "rank_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lp": {
+          "name": "lp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "rank_snapshots_user_captured_idx": {
+          "name": "rank_snapshots_user_captured_idx",
+          "columns": [
+            "user_id",
+            "captured_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rank_snapshots_user_id_users_id_fk": {
+          "name": "rank_snapshots_user_id_users_id_fk",
+          "tableFrom": "rank_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "riot_game_name": {
+          "name": "riot_game_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "riot_tag_line": {
+          "name": "riot_tag_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "puuid": {
+          "name": "puuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summoner_id": {
+          "name": "summoner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_user_id": {
+          "name": "duo_partner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'en-GB'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "columns": [
+            "discord_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1774606197573,
       "tag": "0012_military_proteus",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1774618301401,
+      "tag": "0013_bouncy_ezekiel",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -273,6 +273,22 @@
       "deleteError": "Failed to delete matchup note."
     }
   },
+  "AiInsights": {
+    "generateButton": "Get AI Insight",
+    "regenerateButton": "Regenerate",
+    "loading": "Analyzing...",
+    "matchupTitle": "AI Matchup Advice",
+    "postGameTitle": "AI Match Review",
+    "cached": "Cached",
+    "generatedAt": "Generated {date}",
+    "dailyLimitReached": "Daily insight limit reached.",
+    "noApiKey": "AI insights are not configured. Add a Google Gemini API key to enable this feature.",
+    "toasts": {
+      "generated": "AI insight generated.",
+      "error": "Failed to generate insight.",
+      "limitReached": "Daily insight limit reached."
+    }
+  },
   "Analytics": {
     "pageTitle": "Analytics",
     "gamesAnalyzed": "{count, plural, one {# game} other {# games}} analyzed.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -283,6 +283,9 @@
     "generatedAt": "Generated {date}",
     "dailyLimitReached": "Daily insight limit reached.",
     "noApiKey": "AI insights are not configured. Add a Google Gemini API key to enable this feature.",
+    "triggerLabel": "AI Insight",
+    "triggerTooltip": "Get AI-powered analysis",
+    "viewInsight": "View Insight",
     "toasts": {
       "generated": "AI insight generated.",
       "error": "Failed to generate insight.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -283,6 +283,9 @@
     "generatedAt": "Generado {date}",
     "dailyLimitReached": "Límite diario de análisis alcanzado.",
     "noApiKey": "Los análisis IA no están configurados. Añade una clave API de Google Gemini para habilitar esta función.",
+    "triggerLabel": "Análisis IA",
+    "triggerTooltip": "Obtener análisis con IA",
+    "viewInsight": "Ver análisis",
     "toasts": {
       "generated": "Análisis IA generado.",
       "error": "Error al generar el análisis.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -273,6 +273,22 @@
       "deleteError": "Error al eliminar la nota de matchup."
     }
   },
+  "AiInsights": {
+    "generateButton": "Obtener análisis IA",
+    "regenerateButton": "Regenerar",
+    "loading": "Analizando...",
+    "matchupTitle": "Consejo IA de Matchup",
+    "postGameTitle": "Análisis IA de Partida",
+    "cached": "En caché",
+    "generatedAt": "Generado {date}",
+    "dailyLimitReached": "Límite diario de análisis alcanzado.",
+    "noApiKey": "Los análisis IA no están configurados. Añade una clave API de Google Gemini para habilitar esta función.",
+    "toasts": {
+      "generated": "Análisis IA generado.",
+      "error": "Error al generar el análisis.",
+      "limitReached": "Límite diario de análisis alcanzado."
+    }
+  },
   "Analytics": {
     "pageTitle": "Estadísticas",
     "gamesAnalyzed": "{count, plural, one {# partida} other {# partidas}} analizadas.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "lol-tracker",
-  "version": "0.1.0",
+  "version": "2026.03.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lol-tracker",
-      "version": "0.1.0",
+      "version": "2026.03.10",
       "dependencies": {
+        "@ai-sdk/google": "^3.0.53",
         "@base-ui/react": "^1.3.0",
         "@libsql/client": "^0.17.2",
+        "ai": "^6.0.140",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -24,6 +26,7 @@
         "react": "19.2.4",
         "react-day-picker": "^9.14.0",
         "react-dom": "19.2.4",
+        "react-markdown": "^10.1.0",
         "recharts": "^3.8.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -41,6 +44,68 @@
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.82",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.82.tgz",
+      "integrity": "sha512-ddB9FrkHZank1zyx13vypU0RrPjsXWj3NvlsrJ4yFQnrpR+xh48W4wO9ijndUueBsaADjlvMz2Ghv8yq5tZGCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.21",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.53.tgz",
+      "integrity": "sha512-uz8tIlkDgQJG9Js2Wh9JHzd4kI9+hYJqf9XXJLx60vyN5mRIqhr49iwR5zGP5Gl8odp2PeR3Gh2k+5bh3Z1HHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.21"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.21.tgz",
+      "integrity": "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2545,6 +2610,15 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -4645,6 +4719,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -4664,6 +4747,24 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.140",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.140.tgz",
+      "integrity": "sha512-+jf6fQDPZe+gQlzPoP5mzy+DdfYOpE0cgUm99U8OxVTIPv19gCDuNzlKTZSntcQzLbo6LFXyNhJdV7XTWQ+5vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.82",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.21",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -6679,6 +6780,15 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -7256,6 +7366,16 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/icu-minify": {
@@ -7925,6 +8045,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -10101,6 +10227,33 @@
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -12439,7 +12592,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lol-tracker",
-  "version": "2026.03.10",
+  "version": "2026.03.11",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -15,8 +15,10 @@
     "test:e2e": "playwright test --project=e2e"
   },
   "dependencies": {
+    "@ai-sdk/google": "^3.0.53",
     "@base-ui/react": "^1.3.0",
     "@libsql/client": "^0.17.2",
+    "ai": "^6.0.140",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -31,6 +33,7 @@
     "react": "19.2.4",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.4",
+    "react-markdown": "^10.1.0",
     "recharts": "^3.8.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/src/app/(app)/matches/[id]/match-detail-client.tsx
+++ b/src/app/(app)/matches/[id]/match-detail-client.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/table";
 import { Separator } from "@/components/ui/separator";
 import { HighlightsDisplay, type HighlightItem } from "@/components/highlights-editor";
-import { AiInsightCard } from "@/components/ai-insight-card";
+import { AiInsightDrawer } from "@/components/ai-insight-card";
 import { generatePostGameInsight, type InsightResult } from "@/app/actions/ai-insights";
 import {
   ArrowLeft,
@@ -255,6 +255,15 @@ export function MatchDetailClient({
                     {t("pendingReview")}
                   </Badge>
                 )}
+                <AiInsightDrawer
+                  title={tAi("postGameTitle")}
+                  cachedInsight={cachedAiInsight}
+                  isConfigured={isAiConfigured}
+                  locale={locale}
+                  onGenerate={(forceRegenerate) =>
+                    generatePostGameInsight(match.id, forceRegenerate)
+                  }
+                />
               </div>
               <p className="text-sm text-muted-foreground flex items-center gap-1 flex-wrap">
                 {formatDate(match.gameDate, locale, "datetime")} &middot;{" "}
@@ -411,17 +420,6 @@ export function MatchDetailClient({
           </CardContent>
         </Card>
       )}
-
-      {/* AI Post-Game Insight */}
-      <AiInsightCard
-        title={tAi("postGameTitle")}
-        cachedInsight={cachedAiInsight}
-        isConfigured={isAiConfigured}
-        locale={locale}
-        onGenerate={(forceRegenerate) =>
-          generatePostGameInsight(match.id, forceRegenerate)
-        }
-      />
 
       {/* All 10 Players */}
       {participants && (

--- a/src/app/(app)/matches/[id]/match-detail-client.tsx
+++ b/src/app/(app)/matches/[id]/match-detail-client.tsx
@@ -22,10 +22,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Separator } from "@/components/ui/separator";
-import {
-  HighlightsDisplay,
-  type HighlightItem,
-} from "@/components/highlights-editor";
+import { HighlightsDisplay, type HighlightItem } from "@/components/highlights-editor";
+import { AiInsightCard } from "@/components/ai-insight-card";
+import { generatePostGameInsight, type InsightResult } from "@/app/actions/ai-insights";
 import {
   ArrowLeft,
   GraduationCap,
@@ -82,6 +81,8 @@ interface MatchDetailClientProps {
   matchupNotes: MatchupNoteData[];
   ddragonVersion: string;
   userPuuid: string;
+  isAiConfigured: boolean;
+  cachedAiInsight: InsightResult | null;
 }
 
 function ParticipantRow({
@@ -191,10 +192,13 @@ export function MatchDetailClient({
   matchupNotes,
   ddragonVersion,
   userPuuid,
+  isAiConfigured,
+  cachedAiInsight,
 }: MatchDetailClientProps) {
   const { data: session } = useSession();
   const locale = session?.user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("MatchDetail");
+  const tAi = useTranslations("AiInsights");
 
   // Split participants into teams
   const blueTeam = participants?.filter((p) => p.teamId === 100) || [];
@@ -407,6 +411,17 @@ export function MatchDetailClient({
           </CardContent>
         </Card>
       )}
+
+      {/* AI Post-Game Insight */}
+      <AiInsightCard
+        title={tAi("postGameTitle")}
+        cachedInsight={cachedAiInsight}
+        isConfigured={isAiConfigured}
+        locale={locale}
+        onGenerate={(forceRegenerate) =>
+          generatePostGameInsight(match.id, forceRegenerate)
+        }
+      />
 
       {/* All 10 Players */}
       {participants && (

--- a/src/app/(app)/matches/[id]/page.tsx
+++ b/src/app/(app)/matches/[id]/page.tsx
@@ -7,6 +7,7 @@ import { notFound } from "next/navigation";
 import { MatchDetailClient } from "./match-detail-client";
 import type { RiotMatch } from "@/lib/riot-api";
 import { getMatchupNotesForMatch } from "@/app/actions/matchup-notes";
+import { isAiConfigured, getCachedInsight } from "@/app/actions/ai-insights";
 
 /** Slim participant shape — only the fields used by the client component */
 function slimParticipants(raw: RiotMatch) {
@@ -88,7 +89,7 @@ export default async function MatchDetailPage({
   const { rawMatchJson: _rawJson, ...matchForClient } = match;
 
   // These are independent — run in parallel (ddragonVersion already started above)
-  const [ddragonVersion, linkedSessions, highlights, matchupNotesData] = await Promise.all([
+  const [ddragonVersion, linkedSessions, highlights, matchupNotesData, aiConfigured, cachedAiInsight] = await Promise.all([
     ddragonVersionPromise,
     db
       .select({
@@ -117,6 +118,8 @@ export default async function MatchDetailPage({
     match.matchupChampionName
       ? getMatchupNotesForMatch(match.championName, match.matchupChampionName)
       : Promise.resolve([]),
+    isAiConfigured(),
+    getCachedInsight("post-game", { matchId: match.id }),
   ]);
 
   const highlightItems = highlights.map((h) => ({
@@ -134,6 +137,8 @@ export default async function MatchDetailPage({
       matchupNotes={matchupNotesData}
       ddragonVersion={ddragonVersion}
       userPuuid={matchPuuid}
+      isAiConfigured={aiConfigured}
+      cachedAiInsight={cachedAiInsight}
     />
   );
 }

--- a/src/app/(app)/scout/page.tsx
+++ b/src/app/(app)/scout/page.tsx
@@ -5,6 +5,7 @@ import {
   getMostPlayedChampions,
   getMostFacedOpponents,
 } from "@/app/actions/live";
+import { isAiConfigured } from "@/app/actions/ai-insights";
 import { ScoutClient } from "./scout-client";
 
 export default async function ScoutPage({
@@ -20,11 +21,13 @@ export default async function ScoutPage({
     allChampions,
     mostPlayed,
     mostFaced,
+    aiConfigured,
   ] = await Promise.all([
     getLatestVersion(),
     getAllChampionNames(),
     getMostPlayedChampions(8),
     getMostFacedOpponents(8),
+    isAiConfigured(),
   ]);
 
   const isRiotLinked = !!user.puuid;
@@ -38,6 +41,7 @@ export default async function ScoutPage({
       initialEnemyChampion={params.enemy || ""}
       mostPlayed={mostPlayed}
       mostFaced={mostFaced}
+      isAiConfigured={aiConfigured}
     />
   );
 }

--- a/src/app/(app)/scout/scout-client.tsx
+++ b/src/app/(app)/scout/scout-client.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/app/actions/matchup-notes";
 import { generateMatchupInsight } from "@/app/actions/ai-insights";
 import { MatchupNotesTrigger, MatchupNotesPanel, pickActiveNote } from "./matchup-notes";
-import { AiInsightCard } from "@/components/ai-insight-card";
+import { AiInsightDrawer } from "@/components/ai-insight-card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Progress } from "@/components/ui/progress";
@@ -145,6 +145,19 @@ function ScoutingReport({
                 hasNote={hasNote}
                 isOpen={notesOpen}
                 onToggle={() => setNotesOpen(!notesOpen)}
+              />
+              <AiInsightDrawer
+                title={tAi("matchupTitle")}
+                isConfigured={isAiConfigured}
+                locale={locale}
+                onGenerate={(forceRegenerate) =>
+                  generateMatchupInsight(
+                    report.matchupChampionName,
+                    yourChampionName,
+                    report,
+                    forceRegenerate,
+                  )
+                }
               />
             </div>
             <div className="flex items-center gap-3 mt-1">
@@ -362,22 +375,6 @@ function ScoutingReport({
           ))}
         </div>
       </div>
-
-      {/* AI Matchup Insight */}
-      <Separator />
-      <AiInsightCard
-        title={tAi("matchupTitle")}
-        isConfigured={isAiConfigured}
-        locale={locale}
-        onGenerate={(forceRegenerate) =>
-          generateMatchupInsight(
-            report.matchupChampionName,
-            yourChampionName,
-            report,
-            forceRegenerate
-          )
-        }
-      />
     </div>
   );
 }

--- a/src/app/(app)/scout/scout-client.tsx
+++ b/src/app/(app)/scout/scout-client.tsx
@@ -13,7 +13,9 @@ import {
   getMatchupNotes,
   type MatchupNoteData,
 } from "@/app/actions/matchup-notes";
+import { generateMatchupInsight } from "@/app/actions/ai-insights";
 import { MatchupNotesTrigger, MatchupNotesPanel, pickActiveNote } from "./matchup-notes";
+import { AiInsightCard } from "@/components/ai-insight-card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Progress } from "@/components/ui/progress";
@@ -62,6 +64,7 @@ interface ScoutClientProps {
   ddragonVersion: string;
   allChampions: string[];
   isRiotLinked: boolean;
+  isAiConfigured: boolean;
   initialYourChampion?: string;
   initialEnemyChampion?: string;
   mostPlayed?: ChampionPickCount[];
@@ -76,6 +79,7 @@ function ScoutingReport({
   locale,
   matchupNotes,
   yourChampionName,
+  isAiConfigured,
   onNotesChanged,
 }: {
   report: MatchupReport;
@@ -83,10 +87,12 @@ function ScoutingReport({
   locale: string;
   matchupNotes: MatchupNoteData[];
   yourChampionName?: string;
+  isAiConfigured: boolean;
   onNotesChanged?: () => void;
 }) {
   const { record, runeBreakdown, avgStats, overallAvgStats, duoPairs, games } = report;
   const t = useTranslations("Scout");
+  const tAi = useTranslations("AiInsights");
   const [notesOpen, setNotesOpen] = useState(false);
 
   const { activeNote, activeChampionName } = pickActiveNote(matchupNotes, yourChampionName);
@@ -356,6 +362,22 @@ function ScoutingReport({
           ))}
         </div>
       </div>
+
+      {/* AI Matchup Insight */}
+      <Separator />
+      <AiInsightCard
+        title={tAi("matchupTitle")}
+        isConfigured={isAiConfigured}
+        locale={locale}
+        onGenerate={(forceRegenerate) =>
+          generateMatchupInsight(
+            report.matchupChampionName,
+            yourChampionName,
+            report,
+            forceRegenerate
+          )
+        }
+      />
     </div>
   );
 }
@@ -462,6 +484,7 @@ export function ScoutClient({
   ddragonVersion,
   allChampions,
   isRiotLinked: _isRiotLinked,
+  isAiConfigured,
   initialYourChampion = "",
   initialEnemyChampion = "",
   mostPlayed = [],
@@ -651,6 +674,7 @@ export function ScoutClient({
           locale={locale}
           matchupNotes={matchupNotesList}
           yourChampionName={yourChampion || undefined}
+          isAiConfigured={isAiConfigured}
           onNotesChanged={refreshNotes}
         />
       )}

--- a/src/app/actions/ai-insights.ts
+++ b/src/app/actions/ai-insights.ts
@@ -1,0 +1,314 @@
+"use server";
+
+import { db } from "@/db";
+import { aiInsights } from "@/db/schema";
+import { eq, and, sql } from "drizzle-orm";
+import { requireUser } from "@/lib/session";
+import { google } from "@ai-sdk/google";
+import { generateText } from "ai";
+import { buildMatchupContext } from "@/lib/ai/context";
+import { buildPostGameContext } from "@/lib/ai/context";
+import { buildMatchupPrompt, buildPostGamePrompt } from "@/lib/ai/prompts";
+import type { MatchupReport } from "@/app/actions/live";
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const DAILY_LIMIT = 10;
+const MODEL_ID = "gemini-2.5-flash";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type InsightType = "matchup" | "post-game";
+
+export interface InsightResult {
+  content: string;
+  cached: boolean;
+  createdAt: Date;
+  model: string;
+  promptTokens?: number | null;
+  completionTokens?: number | null;
+}
+
+export interface InsightError {
+  error: string;
+  limitReached?: boolean;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function todayStart(): Date {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+}
+
+function contextKey(type: InsightType, params: Record<string, string | undefined>): string {
+  if (type === "matchup") {
+    const your = params.yourChampion?.toLowerCase() || "any";
+    const enemy = params.enemyChampion?.toLowerCase() || "unknown";
+    return `${your}-vs-${enemy}`;
+  }
+  // post-game: use match ID
+  return params.matchId || "unknown";
+}
+
+async function getDailyUsage(userId: string): Promise<number> {
+  const [row] = await db
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(aiInsights)
+    .where(
+      and(
+        eq(aiInsights.userId, userId),
+        sql`${aiInsights.createdAt} >= ${Math.floor(todayStart().getTime() / 1000)}`
+      )
+    );
+  return row?.count ?? 0;
+}
+
+// ─── Check if AI is configured ──────────────────────────────────────────────
+
+export async function isAiConfigured(): Promise<boolean> {
+  return !!process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+}
+
+// ─── Get daily usage stats ──────────────────────────────────────────────────
+
+export async function getAiDailyUsage(): Promise<{ used: number; limit: number }> {
+  const user = await requireUser();
+  const used = await getDailyUsage(user.id);
+  return { used, limit: DAILY_LIMIT };
+}
+
+// ─── Get cached insight ─────────────────────────────────────────────────────
+
+export async function getCachedInsight(
+  type: InsightType,
+  params: Record<string, string | undefined>
+): Promise<InsightResult | null> {
+  const user = await requireUser();
+  const key = contextKey(type, params);
+
+  const existing = await db.query.aiInsights.findFirst({
+    where: and(
+      eq(aiInsights.userId, user.id),
+      eq(aiInsights.type, type),
+      eq(aiInsights.contextKey, key)
+    ),
+  });
+
+  if (!existing) return null;
+
+  return {
+    content: existing.content,
+    cached: true,
+    createdAt: existing.createdAt,
+    model: existing.model,
+    promptTokens: existing.promptTokens,
+    completionTokens: existing.completionTokens,
+  };
+}
+
+// ─── Generate Matchup Insight ───────────────────────────────────────────────
+
+export async function generateMatchupInsight(
+  enemyChampionName: string,
+  yourChampionName: string | undefined,
+  report: MatchupReport,
+  forceRegenerate = false
+): Promise<InsightResult | InsightError> {
+  const user = await requireUser();
+
+  if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
+    return { error: "AI insights are not configured." };
+  }
+
+  const key = contextKey("matchup", {
+    yourChampion: yourChampionName,
+    enemyChampion: enemyChampionName,
+  });
+
+  // Check cache (unless force-regenerating)
+  if (!forceRegenerate) {
+    const existing = await db.query.aiInsights.findFirst({
+      where: and(
+        eq(aiInsights.userId, user.id),
+        eq(aiInsights.type, "matchup"),
+        eq(aiInsights.contextKey, key)
+      ),
+    });
+
+    if (existing) {
+      return {
+        content: existing.content,
+        cached: true,
+        createdAt: existing.createdAt,
+        model: existing.model,
+        promptTokens: existing.promptTokens,
+        completionTokens: existing.completionTokens,
+      };
+    }
+  }
+
+  // Check daily limit
+  const used = await getDailyUsage(user.id);
+  if (used >= DAILY_LIMIT) {
+    return { error: "Daily insight limit reached.", limitReached: true };
+  }
+
+  // Build context and prompt
+  const summonerName = user.riotGameName
+    ? `${user.riotGameName}#${user.riotTagLine}`
+    : user.name || "Player";
+
+  const ctx = await buildMatchupContext(
+    user.id,
+    summonerName,
+    enemyChampionName,
+    yourChampionName,
+    report
+  );
+
+  const language = user.language || "en";
+  const { system, prompt } = buildMatchupPrompt(ctx, language);
+
+  try {
+    const result = await generateText({
+      model: google(MODEL_ID),
+      system,
+      prompt,
+    });
+
+    // Upsert into DB (replace if regenerating)
+    await db
+      .insert(aiInsights)
+      .values({
+        userId: user.id,
+        type: "matchup",
+        contextKey: key,
+        content: result.text,
+        model: MODEL_ID,
+        promptTokens: result.usage?.inputTokens ?? null,
+        completionTokens: result.usage?.outputTokens ?? null,
+      })
+      .onConflictDoUpdate({
+        target: [aiInsights.userId, aiInsights.type, aiInsights.contextKey],
+        set: {
+          content: result.text,
+          model: MODEL_ID,
+          promptTokens: result.usage?.inputTokens ?? null,
+          completionTokens: result.usage?.outputTokens ?? null,
+          createdAt: new Date(),
+        },
+      });
+
+    return {
+      content: result.text,
+      cached: false,
+      createdAt: new Date(),
+      model: MODEL_ID,
+      promptTokens: result.usage?.inputTokens,
+      completionTokens: result.usage?.outputTokens,
+    };
+  } catch (e) {
+    console.error("[AI Insight] Matchup generation failed:", e);
+    return { error: "Failed to generate insight. Please try again." };
+  }
+}
+
+// ─── Generate Post-Game Insight ─────────────────────────────────────────────
+
+export async function generatePostGameInsight(
+  matchId: string,
+  forceRegenerate = false
+): Promise<InsightResult | InsightError> {
+  const user = await requireUser();
+
+  if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
+    return { error: "AI insights are not configured." };
+  }
+
+  const key = contextKey("post-game", { matchId });
+
+  // Check cache
+  if (!forceRegenerate) {
+    const existing = await db.query.aiInsights.findFirst({
+      where: and(
+        eq(aiInsights.userId, user.id),
+        eq(aiInsights.type, "post-game"),
+        eq(aiInsights.contextKey, key)
+      ),
+    });
+
+    if (existing) {
+      return {
+        content: existing.content,
+        cached: true,
+        createdAt: existing.createdAt,
+        model: existing.model,
+        promptTokens: existing.promptTokens,
+        completionTokens: existing.completionTokens,
+      };
+    }
+  }
+
+  // Check daily limit
+  const used = await getDailyUsage(user.id);
+  if (used >= DAILY_LIMIT) {
+    return { error: "Daily insight limit reached.", limitReached: true };
+  }
+
+  // Build context
+  const summonerName = user.riotGameName
+    ? `${user.riotGameName}#${user.riotTagLine}`
+    : user.name || "Player";
+
+  const ctx = await buildPostGameContext(user.id, summonerName, matchId);
+  if (!ctx) {
+    return { error: "Match not found." };
+  }
+
+  const language = user.language || "en";
+  const { system, prompt } = buildPostGamePrompt(ctx, language);
+
+  try {
+    const result = await generateText({
+      model: google(MODEL_ID),
+      system,
+      prompt,
+    });
+
+    // Upsert into DB
+    await db
+      .insert(aiInsights)
+      .values({
+        userId: user.id,
+        type: "post-game",
+        contextKey: key,
+        content: result.text,
+        model: MODEL_ID,
+        promptTokens: result.usage?.inputTokens ?? null,
+        completionTokens: result.usage?.outputTokens ?? null,
+      })
+      .onConflictDoUpdate({
+        target: [aiInsights.userId, aiInsights.type, aiInsights.contextKey],
+        set: {
+          content: result.text,
+          model: MODEL_ID,
+          promptTokens: result.usage?.inputTokens ?? null,
+          completionTokens: result.usage?.outputTokens ?? null,
+          createdAt: new Date(),
+        },
+      });
+
+    return {
+      content: result.text,
+      cached: false,
+      createdAt: new Date(),
+      model: MODEL_ID,
+      promptTokens: result.usage?.inputTokens,
+      completionTokens: result.usage?.outputTokens,
+    };
+  } catch (e) {
+    console.error("[AI Insight] Post-game generation failed:", e);
+    return { error: "Failed to generate insight. Please try again." };
+  }
+}

--- a/src/components/ai-insight-card.tsx
+++ b/src/components/ai-insight-card.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
+import ReactMarkdown from "react-markdown";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Sparkles, Loader2, RefreshCw, AlertCircle } from "lucide-react";
+import { toast } from "sonner";
+import type { InsightResult, InsightError } from "@/app/actions/ai-insights";
+import { formatDate } from "@/lib/format";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface AiInsightCardProps {
+  /** The title to display (e.g. "AI Matchup Advice") */
+  title: string;
+  /** Pre-loaded cached insight, if any */
+  cachedInsight?: InsightResult | null;
+  /** Whether the AI API key is configured */
+  isConfigured: boolean;
+  /** Current locale for date formatting */
+  locale: string;
+  /** Callback to generate the insight — returns result or error */
+  onGenerate: (forceRegenerate: boolean) => Promise<InsightResult | InsightError>;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function isError(result: InsightResult | InsightError): result is InsightError {
+  return "error" in result;
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+export function AiInsightCard({
+  title,
+  cachedInsight,
+  isConfigured,
+  locale,
+  onGenerate,
+}: AiInsightCardProps) {
+  const t = useTranslations("AiInsights");
+  const [insight, setInsight] = useState<InsightResult | null>(cachedInsight ?? null);
+  const [error, setError] = useState<string | null>(null);
+  const [limitReached, setLimitReached] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const handleGenerate = (forceRegenerate: boolean) => {
+    setError(null);
+    startTransition(async () => {
+      const result = await onGenerate(forceRegenerate);
+      if (isError(result)) {
+        setError(result.error);
+        if (result.limitReached) setLimitReached(true);
+        if (result.limitReached) {
+          toast.error(t("toasts.limitReached"));
+        } else {
+          toast.error(t("toasts.error"));
+        }
+      } else {
+        setInsight(result);
+        if (!result.cached) {
+          toast.success(t("toasts.generated"));
+        }
+      }
+    });
+  };
+
+  // Not configured — show disabled state
+  if (!isConfigured) {
+    return (
+      <Card className="border-dashed opacity-60">
+        <CardContent className="flex items-center gap-3 py-4">
+          <Sparkles className="h-5 w-5 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">{t("noApiKey")}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // No insight yet — show generate button
+  if (!insight) {
+    return (
+      <Card className="border-dashed border-gold/30 hover:border-gold/50 transition-colors">
+        <CardContent className="flex flex-col items-center gap-3 py-6">
+          {error && (
+            <div className="flex items-center gap-2 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              {error}
+            </div>
+          )}
+          <Button
+            variant="outline"
+            onClick={() => handleGenerate(false)}
+            disabled={isPending || limitReached}
+            className="gap-2"
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t("loading")}
+              </>
+            ) : (
+              <>
+                <Sparkles className="h-4 w-4 text-gold" />
+                {t("generateButton")}
+              </>
+            )}
+          </Button>
+          {limitReached && (
+            <p className="text-xs text-muted-foreground">{t("dailyLimitReached")}</p>
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Insight loaded — render it
+  return (
+    <Card className="surface-glow border-gold/20">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-gold" />
+            {title}
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            {insight.cached && (
+              <Badge variant="secondary" className="text-[10px]">
+                {t("cached")}
+              </Badge>
+            )}
+            <span className="text-[10px] text-muted-foreground">
+              {t("generatedAt", { date: formatDate(insight.createdAt, locale) })}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={() => handleGenerate(true)}
+              disabled={isPending}
+              title={t("regenerateButton")}
+            >
+              {isPending ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3 w-3" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="prose prose-sm prose-invert max-w-none text-foreground/80 [&>h1]:text-base [&>h2]:text-sm [&>h3]:text-sm [&>h1]:font-semibold [&>h2]:font-semibold [&>h3]:font-medium [&>h1]:text-foreground [&>h2]:text-foreground [&>h3]:text-foreground [&>ul]:space-y-0.5 [&>ol]:space-y-0.5 [&_li]:text-foreground/80 [&>p]:leading-relaxed [&>hr]:border-border/50">
+          <ReactMarkdown>{insight.content}</ReactMarkdown>
+        </div>
+        {error && (
+          <div className="flex items-center gap-2 text-sm text-destructive mt-3">
+            <AlertCircle className="h-4 w-4" />
+            {error}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ai-insight-card.tsx
+++ b/src/components/ai-insight-card.tsx
@@ -1,20 +1,21 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import ReactMarkdown from "react-markdown";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Sparkles, Loader2, RefreshCw, AlertCircle } from "lucide-react";
+import { Sparkles, Loader2, RefreshCw, AlertCircle, X } from "lucide-react";
 import { toast } from "sonner";
 import type { InsightResult, InsightError } from "@/app/actions/ai-insights";
 import { formatDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-interface AiInsightCardProps {
-  /** The title to display (e.g. "AI Matchup Advice") */
+interface AiInsightDrawerProps {
+  /** The title to display in the drawer header */
   title: string;
   /** Pre-loaded cached insight, if any */
   cachedInsight?: InsightResult | null;
@@ -32,151 +33,238 @@ function isError(result: InsightResult | InsightError): result is InsightError {
   return "error" in result;
 }
 
-// ─── Component ──────────────────────────────────────────────────────────────
+const proseClasses = [
+  "prose prose-sm prose-invert max-w-none",
+  // Headings
+  "[&>h2]:text-sm [&>h2]:font-semibold [&>h2]:text-gold [&>h2]:mt-5 [&>h2]:mb-2 [&>h2]:first:mt-0",
+  "[&>h3]:text-sm [&>h3]:font-medium [&>h3]:text-foreground [&>h3]:mt-4 [&>h3]:mb-1.5",
+  // Lists
+  "[&>ul]:space-y-1.5 [&>ul]:mb-3 [&>ol]:space-y-1.5 [&>ol]:mb-3",
+  "[&_li]:text-foreground/80 [&_li]:leading-relaxed",
+  // Paragraphs
+  "[&>p]:text-foreground/80 [&>p]:leading-relaxed [&>p]:mb-3",
+  // Dividers
+  "[&>hr]:border-border/50 [&>hr]:my-4",
+  // Bold emphasis
+  "[&_strong]:text-foreground [&_strong]:font-semibold",
+].join(" ");
 
-export function AiInsightCard({
+// ─── Trigger Button ─────────────────────────────────────────────────────────
+
+export function AiInsightTrigger({
+  isConfigured,
+  hasCachedInsight,
+  isPending,
+  className,
+}: {
+  isConfigured: boolean;
+  hasCachedInsight: boolean;
+  isPending: boolean;
+  className?: string;
+}) {
+  const t = useTranslations("AiInsights");
+
+  if (!isConfigured) return null;
+
+  return (
+    <DialogPrimitive.Trigger
+      render={
+        <Button
+          variant="outline"
+          size="sm"
+          className={cn(
+            "gap-1.5 transition-all",
+            hasCachedInsight && "border-gold/30 text-gold hover:border-gold/50",
+            className,
+          )}
+          title={t("triggerTooltip")}
+        />
+      }
+    >
+      {isPending ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      ) : (
+        <Sparkles
+          className={cn(
+            "h-3.5 w-3.5",
+            hasCachedInsight ? "text-gold fill-gold/20" : "text-muted-foreground",
+          )}
+        />
+      )}
+      <span className="hidden sm:inline">
+        {isPending
+          ? t("loading")
+          : hasCachedInsight
+            ? t("viewInsight")
+            : t("triggerLabel")}
+      </span>
+    </DialogPrimitive.Trigger>
+  );
+}
+
+// ─── Drawer Component ───────────────────────────────────────────────────────
+
+export function AiInsightDrawer({
   title,
   cachedInsight,
   isConfigured,
   locale,
   onGenerate,
-}: AiInsightCardProps) {
+}: AiInsightDrawerProps) {
   const t = useTranslations("AiInsights");
   const [insight, setInsight] = useState<InsightResult | null>(cachedInsight ?? null);
   const [error, setError] = useState<string | null>(null);
   const [limitReached, setLimitReached] = useState(false);
   const [isPending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
 
-  const handleGenerate = (forceRegenerate: boolean) => {
-    setError(null);
-    startTransition(async () => {
-      const result = await onGenerate(forceRegenerate);
-      if (isError(result)) {
-        setError(result.error);
-        if (result.limitReached) setLimitReached(true);
-        if (result.limitReached) {
-          toast.error(t("toasts.limitReached"));
+  const handleGenerate = useCallback(
+    (forceRegenerate: boolean) => {
+      setError(null);
+      startTransition(async () => {
+        const result = await onGenerate(forceRegenerate);
+        if (isError(result)) {
+          setError(result.error);
+          if (result.limitReached) setLimitReached(true);
+          if (result.limitReached) {
+            toast.error(t("toasts.limitReached"));
+          } else {
+            toast.error(t("toasts.error"));
+          }
         } else {
-          toast.error(t("toasts.error"));
+          setInsight(result);
+          if (!result.cached) {
+            toast.success(t("toasts.generated"));
+          }
         }
-      } else {
-        setInsight(result);
-        if (!result.cached) {
-          toast.success(t("toasts.generated"));
-        }
+      });
+    },
+    [onGenerate, t],
+  );
+
+  // Auto-generate on open if no insight yet and not already loading
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      setOpen(isOpen);
+      if (isOpen && !insight && !isPending && isConfigured && !limitReached) {
+        handleGenerate(false);
       }
-    });
-  };
+    },
+    [insight, isPending, isConfigured, limitReached, handleGenerate],
+  );
 
-  // Not configured — show disabled state
-  if (!isConfigured) {
-    return (
-      <Card className="border-dashed opacity-60">
-        <CardContent className="flex items-center gap-3 py-4">
-          <Sparkles className="h-5 w-5 text-muted-foreground" />
-          <p className="text-sm text-muted-foreground">{t("noApiKey")}</p>
-        </CardContent>
-      </Card>
-    );
-  }
+  if (!isConfigured) return null;
 
-  // No insight yet — show generate button
-  if (!insight) {
-    return (
-      <Card className="border-dashed border-gold/30 hover:border-gold/50 transition-colors">
-        <CardContent className="flex flex-col items-center gap-3 py-6">
-          {error && (
-            <div className="flex items-center gap-2 text-sm text-destructive">
-              <AlertCircle className="h-4 w-4" />
-              {error}
-            </div>
-          )}
-          <Button
-            variant="outline"
-            onClick={() => handleGenerate(false)}
-            disabled={isPending || limitReached}
-            className="gap-2"
-          >
-            {isPending ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                {t("loading")}
-              </>
-            ) : (
-              <>
-                <Sparkles className="h-4 w-4 text-gold" />
-                {t("generateButton")}
-              </>
-            )}
-          </Button>
-          {limitReached && (
-            <p className="text-xs text-muted-foreground">{t("dailyLimitReached")}</p>
-          )}
-        </CardContent>
-      </Card>
-    );
-  }
-
-  // Insight loaded — render it
   return (
-    <Card className="surface-glow border-gold/20">
-      <CardHeader className="pb-2">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-sm flex items-center gap-2">
-            <Sparkles className="h-4 w-4 text-gold" />
-            {title}
-          </CardTitle>
-          <div className="flex items-center gap-2">
-            {insight.cached && (
-              <Badge variant="secondary" className="text-[10px]">
-                {t("cached")}
-              </Badge>
-            )}
-            <span className="text-[10px] text-muted-foreground">
-              {t("generatedAt", { date: formatDate(insight.createdAt, locale) })}
-            </span>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-6 w-6"
-              onClick={() => handleGenerate(true)}
-              disabled={isPending}
-              title={t("regenerateButton")}
-            >
-              {isPending ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : (
-                <RefreshCw className="h-3 w-3" />
+    <DialogPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+      <AiInsightTrigger
+        isConfigured={isConfigured}
+        hasCachedInsight={!!insight}
+        isPending={isPending && !open}
+      />
+      <DialogPrimitive.Portal>
+        {/* Backdrop */}
+        <DialogPrimitive.Backdrop
+          className="fixed inset-0 z-50 bg-black/40 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0"
+        />
+        {/* Drawer panel */}
+        <DialogPrimitive.Popup
+          className={cn(
+            "fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col",
+            "border-l border-border/50 bg-background shadow-2xl outline-none",
+            "data-open:animate-in data-open:slide-in-from-right data-open:duration-300",
+            "data-closed:animate-out data-closed:slide-out-to-right data-closed:duration-200",
+          )}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-border/50 px-5 py-4">
+            <DialogPrimitive.Title className="flex items-center gap-2 text-sm font-semibold">
+              <Sparkles className="h-4 w-4 text-gold" />
+              {title}
+            </DialogPrimitive.Title>
+            <div className="flex items-center gap-1.5">
+              {insight && (
+                <>
+                  {insight.cached && (
+                    <Badge variant="secondary" className="text-[10px]">
+                      {t("cached")}
+                    </Badge>
+                  )}
+                  <span className="text-[10px] text-muted-foreground">
+                    {t("generatedAt", { date: formatDate(insight.createdAt, locale) })}
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={() => handleGenerate(true)}
+                    disabled={isPending}
+                    title={t("regenerateButton")}
+                  >
+                    {isPending ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <RefreshCw className="h-3 w-3" />
+                    )}
+                  </Button>
+                </>
               )}
-            </Button>
+              <DialogPrimitive.Close render={<Button variant="ghost" size="icon-xs" />}>
+                <X className="h-3.5 w-3.5" />
+              </DialogPrimitive.Close>
+            </div>
           </div>
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className={[
-          "prose prose-sm prose-invert max-w-none",
-          // Headings
-          "[&>h2]:text-sm [&>h2]:font-semibold [&>h2]:text-gold [&>h2]:mt-5 [&>h2]:mb-2 [&>h2]:first:mt-0",
-          "[&>h3]:text-sm [&>h3]:font-medium [&>h3]:text-foreground [&>h3]:mt-4 [&>h3]:mb-1.5",
-          // Lists
-          "[&>ul]:space-y-1.5 [&>ul]:mb-3 [&>ol]:space-y-1.5 [&>ol]:mb-3",
-          "[&_li]:text-foreground/80 [&_li]:leading-relaxed",
-          // Paragraphs
-          "[&>p]:text-foreground/80 [&>p]:leading-relaxed [&>p]:mb-3",
-          // Dividers
-          "[&>hr]:border-border/50 [&>hr]:my-4",
-          // Bold emphasis
-          "[&_strong]:text-foreground [&_strong]:font-semibold",
-        ].join(" ")}>
-          <ReactMarkdown>{insight.content}</ReactMarkdown>
-        </div>
-        {error && (
-          <div className="flex items-center gap-2 text-sm text-destructive mt-3">
-            <AlertCircle className="h-4 w-4" />
-            {error}
+
+          {/* Body */}
+          <div className="flex-1 overflow-y-auto px-5 py-4">
+            {/* Loading state */}
+            {isPending && !insight && (
+              <div className="flex flex-col items-center justify-center gap-3 py-12">
+                <Loader2 className="h-6 w-6 animate-spin text-gold" />
+                <p className="text-sm text-muted-foreground">{t("loading")}</p>
+              </div>
+            )}
+
+            {/* Error state (no insight) */}
+            {error && !insight && !isPending && (
+              <div className="flex flex-col items-center gap-4 py-12">
+                <div className="flex items-center gap-2 text-sm text-destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  {error}
+                </div>
+                {!limitReached && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleGenerate(false)}
+                    className="gap-1.5"
+                  >
+                    <Sparkles className="h-3.5 w-3.5 text-gold" />
+                    {t("generateButton")}
+                  </Button>
+                )}
+                {limitReached && (
+                  <p className="text-xs text-muted-foreground">{t("dailyLimitReached")}</p>
+                )}
+              </div>
+            )}
+
+            {/* Insight content */}
+            {insight && (
+              <>
+                <div className={proseClasses}>
+                  <ReactMarkdown>{insight.content}</ReactMarkdown>
+                </div>
+                {error && (
+                  <div className="flex items-center gap-2 text-sm text-destructive mt-4">
+                    <AlertCircle className="h-4 w-4" />
+                    {error}
+                  </div>
+                )}
+              </>
+            )}
           </div>
-        )}
-      </CardContent>
-    </Card>
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   );
 }

--- a/src/components/ai-insight-card.tsx
+++ b/src/components/ai-insight-card.tsx
@@ -153,7 +153,21 @@ export function AiInsightCard({
         </div>
       </CardHeader>
       <CardContent>
-        <div className="prose prose-sm prose-invert max-w-none text-foreground/80 [&>h1]:text-base [&>h2]:text-sm [&>h3]:text-sm [&>h1]:font-semibold [&>h2]:font-semibold [&>h3]:font-medium [&>h1]:text-foreground [&>h2]:text-foreground [&>h3]:text-foreground [&>ul]:space-y-0.5 [&>ol]:space-y-0.5 [&_li]:text-foreground/80 [&>p]:leading-relaxed [&>hr]:border-border/50">
+        <div className={[
+          "prose prose-sm prose-invert max-w-none",
+          // Headings
+          "[&>h2]:text-sm [&>h2]:font-semibold [&>h2]:text-gold [&>h2]:mt-5 [&>h2]:mb-2 [&>h2]:first:mt-0",
+          "[&>h3]:text-sm [&>h3]:font-medium [&>h3]:text-foreground [&>h3]:mt-4 [&>h3]:mb-1.5",
+          // Lists
+          "[&>ul]:space-y-1.5 [&>ul]:mb-3 [&>ol]:space-y-1.5 [&>ol]:mb-3",
+          "[&_li]:text-foreground/80 [&_li]:leading-relaxed",
+          // Paragraphs
+          "[&>p]:text-foreground/80 [&>p]:leading-relaxed [&>p]:mb-3",
+          // Dividers
+          "[&>hr]:border-border/50 [&>hr]:my-4",
+          // Bold emphasis
+          "[&_strong]:text-foreground [&_strong]:font-semibold",
+        ].join(" ")}>
           <ReactMarkdown>{insight.content}</ReactMarkdown>
         </div>
         {error && (

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -257,6 +257,27 @@ export const matchupNotes = sqliteTable("matchup_notes", {
   index("matchup_notes_user_matchup_idx").on(table.userId, table.matchupChampionName),
 ]);
 
+// ─── AI Insights ────────────────────────────────────────────────────────────
+
+export const aiInsights = sqliteTable("ai_insights", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  type: text("type", { enum: ["matchup", "post-game"] }).notNull(),
+  contextKey: text("context_key").notNull(), // e.g. "ahri-vs-zed" or match ID
+  content: text("content").notNull(),
+  model: text("model").notNull(),
+  promptTokens: integer("prompt_tokens"),
+  completionTokens: integer("completion_tokens"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  unique("ai_insights_user_type_context_unq").on(table.userId, table.type, table.contextKey),
+  index("ai_insights_user_created_idx").on(table.userId, table.createdAt),
+]);
+
 // ─── Type Exports ────────────────────────────────────────────────────────────
 
 export type Match = typeof matches.$inferSelect;
@@ -267,3 +288,4 @@ export type CoachingSession = typeof coachingSessions.$inferSelect;
 export type CoachingActionItem = typeof coachingActionItems.$inferSelect;
 export type Goal = typeof goals.$inferSelect;
 export type MatchupNote = typeof matchupNotes.$inferSelect;
+export type AiInsight = typeof aiInsights.$inferSelect;

--- a/src/lib/ai/context.ts
+++ b/src/lib/ai/context.ts
@@ -1,0 +1,377 @@
+/**
+ * Data gathering helpers for AI insight prompts.
+ *
+ * Each builder queries the DB for relevant context and returns
+ * a structured object consumed by the prompt templates.
+ */
+
+import { db } from "@/db";
+import {
+  matches,
+  matchHighlights,
+  matchupNotes,
+  coachingActionItems,
+  goals,
+  rankSnapshots,
+} from "@/db/schema";
+import { eq, and, desc, sql } from "drizzle-orm";
+import { notRemake } from "@/lib/match-queries";
+
+// ─── Shared types ───────────────────────────────────────────────────────────
+
+interface ActionItemSummary {
+  description: string;
+  topic: string | null;
+  status: string;
+}
+
+interface GoalSummary {
+  title: string;
+  status: string;
+}
+
+interface GameSummary {
+  result: string;
+  championName: string;
+  kills: number;
+  deaths: number;
+  assists: number;
+  csPerMin: number;
+  gameDurationMin: number;
+  comment: string | null;
+  highlights: string[];
+}
+
+interface AvgStats {
+  kills: number;
+  deaths: number;
+  assists: number;
+  csPerMin: number;
+  goldEarned: number;
+  visionScore: number;
+  games: number;
+}
+
+// ─── Matchup Insight Context ────────────────────────────────────────────────
+
+export interface MatchupInsightContext {
+  summonerName: string;
+  currentRank: string | null;
+  yourChampionName: string | undefined;
+  enemyChampionName: string;
+  record: { wins: number; losses: number; total: number; winRate: number };
+  avgStats: {
+    kills: number;
+    deaths: number;
+    assists: number;
+    csPerMin: number;
+    goldEarned: number;
+    visionScore: number;
+  };
+  overallAvgStats: AvgStats;
+  runeBreakdown: Array<{
+    keystoneName: string;
+    games: number;
+    wins: number;
+    losses: number;
+    winRate: number;
+  }>;
+  recentGames: GameSummary[];
+  matchupNotes: string | null;
+  activeActionItems: ActionItemSummary[];
+  activeGoals: GoalSummary[];
+}
+
+/**
+ * Build context for a matchup insight.
+ * Re-uses the matchup report data that's already loaded on the Scout page,
+ * plus fetches coaching context from the DB.
+ */
+export async function buildMatchupContext(
+  userId: string,
+  summonerName: string,
+  enemyChampionName: string,
+  yourChampionName: string | undefined,
+  report: {
+    record: { wins: number; losses: number; total: number; winRate: number };
+    avgStats: {
+      kills: number;
+      deaths: number;
+      assists: number;
+      csPerMin: number;
+      goldEarned: number;
+      visionScore: number;
+    };
+    overallAvgStats: AvgStats;
+    runeBreakdown: Array<{
+      keystoneName: string;
+      games: number;
+      wins: number;
+      losses: number;
+      winRate: number;
+    }>;
+    games: Array<{
+      result: string;
+      championName: string;
+      kills: number;
+      deaths: number;
+      assists: number;
+      csPerMin: number;
+      gameDurationSeconds: number;
+      comment: string | null;
+      highlights: Array<{ type: string; text: string; topic: string | null }>;
+    }>;
+  }
+): Promise<MatchupInsightContext> {
+  // Fetch coaching context, notes, and rank in parallel
+  const [actionItems, activeGoalRows, rankRow, noteRows] = await Promise.all([
+    db
+      .select({
+        description: coachingActionItems.description,
+        topic: coachingActionItems.topic,
+        status: coachingActionItems.status,
+      })
+      .from(coachingActionItems)
+      .where(
+        and(
+          eq(coachingActionItems.userId, userId),
+          sql`${coachingActionItems.status} != 'completed'`
+        )
+      ),
+    db
+      .select({ title: goals.title, status: goals.status })
+      .from(goals)
+      .where(and(eq(goals.userId, userId), eq(goals.status, "active"))),
+    db
+      .select({
+        tier: rankSnapshots.tier,
+        division: rankSnapshots.division,
+        lp: rankSnapshots.lp,
+      })
+      .from(rankSnapshots)
+      .where(eq(rankSnapshots.userId, userId))
+      .orderBy(desc(rankSnapshots.capturedAt))
+      .limit(1),
+    db
+      .select({ content: matchupNotes.content, championName: matchupNotes.championName })
+      .from(matchupNotes)
+      .where(
+        and(
+          eq(matchupNotes.userId, userId),
+          eq(matchupNotes.matchupChampionName, enemyChampionName)
+        )
+      ),
+  ]);
+
+  // Pick the most relevant note (champion-specific first, then general)
+  let noteContent: string | null = null;
+  if (yourChampionName) {
+    const specific = noteRows.find((n) => n.championName === yourChampionName);
+    if (specific) noteContent = specific.content;
+  }
+  if (!noteContent) {
+    const general = noteRows.find((n) => n.championName === null);
+    if (general) noteContent = general.content;
+  }
+
+  const currentRank = rankRow[0]
+    ? `${rankRow[0].tier} ${rankRow[0].division} ${rankRow[0].lp} LP`
+    : null;
+
+  // Take the 5 most recent games for the prompt
+  const recentGames: GameSummary[] = report.games.slice(0, 5).map((g) => ({
+    result: g.result,
+    championName: g.championName,
+    kills: g.kills,
+    deaths: g.deaths,
+    assists: g.assists,
+    csPerMin: g.csPerMin,
+    gameDurationMin: Math.round(g.gameDurationSeconds / 60),
+    comment: g.comment,
+    highlights: g.highlights.map(
+      (h) => `[${h.type}]${h.topic ? ` (${h.topic})` : ""} ${h.text}`
+    ),
+  }));
+
+  return {
+    summonerName,
+    currentRank,
+    yourChampionName,
+    enemyChampionName,
+    record: report.record,
+    avgStats: report.avgStats,
+    overallAvgStats: report.overallAvgStats,
+    runeBreakdown: report.runeBreakdown,
+    recentGames,
+    matchupNotes: noteContent,
+    activeActionItems: actionItems,
+    activeGoals: activeGoalRows,
+  };
+}
+
+// ─── Post-Game Insight Context ──────────────────────────────────────────────
+
+export interface PostGameInsightContext {
+  summonerName: string;
+  currentRank: string | null;
+  championName: string;
+  matchupChampionName: string | null;
+  result: string;
+  kills: number;
+  deaths: number;
+  assists: number;
+  cs: number;
+  csPerMin: number;
+  goldEarned: number;
+  visionScore: number;
+  gameDurationMin: number;
+  runeKeystoneName: string | null;
+  comment: string | null;
+  reviewNotes: string | null;
+  highlights: Array<{ type: string; text: string; topic: string | null }>;
+  championAvgStats: AvgStats | null;
+  matchupNotes: string | null;
+  activeActionItems: ActionItemSummary[];
+  activeGoals: GoalSummary[];
+}
+
+export async function buildPostGameContext(
+  userId: string,
+  summonerName: string,
+  matchId: string
+): Promise<PostGameInsightContext | null> {
+  // Fetch the match
+  const match = await db.query.matches.findFirst({
+    where: and(eq(matches.id, matchId), eq(matches.userId, userId)),
+  });
+
+  if (!match) return null;
+
+  // Fetch all supporting context in parallel
+  const [highlightRows, actionItems, activeGoalRows, rankRow, noteRows, championAvgRow] =
+    await Promise.all([
+      db
+        .select({
+          type: matchHighlights.type,
+          text: matchHighlights.text,
+          topic: matchHighlights.topic,
+        })
+        .from(matchHighlights)
+        .where(
+          and(
+            eq(matchHighlights.matchId, matchId),
+            eq(matchHighlights.userId, userId)
+          )
+        ),
+      db
+        .select({
+          description: coachingActionItems.description,
+          topic: coachingActionItems.topic,
+          status: coachingActionItems.status,
+        })
+        .from(coachingActionItems)
+        .where(
+          and(
+            eq(coachingActionItems.userId, userId),
+            sql`${coachingActionItems.status} != 'completed'`
+          )
+        ),
+      db
+        .select({ title: goals.title, status: goals.status })
+        .from(goals)
+        .where(and(eq(goals.userId, userId), eq(goals.status, "active"))),
+      db
+        .select({
+          tier: rankSnapshots.tier,
+          division: rankSnapshots.division,
+          lp: rankSnapshots.lp,
+        })
+        .from(rankSnapshots)
+        .where(eq(rankSnapshots.userId, userId))
+        .orderBy(desc(rankSnapshots.capturedAt))
+        .limit(1),
+      match.matchupChampionName
+        ? db
+            .select({ content: matchupNotes.content, championName: matchupNotes.championName })
+            .from(matchupNotes)
+            .where(
+              and(
+                eq(matchupNotes.userId, userId),
+                eq(matchupNotes.matchupChampionName, match.matchupChampionName)
+              )
+            )
+        : Promise.resolve([]),
+      // Champion averages
+      db
+        .select({
+          avgKills: sql<number>`ROUND(AVG(${matches.kills}), 1)`,
+          avgDeaths: sql<number>`ROUND(AVG(${matches.deaths}), 1)`,
+          avgAssists: sql<number>`ROUND(AVG(${matches.assists}), 1)`,
+          avgCsPerMin: sql<number>`ROUND(AVG(${matches.csPerMin}), 1)`,
+          avgGold: sql<number>`ROUND(AVG(${matches.goldEarned}))`,
+          avgVision: sql<number>`ROUND(AVG(${matches.visionScore}), 1)`,
+          total: sql<number>`COUNT(*)`,
+        })
+        .from(matches)
+        .where(
+          and(
+            eq(matches.userId, userId),
+            eq(matches.championName, match.championName),
+            notRemake
+          )
+        ),
+    ]);
+
+  // Pick matchup note (champion-specific first)
+  let noteContent: string | null = null;
+  if (match.matchupChampionName) {
+    const specific = noteRows.find((n) => n.championName === match.championName);
+    if (specific) noteContent = specific.content;
+    if (!noteContent) {
+      const general = noteRows.find((n) => n.championName === null);
+      if (general) noteContent = general.content;
+    }
+  }
+
+  const currentRank = rankRow[0]
+    ? `${rankRow[0].tier} ${rankRow[0].division} ${rankRow[0].lp} LP`
+    : null;
+
+  const avgRow = championAvgRow[0];
+  const championAvgStats: AvgStats | null =
+    avgRow && avgRow.total > 1
+      ? {
+          kills: avgRow.avgKills ?? 0,
+          deaths: avgRow.avgDeaths ?? 0,
+          assists: avgRow.avgAssists ?? 0,
+          csPerMin: avgRow.avgCsPerMin ?? 0,
+          goldEarned: avgRow.avgGold ?? 0,
+          visionScore: avgRow.avgVision ?? 0,
+          games: avgRow.total ?? 0,
+        }
+      : null;
+
+  return {
+    summonerName,
+    currentRank,
+    championName: match.championName,
+    matchupChampionName: match.matchupChampionName,
+    result: match.result,
+    kills: match.kills,
+    deaths: match.deaths,
+    assists: match.assists,
+    cs: match.cs,
+    csPerMin: match.csPerMin ?? 0,
+    goldEarned: match.goldEarned ?? 0,
+    visionScore: match.visionScore ?? 0,
+    gameDurationMin: Math.round(match.gameDurationSeconds / 60),
+    runeKeystoneName: match.runeKeystoneName,
+    comment: match.comment,
+    reviewNotes: match.reviewNotes,
+    highlights: highlightRows,
+    championAvgStats,
+    matchupNotes: noteContent,
+    activeActionItems: actionItems,
+    activeGoals: activeGoalRows,
+  };
+}

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -10,7 +10,15 @@ import type { MatchupInsightContext, PostGameInsightContext } from "./context";
 // ─── Matchup Insight ────────────────────────────────────────────────────────
 
 export function buildMatchupPrompt(ctx: MatchupInsightContext, language: string) {
-  const systemPrompt = `You are a concise, data-driven League of Legends coach. You analyze a player's personal match history to give actionable matchup advice. You never give generic tips — everything you say must be grounded in the player's own data. Use markdown formatting with bold headers and bullet points. Keep your response under 300 words.`;
+  const systemPrompt = `You are a concise, data-driven League of Legends coach. You analyze a player's personal match history to give actionable matchup advice. You never give generic tips — everything you say must be grounded in the player's own data.
+
+## Formatting rules (STRICT)
+- Use ## headings for each section (e.g. ## Patterns, ## Key Tips, ## Coaching Goals)
+- Use bullet points (- ) for each individual point
+- Use **bold** for emphasis on key stats or champion names
+- Leave a blank line between sections
+- Keep your response under 300 words
+- Do NOT start with a greeting or "Here's your report" — jump straight into the first heading`;
 
   const sections: string[] = [];
 
@@ -92,7 +100,15 @@ export function buildMatchupPrompt(ctx: MatchupInsightContext, language: string)
 // ─── Post-Game Insight ──────────────────────────────────────────────────────
 
 export function buildPostGamePrompt(ctx: PostGameInsightContext, language: string) {
-  const systemPrompt = `You are a concise, data-driven League of Legends coach reviewing a specific game. You compare the player's performance to their own averages and provide actionable feedback. Use markdown formatting with bold headers and bullet points. Keep your response under 300 words.`;
+  const systemPrompt = `You are a concise, data-driven League of Legends coach reviewing a specific game. You compare the player's performance to their own averages and provide actionable feedback.
+
+## Formatting rules (STRICT)
+- Use ## headings for each section (e.g. ## What Went Well, ## What To Improve, ## Coaching Goals)
+- Use bullet points (- ) for each individual point
+- Use **bold** for emphasis on key stats or champion names
+- Leave a blank line between sections
+- Keep your response under 300 words
+- Do NOT start with a greeting or "Here's your report" — jump straight into the first heading`;
 
   const sections: string[] = [];
 

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -1,0 +1,168 @@
+/**
+ * Prompt templates for AI-generated insights.
+ *
+ * Each template receives a structured context object and returns
+ * a { system, prompt } pair for the LLM.
+ */
+
+import type { MatchupInsightContext, PostGameInsightContext } from "./context";
+
+// ─── Matchup Insight ────────────────────────────────────────────────────────
+
+export function buildMatchupPrompt(ctx: MatchupInsightContext, language: string) {
+  const systemPrompt = `You are a concise, data-driven League of Legends coach. You analyze a player's personal match history to give actionable matchup advice. You never give generic tips — everything you say must be grounded in the player's own data. Use markdown formatting with bold headers and bullet points. Keep your response under 300 words.`;
+
+  const sections: string[] = [];
+
+  // Player identity
+  sections.push(`## Player\n- Summoner: ${ctx.summonerName}\n- Current rank: ${ctx.currentRank || "Unknown"}`);
+
+  // Matchup overview
+  const matchupLabel = ctx.yourChampionName
+    ? `${ctx.yourChampionName} vs ${ctx.enemyChampionName}`
+    : `Any champion vs ${ctx.enemyChampionName}`;
+  sections.push(
+    `## Matchup: ${matchupLabel}\n` +
+    `- Record: ${ctx.record.wins}W ${ctx.record.losses}L (${ctx.record.winRate}% win rate)\n` +
+    `- Games: ${ctx.record.total}\n` +
+    `- Avg KDA: ${ctx.avgStats.kills}/${ctx.avgStats.deaths}/${ctx.avgStats.assists}\n` +
+    `- Avg CS/min: ${ctx.avgStats.csPerMin}\n` +
+    `- Avg Gold: ${ctx.avgStats.goldEarned}\n` +
+    `- Avg Vision: ${ctx.avgStats.visionScore}`
+  );
+
+  // Comparison to overall averages
+  if (ctx.overallAvgStats.games > 0) {
+    sections.push(
+      `## Comparison to Overall Averages (${ctx.overallAvgStats.games} games)\n` +
+      `- Overall KDA: ${ctx.overallAvgStats.kills}/${ctx.overallAvgStats.deaths}/${ctx.overallAvgStats.assists}\n` +
+      `- Overall CS/min: ${ctx.overallAvgStats.csPerMin}\n` +
+      `- Overall Gold: ${ctx.overallAvgStats.goldEarned}\n` +
+      `- Overall Vision: ${ctx.overallAvgStats.visionScore}`
+    );
+  }
+
+  // Rune performance
+  if (ctx.runeBreakdown.length > 0) {
+    const runeLines = ctx.runeBreakdown
+      .map((r) => `- ${r.keystoneName}: ${r.wins}W ${r.losses}L (${r.winRate}%, ${r.games} games)`)
+      .join("\n");
+    sections.push(`## Rune Performance\n${runeLines}`);
+  }
+
+  // Recent games summary
+  if (ctx.recentGames.length > 0) {
+    const gameLines = ctx.recentGames
+      .map(
+        (g) =>
+          `- ${g.result} as ${g.championName} (${g.kills}/${g.deaths}/${g.assists}, ${g.csPerMin} CS/min, ${g.gameDurationMin}min)${g.comment ? ` — Player note: "${g.comment}"` : ""}${g.highlights.length > 0 ? ` — Highlights: ${g.highlights.join("; ")}` : ""}`
+      )
+      .join("\n");
+    sections.push(`## Recent Games in This Matchup (newest first)\n${gameLines}`);
+  }
+
+  // Matchup notes
+  if (ctx.matchupNotes) {
+    sections.push(`## Player's Own Matchup Notes\n${ctx.matchupNotes}`);
+  }
+
+  // Active coaching focus
+  if (ctx.activeActionItems.length > 0) {
+    const items = ctx.activeActionItems
+      .map((a) => `- [${a.status}] ${a.description}${a.topic ? ` (${a.topic})` : ""}`)
+      .join("\n");
+    sections.push(`## Active Coaching Action Items\n${items}`);
+  }
+
+  // Goals
+  if (ctx.activeGoals.length > 0) {
+    const goalLines = ctx.activeGoals
+      .map((g) => `- ${g.title} (${g.status})`)
+      .join("\n");
+    sections.push(`## Active Goals\n${goalLines}`);
+  }
+
+  const prompt =
+    sections.join("\n\n") +
+    `\n\n---\n\nBased on the data above, provide:\n1. **Patterns** you observe in this matchup (what's working, what isn't)\n2. **Key tips** specifically for this player in this matchup\n3. **Connection to their coaching goals** if relevant\n\nRespond in ${language === "es" ? "Spanish" : "English"}.`;
+
+  return { system: systemPrompt, prompt };
+}
+
+// ─── Post-Game Insight ──────────────────────────────────────────────────────
+
+export function buildPostGamePrompt(ctx: PostGameInsightContext, language: string) {
+  const systemPrompt = `You are a concise, data-driven League of Legends coach reviewing a specific game. You compare the player's performance to their own averages and provide actionable feedback. Use markdown formatting with bold headers and bullet points. Keep your response under 300 words.`;
+
+  const sections: string[] = [];
+
+  // Player identity
+  sections.push(`## Player\n- Summoner: ${ctx.summonerName}\n- Current rank: ${ctx.currentRank || "Unknown"}`);
+
+  // This game
+  sections.push(
+    `## This Game: ${ctx.championName} vs ${ctx.matchupChampionName || "Unknown"}\n` +
+    `- Result: **${ctx.result}**\n` +
+    `- KDA: ${ctx.kills}/${ctx.deaths}/${ctx.assists}\n` +
+    `- CS: ${ctx.cs} (${ctx.csPerMin}/min)\n` +
+    `- Gold: ${ctx.goldEarned}\n` +
+    `- Vision Score: ${ctx.visionScore}\n` +
+    `- Duration: ${ctx.gameDurationMin} minutes\n` +
+    `- Keystone: ${ctx.runeKeystoneName || "Unknown"}`
+  );
+
+  // Comparison to champion averages
+  if (ctx.championAvgStats) {
+    const avg = ctx.championAvgStats;
+    sections.push(
+      `## Your Averages on ${ctx.championName} (${avg.games} games)\n` +
+      `- Avg KDA: ${avg.kills}/${avg.deaths}/${avg.assists}\n` +
+      `- Avg CS/min: ${avg.csPerMin}\n` +
+      `- Avg Gold: ${avg.goldEarned}\n` +
+      `- Avg Vision: ${avg.visionScore}`
+    );
+  }
+
+  // Player's notes for this game
+  if (ctx.comment) {
+    sections.push(`## Player's Game Comment\n"${ctx.comment}"`);
+  }
+  if (ctx.reviewNotes) {
+    sections.push(`## Player's Review Notes\n"${ctx.reviewNotes}"`);
+  }
+
+  // Highlights and lowlights
+  if (ctx.highlights.length > 0) {
+    const hl = ctx.highlights
+      .map((h) => `- [${h.type}]${h.topic ? ` (${h.topic})` : ""} ${h.text}`)
+      .join("\n");
+    sections.push(`## Player's Highlights/Lowlights\n${hl}`);
+  }
+
+  // Matchup notes
+  if (ctx.matchupNotes) {
+    sections.push(`## Player's Matchup Notes for ${ctx.championName} vs ${ctx.matchupChampionName}\n${ctx.matchupNotes}`);
+  }
+
+  // Active coaching focus
+  if (ctx.activeActionItems.length > 0) {
+    const items = ctx.activeActionItems
+      .map((a) => `- [${a.status}] ${a.description}${a.topic ? ` (${a.topic})` : ""}`)
+      .join("\n");
+    sections.push(`## Active Coaching Action Items\n${items}`);
+  }
+
+  // Goals
+  if (ctx.activeGoals.length > 0) {
+    const goalLines = ctx.activeGoals
+      .map((g) => `- ${g.title} (${g.status})`)
+      .join("\n");
+    sections.push(`## Active Goals\n${goalLines}`);
+  }
+
+  const prompt =
+    sections.join("\n\n") +
+    `\n\n---\n\nBased on the data above, provide:\n1. **What went well** in this game\n2. **What to improve** based on their stats vs averages\n3. **Connection to coaching goals** — did this game show progress or regression on their action items?\n\nRespond in ${language === "es" ? "Spanish" : "English"}.`;
+
+  return { system: systemPrompt, prompt };
+}


### PR DESCRIPTION
## Summary

- Add AI-powered coaching insights using **Google Gemini free tier** (gemini-2.5-flash) with DB caching and a daily limit of 10 generations per user
- **Matchup Insight** on the Scout page: contextual advice based on matchup history, rune performance, win rates, duo pairs, and personal notes
- **Post-Game Insight** on the match detail page: performance review with actionable tips based on stats, highlights, goals, and coaching action items

## Details

### New files
- `src/lib/ai/prompts.ts` — Prompt templates for matchup and post-game insights
- `src/lib/ai/context.ts` — Data gathering from DB (coaching items, goals, rank, notes, champion averages)
- `src/app/actions/ai-insights.ts` — Server actions with caching, daily limit, and upsert logic
- `src/components/ai-insight-card.tsx` — Shared UI: generate button, loading state, markdown rendering, cached badge, regenerate, error/limit states
- `drizzle/0013_bouncy_ezekiel.sql` — Migration for `ai_insights` table

### Modified files
- `src/db/schema.ts` — Added `aiInsights` table
- `src/app/(app)/scout/page.tsx` + `scout-client.tsx` — AI card in scouting report
- `src/app/(app)/matches/[id]/page.tsx` + `match-detail-client.tsx` — AI card with pre-fetched cache
- `messages/en.json` + `messages/es.json` — `AiInsights` i18n namespace
- `.env.example` — `GOOGLE_GENERATIVE_AI_API_KEY`
- `package.json` — version bump to `2026.03.11`, added `ai`, `@ai-sdk/google`, `react-markdown`

### Cost controls
- Results cached in DB (unique per user/type/context) — regenerate only when explicitly requested
- Daily limit of 10 generations per user
- Non-streaming `generateText()` for simplicity
- Gemini free tier: 15 req/min, 1M tokens/day

## How to test

### Setup
1. Get a free API key at https://aistudio.google.com/apikey (no billing required)
2. Add to `.env.local`:
   ```
   GOOGLE_GENERATIVE_AI_API_KEY=your-key-here
   ```
3. Restart the dev server (`npm run dev`)

### Without a key
The UI degrades gracefully — AI cards show a disabled "not configured" message. Nothing breaks. You can verify the cards render on both pages.

### With a key
1. **Scout page**: Pick an enemy champion (optionally your champion too), scroll to the bottom of the scouting report, click **"Get AI Insight"**
2. **Match detail page**: Open any match — the AI card appears below the matchup notes section. Click **"Get AI Insight"**
3. **Caching**: Navigate away and come back to the same matchup/match — the cached result should appear instantly with a "Cached" badge
4. **Regenerate**: Click the refresh icon (↻) on a cached insight to force a new generation
5. **Daily limit**: After 10 generations in a day, the button disables and shows a limit message

Relates to #13