### PR TITLE
fix: use useOptimistic for action item status cycling

### DIFF
--- a/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
+++ b/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
@@ -20,7 +20,7 @@ import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useOptimistic, useState, useTransition } from "react";
 import { toast } from "sonner";
 
 import type { CoachingSession, CoachingActionItem } from "@/db/schema";
@@ -97,12 +97,11 @@ function ActionItemRow({ item }: { item: CoachingActionItem }) {
     setHydrated(true);
   }, []);
 
-  // Optimistic status so the UI updates immediately on click (#74)
-  const [optimisticStatus, setOptimisticStatus] = useState(item.status);
-  // Sync with server-provided status when it changes (e.g. after revalidation)
-  useEffect(() => {
-    setOptimisticStatus(item.status);
-  }, [item.status]);
+  // Optimistic status so the UI updates immediately on click (#74).
+  // useOptimistic survives server re-renders during a transition — unlike
+  // the previous useState + sync useEffect which could be clobbered by a
+  // revalidation flight arriving with stale props, causing flaky E2E (#102).
+  const [optimisticStatus, setOptimisticStatus] = useOptimistic(item.status);
 
   const nextStatusMap: Record<string, "pending" | "in_progress" | "completed"> = {
     pending: "in_progress",
@@ -112,14 +111,12 @@ function ActionItemRow({ item }: { item: CoachingActionItem }) {
 
   function cycleStatus() {
     const next = nextStatusMap[optimisticStatus];
-    setOptimisticStatus(next);
     startTransition(async () => {
+      setOptimisticStatus(next);
       try {
         await updateActionItemStatus(item.id, next);
         toast.success(t("toasts.statusUpdated", { status: next.replace("_", " ") }));
       } catch {
-        // Revert on failure
-        setOptimisticStatus(item.status);
         toast.error(t("toasts.statusUpdateError"));
       }
     });

--- a/src/app/actions/coaching.ts
+++ b/src/app/actions/coaching.ts
@@ -215,9 +215,10 @@ export async function updateActionItemStatus(
     })
     .where(and(eq(coachingActionItems.id, itemId), eq(coachingActionItems.userId, user.id)));
 
-  // Use "layout" type to revalidate the entire /coaching tree,
-  // including /coaching/[id] detail pages that display action items.
-  revalidatePath("/coaching", "layout");
+  // Use "page" type to revalidate page components under /coaching without
+  // re-rendering the layout tree — "layout" can cause client component
+  // remounts that destroy optimistic state (#102).
+  revalidatePath("/coaching", "page");
   revalidatePath("/dashboard");
   invalidateCoachingCaches(user.id);
 
@@ -231,9 +232,10 @@ export async function deleteActionItem(itemId: number) {
     .delete(coachingActionItems)
     .where(and(eq(coachingActionItems.id, itemId), eq(coachingActionItems.userId, user.id)));
 
-  // Use "layout" type to revalidate the entire /coaching tree,
-  // including /coaching/[id] detail pages that display action items.
-  revalidatePath("/coaching", "layout");
+  // Use "page" type to revalidate page components under /coaching without
+  // re-rendering the layout tree — "layout" can cause client component
+  // remounts that destroy optimistic state (#102).
+  revalidatePath("/coaching", "page");
   revalidatePath("/dashboard");
   invalidateCoachingCaches(user.id);
 
@@ -256,7 +258,7 @@ export async function createActionItem(data: { description: string; topic?: stri
     topic: data.topic?.trim() || null,
   });
 
-  revalidatePath("/coaching", "layout");
+  revalidatePath("/coaching", "page");
   revalidatePath("/dashboard");
   invalidateCoachingCaches(user.id);
 


### PR DESCRIPTION
## Summary

Fixes the flaky E2E test that has been blocking CI on multiple PRs.

- **Replace `useState` + sync `useEffect` with `useOptimistic`** in `ActionItemRow` — the previous pattern was vulnerable to revalidation flights overwriting optimistic state during a transition, resetting `data-status` back to `"pending"` on slow CI runners
- **Narrow `revalidatePath` from `"layout"` to `"page"`** for all action item mutations — `"layout"` type revalidates the entire layout tree which can cause client component remounts that destroy local React state

Fixes #102

## Root cause

When clicking the status cycle button:

1. `setOptimisticStatus("in_progress")` fires immediately via `useState`
2. The server action calls `revalidatePath("/coaching", "layout")`
3. On slow CI, the RSC revalidation flight arrives with stale props (`status: "pending"`) before the DB write is visible
4. The sync `useEffect(() => setOptimisticStatus(item.status), [item.status])` overwrites the optimistic value back to `"pending"`
5. Or worse — the `"layout"` revalidation causes a full component remount, reinitializing `useState(item.status)` with stale data

React's `useOptimistic` hook is designed for exactly this case: it maintains an optimistic value that survives server re-renders during a transition and automatically resolves when the transition completes.

## Testing

- Build passes locally
- All 7 coaching E2E tests pass locally (including the previously flaky test at line 184)