### PR TITLE
fix: skip Vercel image optimization for small DDragon icons

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,7 @@ const nextConfig: NextConfig = {
   outputFileTracingRoot: path.resolve(__dirname),
   serverExternalPackages: ["@libsql/client"],
   images: {
+    minimumCacheTTL: 2592000, // 30 days — DDragon assets are versioned and never change
     remotePatterns: [
       {
         protocol: "https",

--- a/src/app/(app)/analytics/analytics-client.tsx
+++ b/src/app/(app)/analytics/analytics-client.tsx
@@ -972,6 +972,7 @@ export function AnalyticsClient({
                                 alt={rune.name}
                                 width={18}
                                 height={18}
+                                unoptimized
                                 className="rounded"
                               />
                             ) : null;

--- a/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
+++ b/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
@@ -409,6 +409,7 @@ export function CoachingDetailClient({
                         alt={match.championName}
                         width={32}
                         height={32}
+                        unoptimized
                         className="rounded"
                       />
                       <div className="flex-1">
@@ -422,6 +423,7 @@ export function CoachingDetailClient({
                                 alt={match.matchupChampionName}
                                 width={16}
                                 height={16}
+                                unoptimized
                                 className="rounded"
                               />
                               {match.matchupChampionName}
@@ -587,6 +589,7 @@ export function CoachingDetailClient({
                           alt={match.championName}
                           width={24}
                           height={24}
+                          unoptimized
                           className="rounded"
                         />
                         <span className="text-sm font-medium">{match.championName}</span>
@@ -599,6 +602,7 @@ export function CoachingDetailClient({
                                 alt={match.matchupChampionName}
                                 width={16}
                                 height={16}
+                                unoptimized
                                 className="rounded"
                               />
                               {match.matchupChampionName}

--- a/src/app/(app)/coaching/[id]/complete/complete-session-client.tsx
+++ b/src/app/(app)/coaching/[id]/complete/complete-session-client.tsx
@@ -180,6 +180,7 @@ export function CompleteSessionClient({
                   alt={vodMatch.championName}
                   width={24}
                   height={24}
+                  unoptimized
                   className="rounded"
                 />
                 <span className="text-sm">{vodMatch.championName}</span>

--- a/src/app/(app)/coaching/[id]/edit/edit-session-client.tsx
+++ b/src/app/(app)/coaching/[id]/edit/edit-session-client.tsx
@@ -265,6 +265,7 @@ export function EditSessionClient({
                         alt={match.championName}
                         width={20}
                         height={20}
+                        unoptimized
                         className="rounded"
                       />
                       {match.championName}
@@ -278,6 +279,7 @@ export function EditSessionClient({
                             alt={match.matchupChampionName}
                             width={16}
                             height={16}
+                            unoptimized
                             className="rounded"
                           />
                           {match.matchupChampionName}

--- a/src/app/(app)/coaching/coaching-hub-client.tsx
+++ b/src/app/(app)/coaching/coaching-hub-client.tsx
@@ -218,6 +218,7 @@ export function CoachingHubClient({
                                 alt={vodMatch.championName}
                                 width={16}
                                 height={16}
+                                unoptimized
                                 className="rounded"
                               />
                               {vodMatch.championName}
@@ -233,6 +234,7 @@ export function CoachingHubClient({
                                     alt={vodMatch.matchupChampionName}
                                     width={16}
                                     height={16}
+                                    unoptimized
                                     className="rounded"
                                   />
                                   {vodMatch.matchupChampionName}

--- a/src/app/(app)/coaching/new/schedule-session-client.tsx
+++ b/src/app/(app)/coaching/new/schedule-session-client.tsx
@@ -244,6 +244,7 @@ export function ScheduleSessionClient({
                         alt={match.championName}
                         width={20}
                         height={20}
+                        unoptimized
                         className="rounded"
                       />
                       {match.championName}
@@ -257,6 +258,7 @@ export function ScheduleSessionClient({
                             alt={match.matchupChampionName}
                             width={16}
                             height={16}
+                            unoptimized
                             className="rounded"
                           />
                           {match.matchupChampionName}

--- a/src/app/(app)/duo/duo-client.tsx
+++ b/src/app/(app)/duo/duo-client.tsx
@@ -48,6 +48,7 @@ function ChampionIcon({
       alt={championName}
       width={size}
       height={size}
+      unoptimized={size <= 32}
       className="rounded"
     />
   );

--- a/src/app/(app)/matches/[id]/match-detail-client.tsx
+++ b/src/app/(app)/matches/[id]/match-detail-client.tsx
@@ -168,6 +168,7 @@ function ParticipantRow({
                 alt={t("itemAlt", { itemId })}
                 width={24}
                 height={24}
+                unoptimized
                 className="rounded"
               />
             ))}
@@ -275,6 +276,7 @@ export function MatchDetailClient({
                           alt={match.runeKeystoneName}
                           width={20}
                           height={20}
+                          unoptimized
                           className="-my-0.5 inline"
                         />
                       ) : null;

--- a/src/app/(app)/matches/matches-client.tsx
+++ b/src/app/(app)/matches/matches-client.tsx
@@ -292,6 +292,7 @@ export function MatchesClient({
                     alt={c}
                     width={16}
                     height={16}
+                    unoptimized
                     className="rounded"
                   />
                   {c}

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -163,6 +163,7 @@ function MatchCardHeaderInfo({
                 alt={match.matchupChampionName}
                 width={16}
                 height={16}
+                unoptimized
                 className="rounded"
               />
               <span className="text-xs">{match.matchupChampionName}</span>
@@ -177,7 +178,14 @@ function MatchCardHeaderInfo({
               {(() => {
                 const iconUrl = getKeystoneIconUrlByName(match.runeKeystoneName);
                 return iconUrl ? (
-                  <Image src={iconUrl} alt="" width={14} height={14} className="rounded-sm" />
+                  <Image
+                    src={iconUrl}
+                    alt=""
+                    width={14}
+                    height={14}
+                    unoptimized
+                    className="rounded-sm"
+                  />
                 ) : null;
               })()}
               {match.runeKeystoneName}

--- a/src/app/(app)/scout/scout-client.tsx
+++ b/src/app/(app)/scout/scout-client.tsx
@@ -51,6 +51,7 @@ function ChampionIcon({
       alt={championName}
       width={size}
       height={size}
+      unoptimized={size <= 32}
       className="rounded"
     />
   );
@@ -215,6 +216,7 @@ function ScoutingReport({
                           alt={rune.keystoneName}
                           width={18}
                           height={18}
+                          unoptimized
                           className="rounded"
                         />
                       ) : null;

--- a/src/components/champion-combobox.tsx
+++ b/src/components/champion-combobox.tsx
@@ -91,6 +91,7 @@ export function ChampionCombobox({
                 alt={value}
                 width={20}
                 height={20}
+                unoptimized
                 className="rounded"
               />
               {value}
@@ -127,6 +128,7 @@ export function ChampionCombobox({
                               alt={c.name}
                               width={20}
                               height={20}
+                              unoptimized
                               className="rounded"
                             />
                             {c.name}
@@ -160,6 +162,7 @@ export function ChampionCombobox({
                         alt={name}
                         width={20}
                         height={20}
+                        unoptimized
                         className="rounded"
                       />
                       {name}

--- a/src/components/champion-link.tsx
+++ b/src/components/champion-link.tsx
@@ -80,6 +80,7 @@ export function ChampionLink({
           alt={champion}
           width={iconSize}
           height={iconSize}
+          unoptimized={iconSize <= 32}
           className="rounded"
         />
       )}

--- a/src/components/match-card.tsx
+++ b/src/components/match-card.tsx
@@ -70,6 +70,7 @@ function ChampionIcon({
       alt={championName}
       width={size}
       height={size}
+      unoptimized={size <= 32}
       className="rounded"
     />
   );
@@ -171,6 +172,7 @@ export function MatchCard({
                         alt={match.matchupChampionName}
                         width={isCompact ? 16 : 20}
                         height={isCompact ? 16 : 20}
+                        unoptimized
                         className="rounded"
                       />
                       {match.matchupChampionName}
@@ -215,7 +217,14 @@ export function MatchCard({
                   (() => {
                     const iconUrl = getKeystoneIconUrlByName(match.runeKeystoneName);
                     return iconUrl ? (
-                      <Image src={iconUrl} alt="" width={12} height={12} className="rounded-sm" />
+                      <Image
+                        src={iconUrl}
+                        alt=""
+                        width={12}
+                        height={12}
+                        unoptimized
+                        className="rounded-sm"
+                      />
                     ) : null;
                   })()}
                 <span>


### PR DESCRIPTION
## Summary

- Add `unoptimized` prop to all `<Image>` instances rendering DDragon champion icons, matchup icons, and keystone icons at **32px or smaller** across 15 files
- Add `unoptimized={size <= 32}` to `ChampionIcon` wrapper components (in `champion-link.tsx`, `match-card.tsx`, `scout-client.tsx`, `duo-client.tsx`) so callers at larger sizes still benefit from optimization
- Set `minimumCacheTTL: 2592000` (30 days) in `next.config.ts` for images that do go through the optimizer

DDragon assets are versioned by patch and never change — optimizing tiny icons wastes Vercel's image optimization quota without meaningful quality or size improvement.

**Images intentionally left optimized** (> 32px): champion icons at 36-56px, keystone at 36px, rank emblems at 48px.

Fixes #89