### PR TITLE
fix: Sonner toast contrast failure — use resolvedTheme instead of theme

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -5,11 +5,11 @@ import { Toaster as Sonner, type ToasterProps } from "sonner"
 import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+  const { resolvedTheme } = useTheme()
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={(resolvedTheme ?? "system") as ToasterProps["theme"]}
       className="toaster group"
       icons={{
         success: (


### PR DESCRIPTION
## Summary

- Fix a real accessibility bug: Sonner toast text had a **1.15:1 contrast ratio** (dark gray on dark background) on the Analytics page
- Root cause: `useTheme()` returns `"system"` before `next-themes` resolves, which Sonner defaults to `"light"` during SSR — activating dark text (`--gray12`) while the document already has the `.dark` class (dark `--popover` background)
- Fix: use `resolvedTheme` instead of `theme`, which gives the actual `"dark"` / `"light"` value after resolution

## One-line change

`src/components/ui/sonner.tsx`: `{ theme }` → `{ resolvedTheme }`, fallback to `"system"` if not yet resolved.

Fixes #67