### PR TITLE
perf: replace revalidateTag(max) with updateTag for immediate cache invalidation

### DIFF
--- a/src/app/actions/invites.ts
+++ b/src/app/actions/invites.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { eq, inArray } from "drizzle-orm";
-import { revalidatePath } from "next/cache";
 
 import { db } from "@/db";
 import { invites, users } from "@/db/schema";
@@ -36,7 +35,6 @@ export async function createInvite() {
     createdBy: admin.id,
   });
 
-  revalidatePath("/settings");
   return { code };
 }
 
@@ -74,6 +72,5 @@ export async function deleteInvite(id: number) {
   await requireAdmin();
 
   await db.delete(invites).where(eq(invites.id, id));
-  revalidatePath("/settings");
   return { success: true };
 }

--- a/src/app/actions/matchup-notes.ts
+++ b/src/app/actions/matchup-notes.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { eq, and, isNull } from "drizzle-orm";
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 
 import { db } from "@/db";
 import { matchupNotes } from "@/db/schema";
@@ -124,7 +124,7 @@ export async function upsertMatchupNote(
     }
 
     await db.delete(matchupNotes).where(and(...conditions));
-    revalidateTag(scoutTag(user.id), "max");
+    updateTag(scoutTag(user.id));
     return { success: true };
   }
 
@@ -148,7 +148,7 @@ export async function upsertMatchupNote(
       },
     });
 
-  revalidateTag(scoutTag(user.id), "max");
+  updateTag(scoutTag(user.id));
   return { success: true };
 }
 
@@ -162,6 +162,6 @@ export async function deleteMatchupNote(id: number): Promise<{ success: boolean;
     .delete(matchupNotes)
     .where(and(eq(matchupNotes.id, id), eq(matchupNotes.userId, user.id)));
 
-  revalidateTag(scoutTag(user.id), "max");
+  updateTag(scoutTag(user.id));
   return { success: true };
 }

--- a/src/app/actions/settings.ts
+++ b/src/app/actions/settings.ts
@@ -40,7 +40,6 @@ export async function linkRiotAccount(formData: FormData) {
       })
       .where(eq(users.id, user.id));
 
-    revalidatePath("/settings");
     revalidatePath("/dashboard");
     invalidateAllCaches(user.id);
 
@@ -69,7 +68,6 @@ export async function unlinkRiotAccount() {
     })
     .where(eq(users.id, user.id));
 
-  revalidatePath("/settings");
   revalidatePath("/dashboard");
   invalidateAllCaches(user.id);
 
@@ -147,7 +145,6 @@ export async function setDuoPartner(partnerUserId: string) {
     })
     .where(eq(users.id, user.id));
 
-  revalidatePath("/settings");
   revalidatePath("/duo");
   invalidateDuoCaches(user.id);
 
@@ -171,7 +168,6 @@ export async function clearDuoPartner() {
     })
     .where(eq(users.id, user.id));
 
-  revalidatePath("/settings");
   revalidatePath("/duo");
   invalidateDuoCaches(user.id);
 

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,4 +1,4 @@
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 
 // ─── Cache Tag Helpers ──────────────────────────────────────────────────────
 // Centralized tag naming so mutations and cached functions stay in sync.
@@ -12,43 +12,43 @@ export const scoutTag = (userId: string) => `scout-${userId}`;
 export const goalsTag = (userId: string) => `goals-${userId}`;
 
 // ─── Invalidation Helpers ───────────────────────────────────────────────────
-// Call these from mutation actions / API routes after writing to the DB.
-// All use profile="max" for stale-while-revalidate semantics.
+// Call these from Server Actions after writing to the DB.
+// All use updateTag() for immediate expiration (read-your-own-writes).
 
 /** Invalidate all Tier 1 caches for a user (sync, account link/unlink). */
 export function invalidateAllCaches(userId: string) {
-  revalidateTag(duoTag(userId), "max");
-  revalidateTag(analyticsTag(userId), "max");
-  revalidateTag(coachingTag(userId), "max");
-  revalidateTag(scoutTag(userId), "max");
-  revalidateTag(goalsTag(userId), "max");
+  updateTag(duoTag(userId));
+  updateTag(analyticsTag(userId));
+  updateTag(coachingTag(userId));
+  updateTag(scoutTag(userId));
+  updateTag(goalsTag(userId));
 }
 
 /** Invalidate caches affected by match review changes. */
 export function invalidateReviewCaches(userId: string) {
-  revalidateTag(analyticsTag(userId), "max");
-  revalidateTag(coachingTag(userId), "max");
-  revalidateTag(scoutTag(userId), "max");
+  updateTag(analyticsTag(userId));
+  updateTag(coachingTag(userId));
+  updateTag(scoutTag(userId));
 }
 
 /** Invalidate caches affected by coaching mutations. */
 export function invalidateCoachingCaches(userId: string) {
-  revalidateTag(coachingTag(userId), "max");
+  updateTag(coachingTag(userId));
 }
 
 /** Invalidate caches affected by duo partner data changes. */
 export function invalidateDuoCaches(userId: string) {
-  revalidateTag(duoTag(userId), "max");
+  updateTag(duoTag(userId));
 }
 
 /** Invalidate caches affected by duo backfill (touches matches table). */
 export function invalidateDuoBackfillCaches(userId: string) {
-  revalidateTag(duoTag(userId), "max");
-  revalidateTag(analyticsTag(userId), "max");
-  revalidateTag(scoutTag(userId), "max");
+  updateTag(duoTag(userId));
+  updateTag(analyticsTag(userId));
+  updateTag(scoutTag(userId));
 }
 
 /** Invalidate caches affected by goal mutations. */
 export function invalidateGoalsCaches(userId: string) {
-  revalidateTag(goalsTag(userId), "max");
+  updateTag(goalsTag(userId));
 }

