### PR TITLE
fix: auto-switch review tab when current tab becomes empty

### DIFF
--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -989,8 +989,26 @@ export function ReviewClient({
         const nextMatch = vodReviewMatches[idx + 1];
         setExpandedVodId(nextMatch?.id ?? null);
       }
+
+      // Auto-switch tab when current tab becomes empty (#78)
+      // Compute next-state counts (after this match is removed)
+      const nextPostGameCount = postGameMatches.filter((m) => m.id !== matchId).length;
+      const nextVodCount = vodReviewMatches.filter((m) => m.id !== matchId).length;
+
+      if (tabValue === 0 && nextPostGameCount === 0 && nextVodCount > 0) {
+        handleTabChange(1);
+      } else if (tabValue === 1 && nextVodCount === 0 && nextPostGameCount > 0) {
+        handleTabChange(0);
+      }
     },
-    [expandedPostGameId, expandedVodId, postGameMatches, vodReviewMatches],
+    [
+      expandedPostGameId,
+      expandedVodId,
+      postGameMatches,
+      vodReviewMatches,
+      tabValue,
+      handleTabChange,
+    ],
   );
 
   const handleCompletedSaved = useCallback(() => {


### PR DESCRIPTION
## Summary

- When the last match in the Post-Game or VOD Review tab is reviewed/skipped, the tab now auto-switches to the other tab if it has remaining matches
- Prevents the user from being stuck on an empty tab with an empty-state placeholder

Fixes #78