### PR TITLE
fix: stabilize action item E2E test with hydration guard

### DIFF
--- a/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
+++ b/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
@@ -90,6 +90,13 @@ function ActionItemRow({ item }: { item: CoachingActionItem }) {
   const t = useTranslations("CoachingDetail");
   const [isPending, startTransition] = useTransition();
 
+  // Signal that React has hydrated this component (event handlers attached).
+  // Used by E2E tests to avoid clicking before hydration completes (#95).
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
   // Optimistic status so the UI updates immediately on click (#74)
   const [optimisticStatus, setOptimisticStatus] = useState(item.status);
   // Sync with server-provided status when it changes (e.g. after revalidation)
@@ -130,6 +137,7 @@ function ActionItemRow({ item }: { item: CoachingActionItem }) {
     <div
       data-testid="action-item-row"
       data-status={displayStatus}
+      data-hydrated={hydrated || undefined}
       className="flex items-center gap-3 rounded-lg border border-border/50 bg-surface-elevated p-3"
     >
       <button

--- a/tests/e2e/coaching-flow.spec.ts
+++ b/tests/e2e/coaching-flow.spec.ts
@@ -197,15 +197,18 @@ test.describe("Coaching flow", () => {
     // Verify initial status is pending
     await expect(firstActionItemRow).toHaveAttribute("data-status", "pending");
 
+    // Wait for React hydration — event handlers aren't attached until this
+    // attribute appears. Without this guard the click can be silently swallowed
+    // on slow CI runners, causing the test to flake (#95).
+    await expect(firstActionItemRow).toHaveAttribute("data-hydrated", "true");
+
     // Click the cycle button — optimistic state updates the UI immediately
     const cycleButton = firstActionItemRow.locator("button").first();
     await expect(cycleButton).toBeVisible();
     await cycleButton.click();
 
     // The status should cycle from "pending" to "in_progress" (optimistic update)
-    await expect(firstActionItemRow).toHaveAttribute("data-status", "in_progress", {
-      timeout: 5_000,
-    });
+    await expect(firstActionItemRow).toHaveAttribute("data-status", "in_progress");
   });
 
   test("delete the new coaching session", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Add `data-hydrated` attribute to `ActionItemRow` that appears once React hydration completes (event handlers are attached)
- Update the E2E test to wait for `data-hydrated="true"` before clicking the status-cycle button
- Remove the explicit 5s timeout override on the status assertion — the project default (15s) provides sufficient headroom

**Root cause:** The test was clicking the button before React finished hydrating the server-streamed HTML. Since the `onClick` handler wasn't attached yet, the click was silently swallowed and `data-status` stayed `"pending"` forever. This only manifested on slow/loaded CI runners.

Fixes #95