### PR TITLE
chore: add merge-permission and flaky-test tracking rules

### DIFF
--- a/.opencode/skills/pr-workflow/SKILL.md
+++ b/.opencode/skills/pr-workflow/SKILL.md
@@ -121,15 +121,26 @@ All four must pass before merging.
 
 ### 6. Merge
 
-**MANDATORY: Wait for CI checks to pass BEFORE merging.** Even if checks are not required by branch protection, always confirm all checks pass first:
+**MANDATORY: NEVER merge a PR without the user's explicit permission.** Even if the user says "proceed" or "do it", that means implement + push — NOT merge. Only merge when the user explicitly says "merge it" (or equivalent).
+
+**MANDATORY: Wait for CI checks to pass BEFORE merging.** Even after receiving merge permission, always confirm all checks pass first:
 
 ```bash
 gh pr checks <number> --watch
 ```
 
-After CI passes, merge the PR via GitHub (squash merge preferred for clean history).
+After the user grants permission AND CI passes, merge the PR via GitHub (squash merge preferred for clean history).
 
 Vercel auto-deploys on merge to main — no manual deploy step needed.
+
+### 7. Flaky tests
+
+**MANDATORY: Flaky tests are unacceptable.** Whenever a CI check passes only on re-run (i.e., a test is flaky), immediately open a GitHub issue with the `flaky-test` label. The issue should describe:
+- Which test flaked (full test name)
+- What the failure looked like (error message / timeout)
+- In which PR/run it was observed (link to the CI run)
+
+Do this even if the overall CI run eventually passes on retry. Flaky tests erode trust in the test suite and must be tracked and fixed.
 
 ## Common scenarios
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ Every PR must include a changelog entry (`changelog/en/*.mdx` + `changelog/es/*.
 
 **MANDATORY: Wait for CI checks to pass BEFORE merging a PR.** Even if checks are not required by branch protection, always run `gh pr checks <number> --watch` (or poll) and confirm all checks pass before merging.
 
+**MANDATORY: NEVER merge a PR without the user's explicit permission.** Even if the user says "proceed" or "do it", that means implement + push — NOT merge. Only merge when the user explicitly says "merge it" (or equivalent). If the user grants permission to merge, verify CI checks are green first.
+
+**MANDATORY: Flaky tests are unacceptable.** Whenever a CI check passes only on re-run (i.e., a test is flaky), immediately open a GitHub issue labeled `flaky-test` describing which test flaked, what the failure looked like, and in which PR/run it was observed. Do this even if the overall CI run eventually passes. Flaky tests must be tracked and fixed.
+
 Full workflow details are in the `pr-workflow` OpenCode skill.
 <!-- END:pr-workflow-rules -->
 


### PR DESCRIPTION
## Summary
- Add mandatory rule: never merge a PR without the user's explicit permission ("merge it")
- Add mandatory rule: open a `flaky-test` GitHub issue whenever a CI test passes only on re-run
- Updated both `AGENTS.md` and `.opencode/skills/pr-workflow/SKILL.md`

## Context
These rules were added after an unintended merge of PR #55 without explicit user permission. The flaky-test rule also retroactively applies — issue #56 was created for the coaching E2E test that flaked during PR #55's CI run.