### PR TITLE
chore: centralize AI provider configuration

### DIFF
--- a/.opencode/skills/pr-workflow/SKILL.md
+++ b/.opencode/skills/pr-workflow/SKILL.md
@@ -121,6 +121,12 @@ All four must pass before merging.
 
 ### 6. Merge
 
+**MANDATORY: Wait for CI checks to pass BEFORE merging.** Even if checks are not required by branch protection, always confirm all checks pass first:
+
+```bash
+gh pr checks <number> --watch
+```
+
 After CI passes, merge the PR via GitHub (squash merge preferred for clean history).
 
 Vercel auto-deploys on merge to main — no manual deploy step needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ Every PR must include a changelog entry (`changelog/en/*.mdx` + `changelog/es/*.
 
 **MANDATORY: Run `npm run lint` and `npm run build` locally BEFORE pushing.** Do not rely on CI as the first lint/build check — catch errors locally first.
 
+**MANDATORY: Wait for CI checks to pass BEFORE merging a PR.** Even if checks are not required by branch protection, always run `gh pr checks <number> --watch` (or poll) and confirm all checks pass before merging.
+
 Full workflow details are in the `pr-workflow` OpenCode skill.
 <!-- END:pr-workflow-rules -->
 

--- a/src/app/(app)/matches/[id]/page.tsx
+++ b/src/app/(app)/matches/[id]/page.tsx
@@ -7,7 +7,7 @@ import { notFound } from "next/navigation";
 import { MatchDetailClient } from "./match-detail-client";
 import type { RiotMatch } from "@/lib/riot-api";
 import { getMatchupNotesForMatch } from "@/app/actions/matchup-notes";
-import { isAiConfigured, getCachedInsight } from "@/app/actions/ai-insights";
+import { checkAiConfigured, getCachedInsight } from "@/app/actions/ai-insights";
 
 /** Slim participant shape — only the fields used by the client component */
 function slimParticipants(raw: RiotMatch) {
@@ -118,7 +118,7 @@ export default async function MatchDetailPage({
     match.matchupChampionName
       ? getMatchupNotesForMatch(match.championName, match.matchupChampionName)
       : Promise.resolve([]),
-    isAiConfigured(),
+    checkAiConfigured(),
     getCachedInsight("post-game", { matchId: match.id }),
   ]);
 

--- a/src/app/(app)/scout/page.tsx
+++ b/src/app/(app)/scout/page.tsx
@@ -5,7 +5,7 @@ import {
   getMostPlayedChampions,
   getMostFacedOpponents,
 } from "@/app/actions/live";
-import { isAiConfigured } from "@/app/actions/ai-insights";
+import { checkAiConfigured } from "@/app/actions/ai-insights";
 import { ScoutClient } from "./scout-client";
 
 export default async function ScoutPage({
@@ -27,7 +27,7 @@ export default async function ScoutPage({
     getAllChampionNames(),
     getMostPlayedChampions(8),
     getMostFacedOpponents(8),
-    isAiConfigured(),
+    checkAiConfigured(),
   ]);
 
   const isRiotLinked = !!user.puuid;

--- a/src/app/actions/ai-insights.ts
+++ b/src/app/actions/ai-insights.ts
@@ -4,8 +4,8 @@ import { db } from "@/db";
 import { aiInsights } from "@/db/schema";
 import { eq, and, sql } from "drizzle-orm";
 import { requireUser } from "@/lib/session";
-import { google } from "@ai-sdk/google";
 import { generateText } from "ai";
+import { aiModel, isAiConfigured, AI_MODEL_ID } from "@/lib/ai/provider";
 import { buildMatchupContext } from "@/lib/ai/context";
 import { buildPostGameContext } from "@/lib/ai/context";
 import { buildMatchupPrompt, buildPostGamePrompt } from "@/lib/ai/prompts";
@@ -14,7 +14,6 @@ import type { MatchupReport } from "@/app/actions/live";
 // ─── Constants ──────────────────────────────────────────────────────────────
 
 const DAILY_LIMIT = 10;
-const MODEL_ID = "gemini-2.5-flash";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -66,8 +65,8 @@ async function getDailyUsage(userId: string): Promise<number> {
 
 // ─── Check if AI is configured ──────────────────────────────────────────────
 
-export async function isAiConfigured(): Promise<boolean> {
-  return !!process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+export async function checkAiConfigured(): Promise<boolean> {
+  return isAiConfigured();
 }
 
 // ─── Get daily usage stats ──────────────────────────────────────────────────
@@ -117,7 +116,7 @@ export async function generateMatchupInsight(
 ): Promise<InsightResult | InsightError> {
   const user = await requireUser();
 
-  if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
+  if (!isAiConfigured()) {
     return { error: "AI insights are not configured." };
   }
 
@@ -172,7 +171,7 @@ export async function generateMatchupInsight(
 
   try {
     const result = await generateText({
-      model: google(MODEL_ID),
+      model: aiModel,
       system,
       prompt,
     });
@@ -185,7 +184,7 @@ export async function generateMatchupInsight(
         type: "matchup",
         contextKey: key,
         content: result.text,
-        model: MODEL_ID,
+        model: AI_MODEL_ID,
         promptTokens: result.usage?.inputTokens ?? null,
         completionTokens: result.usage?.outputTokens ?? null,
       })
@@ -193,7 +192,7 @@ export async function generateMatchupInsight(
         target: [aiInsights.userId, aiInsights.type, aiInsights.contextKey],
         set: {
           content: result.text,
-          model: MODEL_ID,
+          model: AI_MODEL_ID,
           promptTokens: result.usage?.inputTokens ?? null,
           completionTokens: result.usage?.outputTokens ?? null,
           createdAt: new Date(),
@@ -204,7 +203,7 @@ export async function generateMatchupInsight(
       content: result.text,
       cached: false,
       createdAt: new Date(),
-      model: MODEL_ID,
+      model: AI_MODEL_ID,
       promptTokens: result.usage?.inputTokens,
       completionTokens: result.usage?.outputTokens,
     };
@@ -222,7 +221,7 @@ export async function generatePostGameInsight(
 ): Promise<InsightResult | InsightError> {
   const user = await requireUser();
 
-  if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
+  if (!isAiConfigured()) {
     return { error: "AI insights are not configured." };
   }
 
@@ -271,7 +270,7 @@ export async function generatePostGameInsight(
 
   try {
     const result = await generateText({
-      model: google(MODEL_ID),
+      model: aiModel,
       system,
       prompt,
     });
@@ -284,7 +283,7 @@ export async function generatePostGameInsight(
         type: "post-game",
         contextKey: key,
         content: result.text,
-        model: MODEL_ID,
+        model: AI_MODEL_ID,
         promptTokens: result.usage?.inputTokens ?? null,
         completionTokens: result.usage?.outputTokens ?? null,
       })
@@ -292,7 +291,7 @@ export async function generatePostGameInsight(
         target: [aiInsights.userId, aiInsights.type, aiInsights.contextKey],
         set: {
           content: result.text,
-          model: MODEL_ID,
+          model: AI_MODEL_ID,
           promptTokens: result.usage?.inputTokens ?? null,
           completionTokens: result.usage?.outputTokens ?? null,
           createdAt: new Date(),
@@ -303,7 +302,7 @@ export async function generatePostGameInsight(
       content: result.text,
       cached: false,
       createdAt: new Date(),
-      model: MODEL_ID,
+      model: AI_MODEL_ID,
       promptTokens: result.usage?.inputTokens,
       completionTokens: result.usage?.outputTokens,
     };

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -1,0 +1,14 @@
+import { google } from "@ai-sdk/google";
+
+const MODEL_ID = "gemini-2.5-flash";
+
+/** Pre-configured AI model instance. All AI calls should use this. */
+export const aiModel = google(MODEL_ID);
+
+/** Model identifier persisted alongside cached insights in the DB. */
+export const AI_MODEL_ID = MODEL_ID;
+
+/** Whether the AI provider API key is configured in the environment. */
+export function isAiConfigured(): boolean {
+  return !!process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+}


### PR DESCRIPTION
## Summary
- Create `src/lib/ai/provider.ts` as the single source of truth for AI provider config (model instance, model ID, `isAiConfigured()`)
- Update `ai-insights.ts` to import from provider instead of configuring `@ai-sdk/google` inline
- Update callers (`scout/page.tsx`, `matches/[id]/page.tsx`) to use renamed `checkAiConfigured` server action
- Add mandatory CI-check-before-merge rule to `AGENTS.md` and `pr-workflow` skill

Fixes #47

## What changed
| Before | After |
|--------|-------|
| `@ai-sdk/google` imported in `ai-insights.ts` | Only imported in `src/lib/ai/provider.ts` |
| `MODEL_ID` hardcoded in `ai-insights.ts` | `AI_MODEL_ID` exported from provider |
| `process.env.GOOGLE_GENERATIVE_AI_API_KEY` checked in 3 places | `isAiConfigured()` centralized in provider |
| `google(MODEL_ID)` called twice | `aiModel` pre-configured instance used |

Swapping from Gemini to another provider now requires changing only `src/lib/ai/provider.ts`.