### PR TITLE
Copy full invite URL instead of bare code

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -875,7 +875,8 @@
       "generateError": "Failed to generate invite.",
       "deleteSuccess": "Invite deleted.",
       "deleteError": "Failed to delete invite.",
-      "codeCopied": "Invite code copied to clipboard."
+      "codeCopied": "Invite code copied to clipboard.",
+      "linkCopied": "Invite link copied to clipboard."
     }
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -875,7 +875,8 @@
       "generateError": "Error al generar invitación.",
       "deleteSuccess": "Invitación eliminada.",
       "deleteError": "Error al eliminar invitación.",
-      "codeCopied": "Código de invitación copiado al portapapeles."
+      "codeCopied": "Código de invitación copiado al portapapeles.",
+      "linkCopied": "Enlace de invitación copiado al portapapeles."
     }
   }
 }

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -251,8 +251,9 @@ function InvitesSection() {
   }
 
   function handleCopyCode(code: string) {
-    void navigator.clipboard.writeText(code);
-    toast.success(t("toasts.codeCopied"));
+    const url = `${window.location.origin}/login?invite=${encodeURIComponent(code)}`;
+    void navigator.clipboard.writeText(url);
+    toast.success(t("toasts.linkCopied"));
   }
 
   function handleDelete(id: number) {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -119,8 +119,9 @@ function DiscordLoginForm() {
   const searchParams = useSearchParams();
   const error = searchParams.get("error");
 
-  const [showInvite, setShowInvite] = useState(!!error);
-  const [inviteCode, setInviteCode] = useState("");
+  const inviteParam = searchParams.get("invite") ?? "";
+  const [showInvite, setShowInvite] = useState(!!error || !!inviteParam);
+  const [inviteCode, setInviteCode] = useState(inviteParam);
 
   function handleSignIn() {
     // If invite code is provided, store it in a cookie before redirecting


### PR DESCRIPTION
## Summary

- Admin "copy invite" button now copies the full login URL (e.g. `https://lol-tracker.vercel.app/login?invite=abc123`) instead of the bare invite code
- Login page reads the `?invite=` query parameter and auto-fills the invite code field, so invited users just click the link and sign in
- Updated toast text to say "Invite link copied" in both English and Spanish

Relates to #52