### PR TITLE
refactor: wrap client-side auth to reduce Auth.js coupling

### DIFF
--- a/src/app/(app)/analytics/analytics-client.tsx
+++ b/src/app/(app)/analytics/analytics-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { BarChart3, TrendingUp, Trophy, ArrowUpDown } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useMemo, useState } from "react";
@@ -37,6 +36,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useChartColors } from "@/hooks/use-chart-colors";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { filterMeaningful } from "@/lib/match-result";
 import { toCumulativeLP, getTierBoundaries, formatRank } from "@/lib/rank";
@@ -212,8 +212,8 @@ export function AnalyticsClient({
   ddragonVersion,
   activeGoal,
 }: AnalyticsClientProps) {
-  const { data: session } = useSession();
-  const locale = session?.user?.locale ?? DEFAULT_LOCALE;
+  const { user } = useAuth();
+  const locale = user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("Analytics");
   const cc = useChartColors();
 

--- a/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
+++ b/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
@@ -16,7 +16,6 @@ import {
   Swords,
   Pencil,
 } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -33,6 +32,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
 import { getChampionIconUrl } from "@/lib/riot-api";
 
@@ -163,8 +163,8 @@ export function CoachingDetailClient({
   progressHighlightsByMatch,
 }: CoachingDetailClientProps) {
   const router = useRouter();
-  const { data: authSession } = useSession();
-  const locale = authSession?.user?.locale ?? DEFAULT_LOCALE;
+  const { user } = useAuth();
+  const locale = user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("CoachingDetail");
   const [isDeleting, startDelete] = useTransition();
 

--- a/src/app/(app)/coaching/[id]/complete/complete-session-client.tsx
+++ b/src/app/(app)/coaching/[id]/complete/complete-session-client.tsx
@@ -10,7 +10,6 @@ import {
   Clock,
   CheckCircle,
 } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
 import Image from "next/image";
@@ -30,6 +29,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { getChampionIconUrl } from "@/lib/riot-api";
 import { PREDEFINED_TOPICS } from "@/lib/topics";
@@ -65,8 +65,8 @@ export function CompleteSessionClient({
   ddragonVersion,
 }: CompleteSessionClientProps) {
   const router = useRouter();
-  const { data: authSession } = useSession();
-  const locale = authSession?.user?.locale ?? DEFAULT_LOCALE;
+  const { user } = useAuth();
+  const locale = user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("CompleteSession");
   const [isPending, startTransition] = useTransition();
 

--- a/src/app/(app)/coaching/[id]/edit/edit-session-client.tsx
+++ b/src/app/(app)/coaching/[id]/edit/edit-session-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Loader2, ArrowLeft, Video, Check, Calendar, Clock, X } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -20,6 +19,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { getChampionIconUrl } from "@/lib/riot-api";
 import { PREDEFINED_TOPICS } from "@/lib/topics";
@@ -61,8 +61,8 @@ export function EditSessionClient({
   previousCoaches,
 }: EditSessionClientProps) {
   const router = useRouter();
-  const { data: authSession } = useSession();
-  const locale = authSession?.user?.locale ?? DEFAULT_LOCALE;
+  const { user } = useAuth();
+  const locale = user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("EditSession");
   const tCommon = useTranslations("Common");
   const [isPending, startTransition] = useTransition();

--- a/src/app/(app)/coaching/action-items/action-items-client.tsx
+++ b/src/app/(app)/coaching/action-items/action-items-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Loader2, Circle, Play, CheckCircle2, Trash2, ListChecks } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useState, useTransition } from "react";
@@ -18,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 
 interface ActionItemWithSession {
@@ -137,8 +137,8 @@ function ActionItemRow({ item, locale }: { item: ActionItemWithSession; locale: 
 }
 
 export function ActionItemsClient({ items }: ActionItemsClientProps) {
-  const { data: authSession } = useSession();
-  const locale = authSession?.user?.locale ?? DEFAULT_LOCALE;
+  const { user } = useAuth();
+  const locale = user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("ActionItems");
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [topicFilter, setTopicFilter] = useState<string>("all");

--- a/src/app/(app)/coaching/coaching-hub-client.tsx
+++ b/src/app/(app)/coaching/coaching-hub-client.tsx
@@ -15,7 +15,6 @@ import {
   Swords,
   AlertTriangle,
 } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -29,6 +28,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { getChampionIconUrl } from "@/lib/riot-api";
 
@@ -111,8 +111,8 @@ export function CoachingHubClient({
   intervalsData,
   ddragonVersion,
 }: CoachingHubClientProps) {
-  const { data: authSession } = useSession();
-  const locale = authSession?.user?.locale ?? DEFAULT_LOCALE;
+  const { user } = useAuth();
+  const locale = user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("Coaching");
   const totalSessions = scheduledSessions.length + completedSessions.length;
 

--- a/src/app/(app)/coaching/new/schedule-session-client.tsx
+++ b/src/app/(app)/coaching/new/schedule-session-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Loader2, ArrowLeft, Video, Check, Calendar, X } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -17,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { getChampionIconUrl } from "@/lib/riot-api";
 import { PREDEFINED_TOPICS } from "@/lib/topics";
@@ -50,8 +50,8 @@ export function ScheduleSessionClient({
   previousCoaches,
 }: ScheduleSessionClientProps) {
   const router = useRouter();
-  const { data: authSession } = useSession();
-  const locale = authSession?.user?.locale ?? DEFAULT_LOCALE;
+  const { user } = useAuth();
+  const locale = user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("ScheduleSession");
   const tCommon = useTranslations("Common");
   const [isPending, startTransition] = useTransition();

--- a/src/app/(app)/dashboard/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/dashboard-client.tsx
@@ -11,7 +11,6 @@ import {
   Target,
   GraduationCap,
 } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 
@@ -22,6 +21,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { formatTierDivision, calculateProgress } from "@/lib/rank";
 
@@ -137,8 +137,8 @@ export function DashboardClient({
   ddragonVersion,
 }: DashboardClientProps) {
   const t = useTranslations("Dashboard");
-  const { data: session } = useSession();
-  const locale = session?.user?.locale ?? DEFAULT_LOCALE;
+  const { user: authUser } = useAuth();
+  const locale = authUser?.locale ?? DEFAULT_LOCALE;
   const isLinked = !!user.puuid;
   const streak = getStreak(recentMatches);
   const rankInfo = getRankDisplay(latestRank);

--- a/src/app/(app)/duo/duo-client.tsx
+++ b/src/app/(app)/duo/duo-client.tsx
@@ -11,7 +11,6 @@ import {
   Search,
   ArrowUpDown,
 } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -26,6 +25,7 @@ import { Pagination } from "@/components/pagination";
 import { ResultBadge } from "@/components/result-badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
 import { getChampionIconUrl } from "@/lib/riot-api";
 
@@ -387,9 +387,9 @@ export function DuoRecentGames({
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(initialTotalPages);
   const [isPending, startTransition] = useTransition();
-  const { data: authSession } = useSession();
+  const { user } = useAuth();
   const t = useTranslations("Duo");
-  const locale = authSession?.user?.locale ?? DEFAULT_LOCALE;
+  const locale = user?.locale ?? DEFAULT_LOCALE;
 
   function handlePageChange(page: number) {
     startTransition(async () => {

--- a/src/app/(app)/goals/goals-client.tsx
+++ b/src/app/(app)/goals/goals-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Target, Plus, Trophy, Archive, Trash2, Loader2, AlertTriangle } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useTransition } from "react";
@@ -14,6 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Progress, ProgressLabel } from "@/components/ui/progress";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { formatTierDivision, calculateProgress } from "@/lib/rank";
 
@@ -28,8 +28,8 @@ interface GoalsClientProps {
 
 export function GoalsClient({ goals, currentRank }: GoalsClientProps) {
   const t = useTranslations("Goals");
-  const { data: session } = useSession();
-  const locale = session?.user?.locale ?? DEFAULT_LOCALE;
+  const { user } = useAuth();
+  const locale = user?.locale ?? DEFAULT_LOCALE;
 
   const activeGoal = goals.find((g) => g.status === "active");
   const pastGoals = goals.filter((g) => g.status !== "active");

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,5 +1,4 @@
 import { eq } from "drizzle-orm";
-import { SessionProvider } from "next-auth/react";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { connection } from "next/server";
@@ -9,6 +8,7 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { Toaster } from "@/components/ui/sonner";
 import { db } from "@/db";
 import { matches } from "@/db/schema";
+import { AuthProvider } from "@/lib/auth-client";
 import { getLatestChangelogVersion } from "@/lib/changelog";
 import { sidebarReviewCountsSelect } from "@/lib/match-queries";
 import { requireUser } from "@/lib/session";
@@ -58,7 +58,7 @@ async function LocalizedContent({ children }: { children: React.ReactNode }) {
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
-    <SessionProvider>
+    <AuthProvider>
       <Suspense>
         <LocalizedContent>
           <div className="bg-mesh flex min-h-screen">
@@ -78,6 +78,6 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           <Toaster />
         </LocalizedContent>
       </Suspense>
-    </SessionProvider>
+    </AuthProvider>
   );
 }

--- a/src/app/(app)/matches/[id]/match-detail-client.tsx
+++ b/src/app/(app)/matches/[id]/match-detail-client.tsx
@@ -11,7 +11,6 @@ import {
   MessageSquare,
   ExternalLink,
 } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -38,6 +37,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
 import { getKeystoneIconUrl } from "@/lib/riot-api";
 
@@ -188,8 +188,8 @@ export function MatchDetailClient({
   isAiConfigured,
   cachedAiInsight,
 }: MatchDetailClientProps) {
-  const { data: session } = useSession();
-  const locale = session?.user?.locale ?? DEFAULT_LOCALE;
+  const { user } = useAuth();
+  const locale = user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("MatchDetail");
   const tAi = useTranslations("AiInsights");
 

--- a/src/app/(app)/matches/matches-client.tsx
+++ b/src/app/(app)/matches/matches-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Search, Loader2, AlertCircle, ChevronRight, ChevronLeft, Download } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -20,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useAuth } from "@/lib/auth-client";
 import { DEFAULT_LOCALE } from "@/lib/format";
 import { getChampionIconUrl } from "@/lib/riot-api";
 
@@ -164,8 +164,8 @@ export function MatchesClient({
   filters,
 }: MatchesClientProps) {
   const router = useRouter();
-  const { data: session } = useSession();
-  const locale = session?.user?.locale ?? DEFAULT_LOCALE;
+  const { user } = useAuth();
+  const locale = user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("Matches");
   const [isNavigating, startTransition] = useTransition();
 

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -17,7 +17,6 @@ import {
   Pencil,
   X,
 } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -59,6 +58,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
 import { getKeystoneIconUrlByName, getChampionIconUrl } from "@/lib/riot-api";
 import { SKIP_REVIEW_REASONS } from "@/lib/topics";
@@ -739,8 +739,8 @@ export function ReviewClient({
 }: ReviewClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { data: session } = useSession();
-  const locale = session?.user?.locale ?? DEFAULT_LOCALE;
+  const { user } = useAuth();
+  const locale = user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("Review");
 
   // Track which matches have been actioned this session (optimistic removal/movement)

--- a/src/app/(app)/scout/scout-client.tsx
+++ b/src/app/(app)/scout/scout-client.tsx
@@ -10,7 +10,6 @@ import {
   ArrowUp,
   ArrowDown,
 } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -28,6 +27,7 @@ import { MatchCard } from "@/components/match-card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
+import { useAuth } from "@/lib/auth-client";
 import { formatDate, formatNumber, DEFAULT_LOCALE } from "@/lib/format";
 import { getKeystoneIconUrlByName, getChampionIconUrl } from "@/lib/riot-api";
 
@@ -468,8 +468,8 @@ export function ScoutClient({
 }: ScoutClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { data: session } = useSession();
-  const locale = session?.user?.locale ?? DEFAULT_LOCALE;
+  const { user } = useAuth();
+  const locale = user?.locale ?? DEFAULT_LOCALE;
   const t = useTranslations("Scout");
   const [yourChampion, setYourChampion] = useState<string>(initialYourChampion);
   const [enemyChampion, setEnemyChampion] = useState<string>(initialEnemyChampion);

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -12,7 +12,6 @@ import {
   Users,
   Globe,
 } from "lucide-react";
-import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useState, useTransition, useEffect } from "react";
 import { toast } from "sonner";
@@ -42,6 +41,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE, type SupportedLanguage } from "@/i18n/languages";
+import { useAuth } from "@/lib/auth-client";
 import { SUPPORTED_LOCALES, DEFAULT_LOCALE, formatDate, type SupportedLocale } from "@/lib/format";
 
 interface InviteItem {
@@ -54,15 +54,15 @@ interface InviteItem {
 }
 
 export default function SettingsPage() {
-  const { data: session, update: updateSession } = useSession();
+  const { user, updateSession } = useAuth();
   const t = useTranslations("Settings");
   const [riotId, setRiotId] = useState("");
   const [isPending, startTransition] = useTransition();
 
-  const isLinked = !!session?.user?.riotGameName;
-  const isAdmin = session?.user?.role === "admin";
-  const userLocale = (session?.user?.locale as SupportedLocale) ?? DEFAULT_LOCALE;
-  const userLanguage = (session?.user?.language as SupportedLanguage) ?? DEFAULT_LANGUAGE;
+  const isLinked = !!user?.riotGameName;
+  const isAdmin = user?.role === "admin";
+  const userLocale = (user?.locale as SupportedLocale) ?? DEFAULT_LOCALE;
+  const userLanguage = (user?.language as SupportedLanguage) ?? DEFAULT_LANGUAGE;
 
   // Stable date for the locale preview (avoid Next.js prerender `new Date()` error)
   const [previewDate, setPreviewDate] = useState<Date | null>(null);
@@ -282,7 +282,7 @@ export default function SettingsPage() {
                 <div className="flex-1">
                   <p className="text-sm text-muted-foreground">{t("riotAccount.riotIdLabel")}</p>
                   <p className="text-lg font-semibold text-gold">
-                    {session.user.riotGameName}#{session.user.riotTagLine}
+                    {user?.riotGameName}#{user?.riotTagLine}
                   </p>
                 </div>
                 <Button variant="destructive" size="sm" onClick={handleUnlink} disabled={isPending}>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Swords, Ticket, User, Shield } from "lucide-react";
-import { signIn } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useState } from "react";
@@ -11,6 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { login } from "@/lib/auth-client";
 
 // ─── Demo users (must match seed.ts) ──────────────────────────────────────────
 
@@ -109,7 +109,7 @@ function DiscordLoginForm() {
     if (inviteCode.trim()) {
       document.cookie = `invite-code=${encodeURIComponent(inviteCode.trim())}; path=/; max-age=300; SameSite=Lax`;
     }
-    void signIn("discord", { callbackUrl: "/dashboard" });
+    void login("discord", { callbackUrl: "/dashboard" });
   }
 
   return (

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -17,7 +17,6 @@ import {
   Sparkles,
   Target,
 } from "lucide-react";
-import { signOut } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -29,6 +28,7 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { useSyncMatches } from "@/hooks/use-sync-matches";
+import { logout } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 
 interface NavItem {
@@ -265,7 +265,7 @@ function SidebarContent({
               variant="ghost"
               size="icon"
               className="h-8 w-8 shrink-0 hover:text-destructive"
-              onClick={() => void signOut({ callbackUrl: "/login" })}
+              onClick={() => void logout({ callbackUrl: "/login" })}
               aria-label="Log out"
             >
               <LogOut className="h-4 w-4" />

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,0 +1,89 @@
+"use client";
+
+// ─── Client-side auth wrapper ───────────────────────────────────────────────
+// Thin abstraction over next-auth/react so the rest of the app never imports
+// from the auth library directly.  Replacing Auth.js later only requires
+// changing *this* file, not every component that needs session data.
+
+import {
+  SessionProvider,
+  signIn as nextAuthSignIn,
+  signOut as nextAuthSignOut,
+  useSession,
+} from "next-auth/react";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface AuthUser {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  riotGameName?: string | null;
+  riotTagLine?: string | null;
+  puuid?: string | null;
+  role?: string | null;
+  locale?: string | null;
+  language?: string | null;
+}
+
+export interface UseAuthReturn {
+  /** The authenticated user, or `null` while loading / when unauthenticated. */
+  user: AuthUser | null;
+  /** `true` while the session is being fetched for the first time. */
+  isLoading: boolean;
+  /** `true` when a valid session exists. */
+  isAuthenticated: boolean;
+  /** Re-fetch the session from the server (e.g. after a settings change). */
+  updateSession: () => Promise<void>;
+}
+
+// ─── Hooks ──────────────────────────────────────────────────────────────────
+
+/**
+ * Access the current user's session data.
+ *
+ * Replaces direct `useSession()` calls so components depend on our own
+ * interface rather than next-auth's.
+ */
+export function useAuth(): UseAuthReturn {
+  const { data: session, status, update } = useSession();
+
+  return {
+    user: session?.user ?? null,
+    isLoading: status === "loading",
+    isAuthenticated: status === "authenticated",
+    updateSession: async () => {
+      await update();
+    },
+  };
+}
+
+// ─── Actions ────────────────────────────────────────────────────────────────
+
+/**
+ * Trigger a sign-in flow.
+ *
+ * @param provider - OAuth provider id (defaults to `"discord"`).
+ * @param options  - Forwarded to the underlying auth library.
+ */
+export function login(provider = "discord", options?: { callbackUrl?: string }) {
+  return nextAuthSignIn(provider, options);
+}
+
+/**
+ * Sign the current user out.
+ *
+ * @param options - Forwarded to the underlying auth library.
+ */
+export function logout(options?: { callbackUrl?: string }) {
+  return nextAuthSignOut(options);
+}
+
+// ─── Provider ───────────────────────────────────────────────────────────────
+
+/**
+ * Wrap your app tree with this provider to make `useAuth()` available.
+ * Drop-in replacement for next-auth's `SessionProvider`.
+ */
+export const AuthProvider = SessionProvider;


### PR DESCRIPTION
## Summary

- Created `src/lib/auth-client.ts` — a thin wrapper over `next-auth/react` that exports `useAuth()`, `login()`, `logout()`, and `AuthProvider`
- Migrated all 18 client-side files to import from `@/lib/auth-client` instead of `next-auth/react`
- No `next-auth/react` imports remain outside the wrapper module

This decouples the application from Auth.js on the client side, making it easy to swap auth providers in the future.

Relates to #45
Relates to #16

## Changes

| File | Before | After |
|---|---|---|
| `src/lib/auth-client.ts` | _(new)_ | Wrapper: `useAuth`, `login`, `logout`, `AuthProvider`, `AuthUser` type |
| `src/app/(app)/layout.tsx` | `SessionProvider` from `next-auth/react` | `AuthProvider` from `@/lib/auth-client` |
| `src/components/app-sidebar.tsx` | `signOut` from `next-auth/react` | `logout` from `@/lib/auth-client` |
| `src/app/login/page.tsx` | `signIn` from `next-auth/react` | `login` from `@/lib/auth-client` |
| `src/app/(app)/settings/page.tsx` | `useSession` + `session.user.*` | `useAuth` + `user.*` + `updateSession` |
| 14 other client components | `useSession` → `session.user.locale` | `useAuth` → `user?.locale` |

## What's NOT included (deferred)

Discord-specific coupling (schema `discordId` → `oauthId`, `oauthProvider` column, `signIn("discord")` in callbacks) is deferred to a follow-up issue to keep this PR focused on the client-side wrapper.