### PR TITLE
Remove puuid from DuoPartnerInfo client response

### DIFF
--- a/src/app/actions/duo.ts
+++ b/src/app/actions/duo.ts
@@ -21,7 +21,6 @@ export interface DuoPartnerInfo {
   name: string | null;
   riotGameName: string | null;
   riotTagLine: string | null;
-  puuid: string | null;
 }
 
 export interface DuoStats {
@@ -77,7 +76,6 @@ export async function getDuoPartnerInfo(): Promise<DuoPartnerInfo | null> {
       name: true,
       riotGameName: true,
       riotTagLine: true,
-      puuid: true,
     },
   });
 


### PR DESCRIPTION
## Summary

- Removes `puuid` from the `DuoPartnerInfo` interface and the `getDuoPartnerInfo()` query, preventing it from leaking to the client
- Server-side code that needs `puuid` for match participant correlation fetches it independently via separate DB queries

Fixes #111