### PR TITLE
fix: move cache invalidation from Route Handler to Server Action

### DIFF
--- a/src/app/actions/sync.ts
+++ b/src/app/actions/sync.ts
@@ -1,0 +1,17 @@
+"use server";
+
+import { invalidateAllCaches } from "@/lib/cache";
+import { getCurrentUser } from "@/lib/session";
+
+/**
+ * Invalidate all caches after a sync completes. Called from the client
+ * after the SSE stream sends a "done" event with synced > 0.
+ *
+ * This exists because updateTag() (used by invalidateAllCaches) can only
+ * be called from Server Actions, not from Route Handlers.
+ */
+export async function invalidateSyncCaches() {
+  const user = await getCurrentUser();
+  if (!user) return;
+  invalidateAllCaches(user.id);
+}

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -3,7 +3,6 @@ import { eq, desc } from "drizzle-orm";
 import { checkGoalAchievement } from "@/app/actions/goals";
 import { db } from "@/db";
 import { matches, rankSnapshots, users } from "@/db/schema";
-import { invalidateAllCaches } from "@/lib/cache";
 import {
   getMatchIds,
   getMatch,
@@ -249,10 +248,8 @@ export async function GET() {
         // Check if rank goal was achieved after syncing
         await checkGoalAchievement(user.id);
 
-        // Invalidate all cached data for this user after syncing new matches
-        if (syncedCount > 0) {
-          invalidateAllCaches(user.id);
-        }
+        // Cache invalidation is handled client-side via a Server Action
+        // after the "done" event (updateTag cannot be called from Route Handlers).
 
         const parts = [`Synced ${syncedCount} match${syncedCount !== 1 ? "es" : ""}`];
         if (failedCount > 0) {

--- a/src/hooks/use-sync-matches.ts
+++ b/src/hooks/use-sync-matches.ts
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation";
 import { useState, useCallback, useRef, useEffect } from "react";
 import { toast } from "sonner";
 
+import { invalidateSyncCaches } from "@/app/actions/sync";
+
 interface SyncProgress {
   current: number;
   total: number;
@@ -79,7 +81,7 @@ export function useSyncMatches(isLinked: boolean = false) {
           let buffer = "";
           let receivedFinal = false;
 
-          const processMessage = (msg: string) => {
+          const processMessage = async (msg: string) => {
             const dataLine = msg.split("\n").find((line) => line.startsWith("data: "));
             if (!dataLine) return;
 
@@ -122,6 +124,7 @@ export function useSyncMatches(isLinked: boolean = false) {
                       id: toastIdRef.current,
                       duration: 8000,
                     });
+                    await invalidateSyncCaches();
                     router.refresh();
                   } else if (!silent) {
                     // Manual/login sync: always show the result
@@ -163,7 +166,7 @@ export function useSyncMatches(isLinked: boolean = false) {
             buffer = messages.pop() || "";
 
             for (const msg of messages) {
-              processMessage(msg);
+              await processMessage(msg);
             }
           }
 
@@ -171,7 +174,7 @@ export function useSyncMatches(isLinked: boolean = false) {
           // The final SSE message may not have a trailing \n\n before
           // the server closes the stream.
           if (buffer.trim()) {
-            processMessage(buffer);
+            await processMessage(buffer);
           }
 
           // If the stream ended without a done/error event, show a warning


### PR DESCRIPTION
## Summary

- Move `invalidateAllCaches()` call from the sync Route Handler (`/api/sync`) to a new Server Action (`invalidateSyncCaches`)
- The client hook (`use-sync-matches.ts`) now calls the Server Action after the SSE "done" event, before `router.refresh()`
- This fixes the `updateTag can only be called from within a Server Action` error that appeared on every sync

Fixes #77