--- a/tests/e2e/coaching-flow.spec.ts
+++ b/tests/e2e/coaching-flow.spec.ts
@@ -200,19 +200,7 @@ test.describe("Coaching flow", () => {
     await cycleButton.click();
 
     // The status should cycle from "pending" to "in progress".
-    // Revalidation can be slow on CI — if the status doesn't appear within
-    // the timeout, reload the page and check again (the DB write is synchronous).
-    try {
-      await expect(firstActionItemRow.getByText("in progress")).toBeVisible({ timeout: 10_000 });
-    } catch {
-      await page.reload();
-      await expect(
-        mainContent
-          .getByText("Practice freezing near tower for 5 games")
-          .locator("../..")
-          .getByText("in progress"),
-      ).toBeVisible({ timeout: 10_000 });
-    }
+    await expect(firstActionItemRow.getByText("in progress")).toBeVisible({ timeout: 10_000 });
   });
 
   test("delete the new coaching session", async ({ page }) => {

--- a/tests/e2e/goals-flow.spec.ts
+++ b/tests/e2e/goals-flow.spec.ts
@@ -56,18 +56,10 @@ test.describe("Goals flow", () => {
     // Click the "Retire" button
     await main.getByRole("button", { name: "Retire" }).click();
 
-    // Verify the goal moved to past goals with "Retired" badge.
-    // Use reload fallback for revalidation timing.
-    try {
-      await expect(main.locator('[data-slot="badge"]:has-text("Retired")').first()).toBeVisible({
-        timeout: 10_000,
-      });
-    } catch {
-      await page.reload();
-      await expect(
-        page.getByRole("main").locator('[data-slot="badge"]:has-text("Retired")').first(),
-      ).toBeVisible({ timeout: 10_000 });
-    }
+    // Verify the goal moved to past goals with "Retired" badge
+    await expect(main.locator('[data-slot="badge"]:has-text("Retired")').first()).toBeVisible({
+      timeout: 10_000,
+    });
 
     // "New Goal" button should appear now
     await expect(page.getByRole("main").getByRole("link", { name: "New Goal" })).toBeVisible();
@@ -141,16 +133,9 @@ test.describe("Goals flow", () => {
     await deleteButton.click();
 
     // Verify "Reach Gold IV" is gone after deletion
-    try {
-      await expect(main.getByText("Reach Gold IV")).not.toBeVisible({
-        timeout: 10_000,
-      });
-    } catch {
-      await page.reload();
-      await expect(page.getByRole("main").getByText("Reach Gold IV")).not.toBeVisible({
-        timeout: 10_000,
-      });
-    }
+    await expect(main.getByText("Reach Gold IV")).not.toBeVisible({
+      timeout: 10_000,
+    });
 
     // "Reach Platinum IV" (retired) should still be there
     await expect(page.getByRole("main").getByText("Reach Platinum IV")).toBeVisible();


### PR DESCRIPTION
## Summary

- Replace all `revalidateTag(tag, "max")` (stale-while-revalidate) with `updateTag(tag)` (immediate expiration) so user mutations are visible on the very next request — no second page load needed
- Remove no-op `revalidatePath("/settings")` calls (`/settings` is a `"use client"` page, path revalidation has no effect)
- Remove E2E test try/catch + `page.reload()` workarounds that existed solely to handle stale-while-revalidate timing

### Files changed

| File | Change |
|------|--------|
| `src/lib/cache.ts` | All 6 invalidation helpers: `revalidateTag(tag, "max")` → `updateTag(tag)` |
| `src/app/actions/matchup-notes.ts` | 3 direct `revalidateTag` calls → `updateTag` |
| `src/app/actions/settings.ts` | Remove 4 `revalidatePath("/settings")` no-ops |
| `src/app/actions/invites.ts` | Remove 2 `revalidatePath("/settings")` no-ops + unused import |
| `tests/e2e/goals-flow.spec.ts` | Remove 2 try/catch + reload workarounds |
| `tests/e2e/coaching-flow.spec.ts` | Remove 1 try/catch + reload workaround |

### What stays unchanged

- `revalidatePath("/dashboard")`, `revalidatePath("/duo")`, `revalidatePath("/")` — these invalidate the page-level ISR/PPR cache for pages with direct DB queries (different cache layer)
- E2E workarounds for genuine navigation races (router.push vs server redirect) in coaching schedule/complete/delete tests
- `settings-flow.spec.ts` reloads — those are intentional (language cookie requires next render)
- `getCachedAllChampionNames` — TTL-only cache with no tag, unaffected

Fixes #65