### PR TITLE
feat: unify match rendering with MatchCard compact variant on dashboard

### DIFF
--- a/changelog/en/2026-03-27-unify-match-card.mdx
+++ b/changelog/en/2026-03-27-unify-match-card.mdx
@@ -1,0 +1,13 @@
+---
+version: "2026.03.12"
+date: "2026-03-27"
+title: "Unified Match Cards on Dashboard"
+tags: ["improvement"]
+---
+
+The dashboard now uses the same MatchCard component as the matches page, with a compact variant tailored for the dashboard layout.
+
+- **Highlights on the dashboard** — your post-game highlights and lowlights are now visible directly on the dashboard's recent games list (up to 2 pills with an overflow count)
+- **Review status icons** — quickly see which recent games have been reviewed or still need attention
+- **Consistent result indicator** — match rows now use a thin vertical result bar across the entire app instead of a colored left border
+- **Rune keystone and scout links preserved** — the compact variant still shows rune keystones and links to the scout page, just like before

--- a/changelog/es/2026-03-27-unify-match-card.mdx
+++ b/changelog/es/2026-03-27-unify-match-card.mdx
@@ -1,0 +1,13 @@
+---
+version: "2026.03.12"
+date: "2026-03-27"
+title: "Tarjetas de partida unificadas en el panel"
+tags: ["improvement"]
+---
+
+El panel ahora usa el mismo componente MatchCard que la página de partidas, con una variante compacta adaptada al diseño del panel.
+
+- **Aciertos y errores en el panel** — tus aciertos y errores de post-partida ahora se ven directamente en la lista de juegos recientes del panel (hasta 2 etiquetas con indicador de exceso)
+- **Iconos de estado de revisión** — ve rápidamente qué partidas recientes han sido revisadas o necesitan atención
+- **Indicador de resultado consistente** — las filas de partidas ahora usan una barra vertical delgada de resultado en toda la aplicación en lugar de un borde izquierdo coloreado
+- **Runa clave y enlaces de scout preservados** — la variante compacta sigue mostrando las runas clave y los enlaces a la página de scout, igual que antes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lol-tracker",
-  "version": "2026.03.11",
+  "version": "2026.03.12",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(app)/dashboard/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/dashboard-client.tsx
@@ -350,7 +350,7 @@ export function DashboardClient({
                 {t("noMatchesYet")}
               </p>
             ) : (
-              <div className="space-y-2">
+              <div className="space-y-3">
                 {recentMatches.slice(0, 10).map((match) => (
                   <MatchCard
                     key={match.id}

--- a/src/app/(app)/dashboard/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/dashboard-client.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import Image from "next/image";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { ResultBadge, ResultBar } from "@/components/result-badge";
 import { Progress } from "@/components/ui/progress";
 import {
   Card,
@@ -27,9 +25,8 @@ import {
   GraduationCap,
 } from "lucide-react";
 import type { RankSnapshot, CoachingActionItem, Goal, MatchResult } from "@/db/schema";
-import { getKeystoneIconUrlByName, getChampionIconUrl } from "@/lib/riot-api";
-import { ChampionLink } from "@/components/champion-link";
-import { formatDuration, formatDate, DEFAULT_LOCALE } from "@/lib/format";
+import { MatchCard, type MatchHighlightData } from "@/components/match-card";
+import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import {
   formatTierDivision,
   calculateProgress,
@@ -54,7 +51,10 @@ interface DashboardMatch {
   goldEarned: number | null;
   visionScore: number | null;
   reviewed: boolean;
+  reviewNotes: string | null;
+  reviewSkippedReason: string | null;
   comment: string | null;
+  duoPartnerPuuid: string | null;
   queueId: number | null;
 }
 
@@ -88,6 +88,7 @@ interface DashboardClientProps {
     puuid?: string | null;
   };
   recentMatches: DashboardMatch[];
+  highlightsPerMatch: Record<string, MatchHighlightData[]>;
   matchStats: MatchStats;
   latestRank: RankSnapshot | null;
   lpTrend: number | null;
@@ -130,6 +131,7 @@ function getRankDisplay(rank: RankSnapshot | null) {
 export function DashboardClient({
   user,
   recentMatches,
+  highlightsPerMatch,
   matchStats,
   latestRank,
   lpTrend,
@@ -350,60 +352,14 @@ export function DashboardClient({
             ) : (
               <div className="space-y-2">
                 {recentMatches.slice(0, 10).map((match) => (
-                  <Link
+                  <MatchCard
                     key={match.id}
-                    href={`/matches/${match.id}`}
-                    className="flex items-center gap-3 rounded-lg p-2 hover:bg-surface-elevated transition-colors"
-                  >
-                    <ResultBar result={match.result} />
-                    <Image
-                      src={getChampionIconUrl(ddragonVersion, match.championName)}
-                      alt={match.championName}
-                      width={32}
-                      height={32}
-                      className="rounded"
-                    />
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium">
-                          {match.championName}
-                        </span>
-                        <span className="text-xs text-muted-foreground inline-flex items-center gap-1">
-                          {t("vs")}
-                          {match.matchupChampionName ? (
-                            <ChampionLink
-                              champion={match.matchupChampionName}
-                              ddragonVersion={ddragonVersion}
-                              linkTo="scout-enemy"
-                              yourChampion={match.championName}
-                              iconSize={16}
-                              textClassName="text-xs text-muted-foreground"
-                              stopPropagation
-                            />
-                          ) : "?"}
-                        </span>
-                      </div>
-                      <div className="text-xs text-muted-foreground inline-flex items-center gap-1">
-                        {match.runeKeystoneName && (() => {
-                          const iconUrl = getKeystoneIconUrlByName(match.runeKeystoneName);
-                          return iconUrl ? (
-                            <Image src={iconUrl} alt="" width={12} height={12} className="rounded-sm" />
-                          ) : null;
-                        })()}
-                        {match.runeKeystoneName || "—"} &middot;{" "}
-                        {formatDuration(match.gameDurationSeconds)}
-                      </div>
-                    </div>
-                    <div className="text-right">
-                      <span className="text-sm font-mono">
-                        {match.kills}/{match.deaths}/{match.assists}
-                      </span>
-                      <div className="text-xs text-muted-foreground">
-                        {t("csLabel", { cs: match.cs })}
-                      </div>
-                    </div>
-                    <ResultBadge result={match.result} className="w-6 justify-center" />
-                  </Link>
+                    match={match}
+                    ddragonVersion={ddragonVersion}
+                    matchHighlights={highlightsPerMatch[match.id] || []}
+                    variant="compact"
+                    showScoutLink
+                  />
                 ))}
               </div>
             )}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -7,7 +7,7 @@ import {
   coachingSessions,
   goals,
 } from "@/db/schema";
-import { eq, desc, and, count, sql, asc, lte } from "drizzle-orm";
+import { eq, desc, and, count, sql, asc, lte, inArray } from "drizzle-orm";
 import { requireUser } from "@/lib/session";
 import { getLatestVersion } from "@/lib/riot-api";
 import { toCumulativeLP } from "@/lib/rank";
@@ -54,7 +54,10 @@ export default async function DashboardPage() {
         goldEarned: true,
         visionScore: true,
         reviewed: true,
+        reviewNotes: true,
+        reviewSkippedReason: true,
         comment: true,
+        duoPartnerPuuid: true,
         queueId: true,
       },
     }),
@@ -154,6 +157,39 @@ export default async function DashboardPage() {
   };
   const postGamePending = unreviewed - vodPending;
 
+  // Fetch highlights for the recent matches
+  const recentMatchIds = recentMatches.map((m) => m.id);
+  const recentHighlights =
+    recentMatchIds.length > 0
+      ? await db.query.matchHighlights.findMany({
+          where: and(
+            eq(matchHighlights.userId, user.id),
+            inArray(matchHighlights.matchId, recentMatchIds),
+          ),
+          columns: {
+            matchId: true,
+            type: true,
+            text: true,
+            topic: true,
+          },
+        })
+      : [];
+
+  const highlightsPerMatch: Record<
+    string,
+    Array<{ type: "highlight" | "lowlight"; text: string; topic: string | null }>
+  > = {};
+  for (const h of recentHighlights) {
+    if (!highlightsPerMatch[h.matchId]) {
+      highlightsPerMatch[h.matchId] = [];
+    }
+    highlightsPerMatch[h.matchId].push({
+      type: h.type as "highlight" | "lowlight",
+      text: h.text,
+      topic: h.topic,
+    });
+  }
+
   // LP trend: compare first vs. last rank snapshot within the timeframe of
   // the last 10 games, giving a consistent "LP change over recent games"
   // indicator that aligns with the analytics page.
@@ -191,6 +227,7 @@ export default async function DashboardPage() {
         puuid: user.puuid,
       }}
       recentMatches={recentMatches}
+      highlightsPerMatch={highlightsPerMatch}
       matchStats={{ total, wins, losses: total - wins, unreviewed, postGamePending, vodPending }}
       latestRank={latestRankOrUndef}
       lpTrend={lpTrend}

--- a/src/components/match-card.tsx
+++ b/src/components/match-card.tsx
@@ -181,17 +181,21 @@ export function MatchCard({
               )}
             </div>
 
-            {/* Rune keystone — compact variant only */}
-            {isCompact && match.runeKeystoneName && (
+            {/* Rune keystone + stats — compact variant only */}
+            {isCompact && (
               <div className="text-xs text-muted-foreground inline-flex items-center gap-1">
-                {(() => {
+                {match.runeKeystoneName && (() => {
                   const iconUrl = getKeystoneIconUrlByName(match.runeKeystoneName);
                   return iconUrl ? (
                     <Image src={iconUrl} alt="" width={12} height={12} className="rounded-sm" />
                   ) : null;
                 })()}
-                {match.runeKeystoneName} &middot;{" "}
-                {formatDuration(match.gameDurationSeconds)}
+                {match.runeKeystoneName || "\u2014"} &middot;{" "}
+                {formatDuration(match.gameDurationSeconds)} &middot;{" "}
+                <span className="font-mono">
+                  {match.kills}/{match.deaths}/{match.assists}
+                </span>{" "}
+                &middot; {t("csLabel", { cs: match.cs })}
               </div>
             )}
 
@@ -258,17 +262,8 @@ export function MatchCard({
             )}
           </div>
 
-          {/* Stats — compact on mobile, full on sm+ */}
-          {isCompact ? (
-            <div className="text-right shrink-0">
-              <span className="text-sm font-mono">
-                {match.kills}/{match.deaths}/{match.assists}
-              </span>
-              <div className="text-xs text-muted-foreground">
-                {t("csLabel", { cs: match.cs })}
-              </div>
-            </div>
-          ) : (
+          {/* Stats — default variant only (compact stats are inline above) */}
+          {!isCompact && (
             <>
               <span className="sm:hidden font-mono text-xs text-muted-foreground shrink-0">
                 {match.kills}/{match.deaths}/{match.assists}

--- a/src/components/match-card.tsx
+++ b/src/components/match-card.tsx
@@ -107,17 +107,17 @@ export function MatchCard({
   const lowlightItems = matchHighlights.filter((h) => h.type === "lowlight");
   const hasHighlights = matchHighlights.length > 0;
 
-  // In compact mode, limit total visible pills to 2
-  const maxCompactPills = 2;
+  // In compact mode, limit visible pills to 1 per line (highlights on line 1, lowlights on line 2)
+  const maxCompactPerLine = 1;
   let visibleHighlights = highlightItems;
   let visibleLowlights = lowlightItems;
-  let overflowCount = 0;
+  let highlightOverflow = 0;
+  let lowlightOverflow = 0;
   if (isCompact && hasHighlights) {
-    const allItems = [...highlightItems, ...lowlightItems];
-    const visible = allItems.slice(0, maxCompactPills);
-    overflowCount = allItems.length - visible.length;
-    visibleHighlights = visible.filter((h) => h.type === "highlight");
-    visibleLowlights = visible.filter((h) => h.type === "lowlight");
+    visibleHighlights = highlightItems.slice(0, maxCompactPerLine);
+    highlightOverflow = highlightItems.length - visibleHighlights.length;
+    visibleLowlights = lowlightItems.slice(0, maxCompactPerLine);
+    lowlightOverflow = lowlightItems.length - visibleLowlights.length;
   }
 
   // Review status for tooltip
@@ -148,6 +148,7 @@ export function MatchCard({
 
           {/* Main info */}
           <div className="flex-1 min-w-0">
+            {/* Line 1: Champion vs Opponent + compact highlight pills */}
             <div className="flex items-center gap-2 flex-wrap">
               <span className={`font-medium ${isCompact ? "text-sm" : "text-sm"}`}>{match.championName}</span>
               {match.matchupChampionName ? (
@@ -179,9 +180,37 @@ export function MatchCard({
               ) : (
                 <span className="text-sm text-muted-foreground">&mdash;</span>
               )}
+              {/* Compact: highlight pills on champion line */}
+              {isCompact && hasHighlights && visibleHighlights.map((item, i) => {
+                const hasText = !!(item.text && item.topic);
+                return (
+                  <Tooltip key={`h-${i}`}>
+                    <TooltipTrigger
+                      className={`inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[10px] cursor-default ${
+                        hasText
+                          ? "bg-win/20 text-win-muted"
+                          : "bg-win/10 text-win"
+                      }`}
+                    >
+                      <ThumbsUp className="h-2.5 w-2.5" />
+                      {item.topic || item.text}
+                    </TooltipTrigger>
+                    {hasText && (
+                      <TooltipContent side="bottom" className="max-w-sm">
+                        <p className="whitespace-pre-wrap">{item.text}</p>
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                );
+              })}
+              {isCompact && hasHighlights && highlightOverflow > 0 && (
+                <span className="text-[10px] text-muted-foreground">
+                  +{highlightOverflow}
+                </span>
+              )}
             </div>
 
-            {/* Rune keystone + stats + inline highlights — compact variant only */}
+            {/* Line 2 (compact): Rune · Duration · KDA · CS + lowlight pills */}
             {isCompact && (
               <div className="text-xs text-muted-foreground inline-flex items-center gap-1 flex-wrap">
                 {match.runeKeystoneName && (() => {
@@ -198,28 +227,6 @@ export function MatchCard({
                   </span>{" "}
                   &middot; {t("csLabel", { cs: match.cs })}
                 </span>
-                {hasHighlights && visibleHighlights.map((item, i) => {
-                  const hasText = !!(item.text && item.topic);
-                  return (
-                    <Tooltip key={`h-${i}`}>
-                      <TooltipTrigger
-                        className={`inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[10px] cursor-default ${
-                          hasText
-                            ? "bg-win/20 text-win-muted"
-                            : "bg-win/10 text-win"
-                        }`}
-                      >
-                        <ThumbsUp className="h-2.5 w-2.5" />
-                        {item.topic || item.text}
-                      </TooltipTrigger>
-                      {hasText && (
-                        <TooltipContent side="bottom" className="max-w-sm">
-                          <p className="whitespace-pre-wrap">{item.text}</p>
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
-                  );
-                })}
                 {hasHighlights && visibleLowlights.map((item, i) => {
                   const hasText = !!(item.text && item.topic);
                   return (
@@ -242,9 +249,9 @@ export function MatchCard({
                     </Tooltip>
                   );
                 })}
-                {hasHighlights && overflowCount > 0 && (
+                {isCompact && hasHighlights && lowlightOverflow > 0 && (
                   <span className="text-[10px] text-muted-foreground">
-                    +{overflowCount}
+                    +{lowlightOverflow}
                   </span>
                 )}
               </div>

--- a/src/components/match-card.tsx
+++ b/src/components/match-card.tsx
@@ -181,28 +181,24 @@ export function MatchCard({
               )}
             </div>
 
-            {/* Rune keystone + stats — compact variant only */}
+            {/* Rune keystone + stats + inline highlights — compact variant only */}
             {isCompact && (
-              <div className="text-xs text-muted-foreground inline-flex items-center gap-1">
+              <div className="text-xs text-muted-foreground inline-flex items-center gap-1 flex-wrap">
                 {match.runeKeystoneName && (() => {
                   const iconUrl = getKeystoneIconUrlByName(match.runeKeystoneName);
                   return iconUrl ? (
                     <Image src={iconUrl} alt="" width={12} height={12} className="rounded-sm" />
                   ) : null;
                 })()}
-                {match.runeKeystoneName || "\u2014"} &middot;{" "}
-                {formatDuration(match.gameDurationSeconds)} &middot;{" "}
-                <span className="font-mono">
-                  {match.kills}/{match.deaths}/{match.assists}
-                </span>{" "}
-                &middot; {t("csLabel", { cs: match.cs })}
-              </div>
-            )}
-
-            {/* Highlights preview — show topic badges with tooltip for details */}
-            {hasHighlights && (
-              <div className="flex items-center gap-1.5 mt-1 flex-wrap">
-                {(isCompact ? visibleHighlights : highlightItems).map((item, i) => {
+                <span>
+                  {match.runeKeystoneName || "\u2014"} &middot;{" "}
+                  {formatDuration(match.gameDurationSeconds)} &middot;{" "}
+                  <span className="font-mono">
+                    {match.kills}/{match.deaths}/{match.assists}
+                  </span>{" "}
+                  &middot; {t("csLabel", { cs: match.cs })}
+                </span>
+                {hasHighlights && visibleHighlights.map((item, i) => {
                   const hasText = !!(item.text && item.topic);
                   return (
                     <Tooltip key={`h-${i}`}>
@@ -224,7 +220,7 @@ export function MatchCard({
                     </Tooltip>
                   );
                 })}
-                {(isCompact ? visibleLowlights : lowlightItems).map((item, i) => {
+                {hasHighlights && visibleLowlights.map((item, i) => {
                   const hasText = !!(item.text && item.topic);
                   return (
                     <Tooltip key={`l-${i}`}>
@@ -246,11 +242,61 @@ export function MatchCard({
                     </Tooltip>
                   );
                 })}
-                {isCompact && overflowCount > 0 && (
+                {hasHighlights && overflowCount > 0 && (
                   <span className="text-[10px] text-muted-foreground">
                     +{overflowCount}
                   </span>
                 )}
+              </div>
+            )}
+
+            {/* Highlights preview — default variant only (compact shows them inline above) */}
+            {!isCompact && hasHighlights && (
+              <div className="flex items-center gap-1.5 mt-1 flex-wrap">
+                {highlightItems.map((item, i) => {
+                  const hasText = !!(item.text && item.topic);
+                  return (
+                    <Tooltip key={`h-${i}`}>
+                      <TooltipTrigger
+                        className={`inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[10px] cursor-default ${
+                          hasText
+                            ? "bg-win/20 text-win-muted"
+                            : "bg-win/10 text-win"
+                        }`}
+                      >
+                        <ThumbsUp className="h-2.5 w-2.5" />
+                        {item.topic || item.text}
+                      </TooltipTrigger>
+                      {hasText && (
+                        <TooltipContent side="bottom" className="max-w-sm">
+                          <p className="whitespace-pre-wrap">{item.text}</p>
+                        </TooltipContent>
+                      )}
+                    </Tooltip>
+                  );
+                })}
+                {lowlightItems.map((item, i) => {
+                  const hasText = !!(item.text && item.topic);
+                  return (
+                    <Tooltip key={`l-${i}`}>
+                      <TooltipTrigger
+                        className={`inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[10px] cursor-default ${
+                          hasText
+                            ? "bg-loss/20 text-loss-muted"
+                            : "bg-loss/10 text-loss"
+                        }`}
+                      >
+                        <ThumbsDown className="h-2.5 w-2.5" />
+                        {item.topic || item.text}
+                      </TooltipTrigger>
+                      {hasText && (
+                        <TooltipContent side="bottom" className="max-w-sm">
+                          <p className="whitespace-pre-wrap">{item.text}</p>
+                        </TooltipContent>
+                      )}
+                    </Tooltip>
+                  );
+                })}
               </div>
             )}
 

--- a/src/components/match-card.tsx
+++ b/src/components/match-card.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { ResultBadge } from "@/components/result-badge";
+import { ResultBadge, ResultBar } from "@/components/result-badge";
 import {
   Tooltip,
   TooltipTrigger,
@@ -19,10 +19,10 @@ import {
   ChevronRight,
   EyeOff,
 } from "lucide-react";
-import { getChampionIconUrl } from "@/lib/riot-api";
+import { getChampionIconUrl, getKeystoneIconUrlByName } from "@/lib/riot-api";
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
+import { ChampionLink } from "@/components/champion-link";
 import type { MatchResult } from "@/lib/match-result";
-import { resultBorderColor } from "@/lib/match-result";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -33,7 +33,7 @@ export interface MatchHighlightData {
 }
 
 /** The minimal match shape that MatchCard needs */
-interface MatchCardData {
+export interface MatchCardData {
   id: string;
   gameDate: Date;
   result: MatchResult;
@@ -84,13 +84,18 @@ export function MatchCard({
   ddragonVersion,
   matchHighlights,
   locale = DEFAULT_LOCALE,
+  variant = "default",
+  showScoutLink = false,
 }: {
   match: MatchCardData;
   ddragonVersion: string;
   matchHighlights: MatchHighlightData[];
   locale?: string;
+  variant?: "default" | "compact";
+  showScoutLink?: boolean;
 }) {
   const t = useTranslations("MatchCard");
+  const isCompact = variant === "compact";
   const hasComment = !!match.comment;
   const hasReviewNotes = !!match.reviewNotes;
   const kda =
@@ -101,6 +106,19 @@ export function MatchCard({
   const highlightItems = matchHighlights.filter((h) => h.type === "highlight");
   const lowlightItems = matchHighlights.filter((h) => h.type === "lowlight");
   const hasHighlights = matchHighlights.length > 0;
+
+  // In compact mode, limit total visible pills to 2
+  const maxCompactPills = 2;
+  let visibleHighlights = highlightItems;
+  let visibleLowlights = lowlightItems;
+  let overflowCount = 0;
+  if (isCompact && hasHighlights) {
+    const allItems = [...highlightItems, ...lowlightItems];
+    const visible = allItems.slice(0, maxCompactPills);
+    overflowCount = allItems.length - visible.length;
+    visibleHighlights = visible.filter((h) => h.type === "highlight");
+    visibleLowlights = visible.filter((h) => h.type === "lowlight");
+  }
 
   // Review status for tooltip
   const reviewStatusText = match.reviewed
@@ -115,47 +133,72 @@ export function MatchCard({
     <TooltipProvider>
       <Link
         href={`/matches/${match.id}`}
-        className={`block rounded-lg border bg-card transition-all hover:bg-surface-elevated/50 border-l-[3px] ${resultBorderColor(match.result)}`}
+        className={`block rounded-lg border bg-card transition-all hover:bg-surface-elevated/50`}
       >
-        <div className="flex items-center gap-3 px-4 py-3">
+        <div className={`flex items-center gap-3 ${isCompact ? "px-3 py-2" : "px-4 py-3"}`}>
+          {/* Result bar */}
+          <ResultBar result={match.result} size={isCompact ? "sm" : "md"} />
+
           {/* Champion */}
           <ChampionIcon
             championName={match.championName}
             version={ddragonVersion}
-            size={36}
+            size={isCompact ? 32 : 36}
           />
 
           {/* Main info */}
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
-              <span className="font-medium text-sm">{match.championName}</span>
-              {match.matchupChampionName && (
+              <span className={`font-medium ${isCompact ? "text-sm" : "text-sm"}`}>{match.championName}</span>
+              {match.matchupChampionName ? (
                 <>
                   <span className="text-muted-foreground text-xs">{t("vs")}</span>
-                  <span className="inline-flex items-center gap-1 text-sm">
-                    <Image
-                      src={getChampionIconUrl(
-                        ddragonVersion,
-                        match.matchupChampionName
-                      )}
-                      alt={match.matchupChampionName}
-                      width={20}
-                      height={20}
-                      className="rounded"
+                  {showScoutLink ? (
+                    <ChampionLink
+                      champion={match.matchupChampionName}
+                      ddragonVersion={ddragonVersion}
+                      linkTo="scout-enemy"
+                      yourChampion={match.championName}
+                      iconSize={isCompact ? 16 : 20}
+                      textClassName={`text-muted-foreground ${isCompact ? "text-xs" : "text-sm"}`}
+                      stopPropagation
                     />
-                    {match.matchupChampionName}
-                  </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1 text-sm">
+                      <Image
+                        src={getChampionIconUrl(ddragonVersion, match.matchupChampionName)}
+                        alt={match.matchupChampionName}
+                        width={isCompact ? 16 : 20}
+                        height={isCompact ? 16 : 20}
+                        className="rounded"
+                      />
+                      {match.matchupChampionName}
+                    </span>
+                  )}
                 </>
-              )}
-              {!match.matchupChampionName && (
+              ) : (
                 <span className="text-sm text-muted-foreground">&mdash;</span>
               )}
             </div>
 
+            {/* Rune keystone — compact variant only */}
+            {isCompact && match.runeKeystoneName && (
+              <div className="text-xs text-muted-foreground inline-flex items-center gap-1">
+                {(() => {
+                  const iconUrl = getKeystoneIconUrlByName(match.runeKeystoneName);
+                  return iconUrl ? (
+                    <Image src={iconUrl} alt="" width={12} height={12} className="rounded-sm" />
+                  ) : null;
+                })()}
+                {match.runeKeystoneName} &middot;{" "}
+                {formatDuration(match.gameDurationSeconds)}
+              </div>
+            )}
+
             {/* Highlights preview — show topic badges with tooltip for details */}
             {hasHighlights && (
               <div className="flex items-center gap-1.5 mt-1 flex-wrap">
-                {highlightItems.map((item, i) => {
+                {(isCompact ? visibleHighlights : highlightItems).map((item, i) => {
                   const hasText = !!(item.text && item.topic);
                   return (
                     <Tooltip key={`h-${i}`}>
@@ -177,7 +220,7 @@ export function MatchCard({
                     </Tooltip>
                   );
                 })}
-                {lowlightItems.map((item, i) => {
+                {(isCompact ? visibleLowlights : lowlightItems).map((item, i) => {
                   const hasText = !!(item.text && item.topic);
                   return (
                     <Tooltip key={`l-${i}`}>
@@ -199,11 +242,16 @@ export function MatchCard({
                     </Tooltip>
                   );
                 })}
+                {isCompact && overflowCount > 0 && (
+                  <span className="text-[10px] text-muted-foreground">
+                    +{overflowCount}
+                  </span>
+                )}
               </div>
             )}
 
-            {/* Fallback: show comment preview if no highlights */}
-            {!hasHighlights && hasComment && (
+            {/* Fallback: show comment preview if no highlights (default variant only) */}
+            {!isCompact && !hasHighlights && hasComment && (
               <p className="text-xs text-muted-foreground italic mt-0.5 truncate max-w-md">
                 &ldquo;{match.comment}&rdquo;
               </p>
@@ -211,27 +259,40 @@ export function MatchCard({
           </div>
 
           {/* Stats — compact on mobile, full on sm+ */}
-          <span className="sm:hidden font-mono text-xs text-muted-foreground shrink-0">
-            {match.kills}/{match.deaths}/{match.assists}
-          </span>
-          <div className="hidden sm:flex items-center gap-4 text-sm shrink-0">
-            <span className="font-mono">
-              {match.kills}/{match.deaths}/{match.assists}
-              <span className="text-muted-foreground text-xs ml-1">
-                ({kda})
+          {isCompact ? (
+            <div className="text-right shrink-0">
+              <span className="text-sm font-mono">
+                {match.kills}/{match.deaths}/{match.assists}
               </span>
-            </span>
-            <span className="font-mono text-muted-foreground">
-              {t("csLabel", { cs: match.cs })}
-            </span>
-            <span className="text-muted-foreground">
-              {formatDuration(match.gameDurationSeconds)}
-            </span>
-          </div>
+              <div className="text-xs text-muted-foreground">
+                {t("csLabel", { cs: match.cs })}
+              </div>
+            </div>
+          ) : (
+            <>
+              <span className="sm:hidden font-mono text-xs text-muted-foreground shrink-0">
+                {match.kills}/{match.deaths}/{match.assists}
+              </span>
+              <div className="hidden sm:flex items-center gap-4 text-sm shrink-0">
+                <span className="font-mono">
+                  {match.kills}/{match.deaths}/{match.assists}
+                  <span className="text-muted-foreground text-xs ml-1">
+                    ({kda})
+                  </span>
+                </span>
+                <span className="font-mono text-muted-foreground">
+                  {t("csLabel", { cs: match.cs })}
+                </span>
+                <span className="text-muted-foreground">
+                  {formatDuration(match.gameDurationSeconds)}
+                </span>
+              </div>
+            </>
+          )}
 
-          {/* Indicators with tooltips */}
+          {/* Indicators with tooltips (hide duo/comment/unreviewed in compact) */}
           <div className="flex items-center gap-1.5 shrink-0">
-            {match.duoPartnerPuuid && (
+            {!isCompact && match.duoPartnerPuuid && (
               <Tooltip>
                 <TooltipTrigger className="cursor-default">
                   <Users className="h-3.5 w-3.5 text-electric/70" />
@@ -239,7 +300,7 @@ export function MatchCard({
                 <TooltipContent>{t("duoGameTooltip")}</TooltipContent>
               </Tooltip>
             )}
-            {hasComment && (
+            {!isCompact && hasComment && (
               <Tooltip>
                 <TooltipTrigger className="cursor-default">
                   <MessageSquare className="h-3.5 w-3.5 text-gold/70" />
@@ -269,16 +330,20 @@ export function MatchCard({
             )}
           </div>
 
-          {/* Result + Date */}
-          <div className="flex flex-col items-end gap-0.5 shrink-0">
-            <ResultBadge result={match.result} />
-            <span className="text-[10px] text-muted-foreground whitespace-nowrap">
+          {/* Result badge */}
+          <ResultBadge result={match.result} className={isCompact ? "w-6 justify-center" : ""} />
+
+          {/* Date — default variant only */}
+          {!isCompact && (
+            <span className="text-[10px] text-muted-foreground whitespace-nowrap shrink-0">
               {formatDate(match.gameDate, locale)}
             </span>
-          </div>
+          )}
 
-          {/* Navigate indicator */}
-          <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+          {/* Navigate indicator — default variant only */}
+          {!isCompact && (
+            <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+          )}
         </div>
       </Link>
     </TooltipProvider>


### PR DESCRIPTION
## Summary

- Unify match rendering across the app by using `MatchCard` everywhere with a `variant` prop (`default` | `compact`)
- Dashboard now shows highlights/lowlights, review status icons, and rune keystones via the shared `MatchCard` component
- Replace the colored left border with `ResultBar` (thin vertical bar) on both variants for consistent result indication
- Remove ~50 lines of inline match rendering JSX from `dashboard-client.tsx`

Fixes #48

## Changes

### `src/components/match-card.tsx`
- Export `MatchCardData` interface (was private)
- Add `variant` prop: `"default"` (matches page) and `"compact"` (dashboard)
- Add `showScoutLink` prop for `ChampionLink` integration
- Replace colored left border with `ResultBar` on both variants
- Compact variant: tighter padding, smaller icons, max 2 highlight pills with "+N" overflow, rune keystone display, no date/chevron/comment preview

### `src/app/(app)/dashboard/page.tsx`
- Add `reviewNotes`, `reviewSkippedReason`, `duoPartnerPuuid` to match query
- Fetch `matchHighlights` for recent matches (same pattern as matches page)
- Pass `highlightsPerMatch` to `DashboardClient`

### `src/app/(app)/dashboard/dashboard-client.tsx`
- Replace inline match rendering (lines 353-406) with `<MatchCard variant="compact" showScoutLink />`
- Remove unused imports: `Image`, `ResultBar`, `ChampionLink`, `getChampionIconUrl`, `getKeystoneIconUrlByName`, `formatDuration`
- Add `highlightsPerMatch` prop

## Changelog
- Version 2026.03.12: Unified match cards on dashboard — highlights, review status, and consistent result bars