### PR TITLE
fix: run migrations before seeding in smoke/E2E test setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lol-tracker",
-  "version": "2026.03.12",
+  "version": "2026.03.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lol-tracker",
-      "version": "2026.03.12",
+      "version": "2026.03.13",
       "dependencies": {
         "@ai-sdk/google": "^3.0.53",
         "@base-ui/react": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "db:pull": "tsx scripts/db-pull.ts",
     "db:push": "tsx scripts/db-push.ts",
+    "db:migrate": "tsx scripts/migrate.ts",
     "db:seed": "tsx scripts/seed.ts",
     "test:smoke": "playwright test --project=smoke",
     "test:e2e": "playwright test --project=e2e"

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -2,6 +2,10 @@
 // Deterministic seed data for dev/preview environments.
 // Run: npm run db:seed
 //
+// IMPORTANT: Run migrations first (`npx tsx scripts/migrate.ts`) to
+// create all tables. This script only inserts data — it does NOT
+// create tables.
+//
 // Creates 2 users, ~50 matches, rank snapshots, coaching sessions,
 // action items, highlights, and an invite. Uses a simple seeded PRNG
 // for reproducibility (same seed = same data every time).
@@ -192,139 +196,13 @@ async function seed() {
 
   const client = createClient({ url: dbUrl, authToken: dbToken });
 
-  // Ensure tables exist (CREATE IF NOT EXISTS).
-  // This makes the seed script self-contained — no need to run
-  // drizzle-kit push separately for local dev.
-  console.log("Ensuring tables exist...");
-  await client.executeMultiple(`
-    CREATE TABLE IF NOT EXISTS users (
-      id TEXT PRIMARY KEY,
-      discord_id TEXT NOT NULL UNIQUE,
-      name TEXT,
-      image TEXT,
-      email TEXT,
-      riot_game_name TEXT,
-      riot_tag_line TEXT,
-      puuid TEXT,
-      summoner_id TEXT,
-      duo_partner_user_id TEXT,
-      locale TEXT DEFAULT 'en-GB',
-      language TEXT DEFAULT 'en',
-      role TEXT NOT NULL DEFAULT 'user',
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    );
-    CREATE TABLE IF NOT EXISTS matches (
-      id TEXT NOT NULL,
-      odometer INTEGER NOT NULL,
-      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      game_date INTEGER NOT NULL,
-      result TEXT NOT NULL,
-      champion_id INTEGER NOT NULL,
-      champion_name TEXT NOT NULL,
-      rune_keystone_id INTEGER,
-      rune_keystone_name TEXT,
-      matchup_champion_id INTEGER,
-      matchup_champion_name TEXT,
-      kills INTEGER NOT NULL DEFAULT 0,
-      deaths INTEGER NOT NULL DEFAULT 0,
-      assists INTEGER NOT NULL DEFAULT 0,
-      cs INTEGER NOT NULL DEFAULT 0,
-      cs_per_min REAL DEFAULT 0,
-      game_duration_seconds INTEGER NOT NULL DEFAULT 0,
-      gold_earned INTEGER DEFAULT 0,
-      vision_score INTEGER DEFAULT 0,
-      comment TEXT,
-      reviewed INTEGER NOT NULL DEFAULT 0,
-      review_notes TEXT,
-      review_skipped_reason TEXT,
-      vod_url TEXT,
-      queue_id INTEGER,
-      synced_at INTEGER NOT NULL,
-      raw_match_json TEXT,
-      duo_partner_puuid TEXT,
-      duo_partner_champion_name TEXT,
-      duo_partner_kills INTEGER,
-      duo_partner_deaths INTEGER,
-      duo_partner_assists INTEGER,
-      PRIMARY KEY (id, user_id)
-    );
-    CREATE TABLE IF NOT EXISTS rank_snapshots (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      captured_at INTEGER NOT NULL,
-      tier TEXT,
-      division TEXT,
-      lp INTEGER DEFAULT 0,
-      wins INTEGER DEFAULT 0,
-      losses INTEGER DEFAULT 0
-    );
-    CREATE TABLE IF NOT EXISTS coaching_sessions (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      coach_name TEXT NOT NULL,
-      date INTEGER NOT NULL,
-      status TEXT NOT NULL DEFAULT 'scheduled',
-      vod_match_id TEXT,
-      duration_minutes INTEGER,
-      topics TEXT,
-      notes TEXT,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL
-    );
-    CREATE TABLE IF NOT EXISTS coaching_session_matches (
-      session_id INTEGER NOT NULL REFERENCES coaching_sessions(id) ON DELETE CASCADE,
-      match_id TEXT NOT NULL,
-      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      PRIMARY KEY (session_id, match_id)
-    );
-    CREATE TABLE IF NOT EXISTS coaching_action_items (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      session_id INTEGER NOT NULL REFERENCES coaching_sessions(id) ON DELETE CASCADE,
-      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      description TEXT NOT NULL,
-      topic TEXT,
-      status TEXT NOT NULL DEFAULT 'pending',
-      completed_at INTEGER,
-      created_at INTEGER NOT NULL
-    );
-    CREATE TABLE IF NOT EXISTS invites (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      code TEXT NOT NULL UNIQUE,
-      created_by TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      used_by TEXT REFERENCES users(id) ON DELETE SET NULL,
-      used_at INTEGER,
-      created_at INTEGER NOT NULL
-    );
-    CREATE TABLE IF NOT EXISTS match_highlights (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      match_id TEXT NOT NULL,
-      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      type TEXT NOT NULL,
-      text TEXT NOT NULL,
-      topic TEXT,
-      created_at INTEGER NOT NULL
-    );
-    CREATE TABLE IF NOT EXISTS goals (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      title TEXT NOT NULL,
-      target_tier TEXT NOT NULL,
-      target_division TEXT,
-      start_tier TEXT NOT NULL,
-      start_division TEXT,
-      start_lp INTEGER NOT NULL DEFAULT 0,
-      status TEXT NOT NULL DEFAULT 'active',
-      deadline INTEGER,
-      created_at INTEGER NOT NULL,
-      achieved_at INTEGER,
-      retired_at INTEGER
-    );
-  `);
-
-  // Clear existing data (order matters for foreign keys)
+  // Clear existing data (order matters for foreign keys).
+  // Tables are created by migrations (scripts/migrate.ts) — this script
+  // only handles data.
   console.log("Clearing existing data...");
   await client.executeMultiple(`
+    DELETE FROM ai_insights;
+    DELETE FROM matchup_notes;
     DELETE FROM goals;
     DELETE FROM match_highlights;
     DELETE FROM coaching_action_items;

--- a/tests/smoke/setup/global-setup.ts
+++ b/tests/smoke/setup/global-setup.ts
@@ -7,7 +7,8 @@ import fs from "fs";
  * Global setup for smoke tests:
  * 1. Ensures the data/ directory exists
  * 2. Removes any stale local SQLite database
- * 3. Seeds the database with demo data
+ * 3. Runs Drizzle migrations to create all tables
+ * 4. Seeds the database with demo data
  *
  * The Next.js build is handled externally:
  * - Locally: Playwright's webServer.command builds + starts the app
@@ -18,6 +19,11 @@ import fs from "fs";
  */
 export default async function globalSetup(_config: FullConfig) {
   const projectRoot = path.resolve(__dirname, "../../..");
+  const dbEnv = {
+    ...process.env,
+    TURSO_DATABASE_URL: "file:./data/lol-tracker.db",
+    TURSO_AUTH_TOKEN: "",
+  };
 
   // ─── 1. Ensure data directory + remove stale DB ──────────────────────────
   const dataDir = path.join(projectRoot, "data");
@@ -28,16 +34,20 @@ export default async function globalSetup(_config: FullConfig) {
     if (fs.existsSync(file)) fs.unlinkSync(file);
   }
 
-  // ─── 2. Seed the database ────────────────────────────────────────────────
+  // ─── 2. Run migrations (creates all tables) ─────────────────────────────
+  console.log("[smoke] Running migrations...");
+  execSync("npx tsx scripts/migrate.ts", {
+    cwd: projectRoot,
+    stdio: "inherit",
+    env: dbEnv,
+  });
+
+  // ─── 3. Seed the database ────────────────────────────────────────────────
   console.log("[smoke] Seeding local database...");
   execSync("npm run db:seed", {
     cwd: projectRoot,
     stdio: "inherit",
-    env: {
-      ...process.env,
-      TURSO_DATABASE_URL: "file:./data/lol-tracker.db",
-      TURSO_AUTH_TOKEN: "",
-    },
+    env: dbEnv,
   });
 
   // Ensure the .auth directory exists for the setup project


### PR DESCRIPTION
## Summary
- Run `scripts/migrate.ts` in Playwright global setup before seeding, so all tables (including `matchup_notes` and `ai_insights`) are created via Drizzle migrations
- Remove hardcoded `CREATE TABLE IF NOT EXISTS` statements from `scripts/seed.ts` — migrations are now the single source of truth for schema
- Add `db:migrate` npm script for convenience

Fixes #62

## Details

The smoke test seed script (`scripts/seed.ts`) had inline DDL that was never updated for newer tables (`matchup_notes` from migration 0012, `ai_insights` from 0013). This caused `SQLITE_ERROR: no such table: matchup_notes` errors in CI when visiting match detail pages.

The fix mirrors how Vercel deploys work: **migrate -> seed -> build**. Future schema changes will automatically work in tests without touching the seed script.