### PR TITLE
Security audit: harden auth, headers, sessions, and error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,16 @@ jobs:
           fi
           echo "Changelog files changed:"
           echo "$CHANGED"
+
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".tool-versions"
+          cache: npm
+      - run: npm ci
+      - name: Check for high/critical vulnerabilities (production)
+        run: npm audit --omit=dev --audit-level=high

--- a/.opencode/skills/drizzle-schema/SKILL.md
+++ b/.opencode/skills/drizzle-schema/SKILL.md
@@ -274,3 +274,21 @@ const champions = await db
   .from(matches)
   .where(eq(matches.userId, user.id));
 ```
+
+## Security
+
+### Always scope queries by userId
+
+Every DB query in a server action must filter by `userId: user.id` from `requireUser()`. Never trust a userId from client input.
+
+### SQL injection
+
+Drizzle ORM parameterises all queries automatically. When using `sql` tagged template literals, values are parameterised — never use string concatenation or interpolation for user input in SQL.
+
+```typescript
+// GOOD — parameterised
+sql`${matches.championName} LIKE ${pattern}`;
+
+// BAD — string interpolation (never do this)
+sql`champion_name LIKE '${userInput}'`;
+```

--- a/.opencode/skills/nextjs-auth/SKILL.md
+++ b/.opencode/skills/nextjs-auth/SKILL.md
@@ -171,3 +171,17 @@ export const requireUser = cache(async () => {
 | `UNTRUST_HOST` error                | Missing `AUTH_TRUST_HOST` on Vercel                             | Add `AUTH_TRUST_HOST=true` env var                                      |
 | Infinite redirect loop              | Middleware misconfigured or `signIn` callback returning falsy   | Check callback return values, ensure login page is public               |
 | Session missing custom fields       | Not extending session type or not mapping in `session` callback | Extend `Session` type in `types/next-auth.d.ts`, map fields in callback |
+
+## Security
+
+### Session data minimization
+
+The JWT session should contain only the minimum data needed by client components. Sensitive identifiers like `puuid` should NOT be in the session — use `isRiotLinked: boolean` instead. Server components that need the full user record should call `requireUser()` which reads from the DB.
+
+### Cookie security
+
+All cookies set by Auth.js and custom code must include the `Secure` flag. Auth.js handles this automatically in production. For custom cookies (invite codes, onboarding state), set `secure: true` explicitly.
+
+### requireUser() and requireAdmin()
+
+Both are in `src/lib/session.ts`. Every server action and API route must call one as its first operation. `requireAdmin()` is used for admin-only actions and is also checked at the layout level in `src/app/(app)/admin/layout.tsx`.

--- a/.opencode/skills/riot-api/SKILL.md
+++ b/.opencode/skills/riot-api/SKILL.md
@@ -262,3 +262,24 @@ The `rawMatchJson` column stores the full Riot match detail response (50-100KB p
 4. **Exclude from processing queries** — if a feature reads matches for processing (not display), it likely doesn't need rawMatchJson either.
 
 See `nextjs-performance` skill for the full server-side data extraction pattern.
+
+## Security
+
+### Error sanitization
+
+`RiotApiError` has a `userMessage` getter that maps status codes to safe user-facing messages. Never expose raw Riot API errors, status codes, or response bodies to the client.
+
+```typescript
+catch (err) {
+  if (err instanceof RiotApiError) {
+    return { error: err.userMessage };  // safe for client
+  }
+  return { error: "An unexpected error occurred." };
+}
+```
+
+### API key protection
+
+- `RIOT_API_KEY` is server-only — never expose in client bundles or CSP
+- The key is only read in `src/lib/riot-api.ts` server-side functions
+- All Riot data flows: server action/route → DB → client component (never direct client→Riot)

--- a/.opencode/skills/security/SKILL.md
+++ b/.opencode/skills/security/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: security
+description: Security patterns for lol-tracker — CSP, cookie flags, error sanitization, auth checks, URL validation, and supply-chain monitoring
+---
+
+## What I do
+
+Guide secure coding patterns for the lol-tracker Next.js application, covering HTTP security headers, authentication/authorization checks, input validation, error handling, and supply-chain security.
+
+## When to use me
+
+- Adding new server actions or API routes (auth/authz checklist)
+- Rendering user-supplied URLs (XSS prevention)
+- Handling external API errors (information leakage prevention)
+- Modifying cookies or session data (security flags)
+- Reviewing Content Security Policy impact of new external resources
+- Adding new npm dependencies (supply-chain risk assessment)
+
+## Security headers
+
+All security headers are configured in `next.config.ts` via the `headers()` function:
+
+- **Content-Security-Policy**: Enforcing (not report-only). Allows `'self'`, `'unsafe-inline'` (required by `next-themes`), and specific external domains (CDN, Discord avatars, DDragon).
+- **Strict-Transport-Security**: `max-age=63072000; includeSubDomains; preload`
+- **X-Content-Type-Options**: `nosniff`
+- **Referrer-Policy**: `strict-origin-when-cross-origin`
+- **Permissions-Policy**: Restrictive — disables camera, microphone, geolocation, etc.
+- **X-Frame-Options**: `SAMEORIGIN`
+- **poweredByHeader**: Disabled in `next.config.ts`
+
+### Adding new external resources
+
+When adding a new external CDN, image host, or script source:
+
+1. Update the CSP in `next.config.ts`
+2. Add only the specific domain needed (never use `*`)
+3. Test with browser DevTools console — CSP violations appear there
+
+### Why `'unsafe-inline'` is needed
+
+`next-themes` injects an inline `<script>` via `dangerouslySetInnerHTML` to prevent FOUC. Nonce-based CSP is incompatible with Next.js PPR and `cacheComponents: true`. If `next-themes` is removed, switch to nonce-based CSP.
+
+## Authentication & authorization checklist
+
+### Every server action MUST:
+
+1. Call `requireUser()` (or `requireAdmin()`) as its first operation
+2. Scope all DB queries with `userId: user.id` from the authenticated session
+3. Never accept a `userId` parameter from the client — derive it from the session
+
+### Internal server-to-server functions
+
+Functions called only from other server code (e.g., sync route calling goal checks) must NOT be exported from `"use server"` files. Place them in `src/lib/` instead. If a function in a `"use server"` file accepts a `userId` parameter, it's a red flag — anyone can invoke it with an arbitrary ID.
+
+Pattern:
+
+```
+// BAD — in a "use server" file, callable from client with any userId
+export async function checkGoalAchievement(userId: string) { ... }
+
+// GOOD — in src/lib/goals.ts (not a server action)
+export async function checkGoalAchievement(userId: string) { ... }
+```
+
+### Admin routes
+
+- Server-side guard: `src/app/(app)/admin/layout.tsx` checks `user.role === "admin"` and redirects non-admins
+- Action-level guard: `requireAdmin()` from `src/lib/session.ts` in every admin action
+- Both layers are required — the layout prevents page load, the action prevents direct invocation
+
+## Session data — minimal exposure
+
+The client-side session (JWT) should contain the minimum data needed:
+
+- `id`, `name`, `email`, `image` — standard fields
+- `isRiotLinked: boolean` — NOT the raw `puuid`
+- `region`, `onboardingCompleted`, `role`, `locale`, `language`, `primaryRole`, `secondaryRole`
+
+Never expose sensitive identifiers (puuid, internal IDs beyond the user's own) in the session token. Server components that need the full DB user should call `requireUser()`.
+
+## URL validation
+
+User-supplied URLs (VOD links, external resources) must be validated:
+
+### On write (server action)
+
+```typescript
+import { validateVodUrl } from "@/lib/url";
+
+const sanitised = validateVodUrl(data.vodUrl);
+if (data.vodUrl?.trim() && !sanitised) {
+  return { error: "Invalid VOD URL. Only http:// and https:// links are allowed." };
+}
+```
+
+### On render (client component)
+
+```typescript
+import { safeExternalUrl } from "@/lib/url";
+
+<a href={safeExternalUrl(match.vodUrl) ?? "#"} target="_blank" rel="noopener noreferrer">
+```
+
+Both functions reject `javascript:`, `data:`, `vbscript:`, and other dangerous URI schemes.
+
+## Error sanitization
+
+### Riot API errors
+
+`RiotApiError` (in `src/lib/riot-api.ts`) has a `userMessage` getter that maps HTTP status codes to generic user-facing messages. Server-side code logs the full error; client-facing code uses `userMessage`.
+
+```typescript
+catch (err) {
+  if (err instanceof RiotApiError) {
+    return { error: err.userMessage };  // safe for client
+  }
+  return { error: "An unexpected error occurred." };
+}
+```
+
+Never expose raw API responses, status codes, or stack traces to the client.
+
+## Cookie security
+
+All cookies set by the app must include the `Secure` flag in production. Check protocol before setting on the client:
+
+```typescript
+// Server-side (always secure in production)
+cookies().set("name", value, { secure: true, httpOnly: true, sameSite: "lax" });
+
+// Client-side
+document.cookie = `name=value; path=/; max-age=...; samesite=lax${
+  window.location.protocol === "https:" ? "; secure" : ""
+}`;
+```
+
+## Export safety
+
+Data export endpoints (e.g., CSV export) must include a `LIMIT` clause to prevent unbounded queries. The current limit is 10,000 rows in `src/app/api/export/matches/route.ts`.
+
+## Supply-chain security
+
+- **Dependabot**: Vulnerability alerts and automated security updates are enabled on the GitHub repo
+- **CI audit**: `npm audit --omit=dev --audit-level=high` runs in CI on every PR, failing on high/critical production vulnerabilities
+- **Dev-only CVEs**: Tracked but not blocking (e.g., esbuild CVEs via drizzle-kit)
+
+## SQL injection
+
+Drizzle ORM parameterises all queries automatically. Raw SQL is only used via `sql` tagged template literals, which also parameterise values. No string concatenation in queries.
+
+## Rate limiting
+
+Inbound rate limiting is tracked as a separate issue. The Riot API client handles outbound rate limits via retry logic in `riotFetch`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,3 +165,26 @@ If you forgot to capture "before" screenshots, check out `main`, capture them, t
 Full workflow details are in the `ui-screenshots` OpenCode skill.
 
 <!-- END:ui-screenshots-rules -->
+
+<!-- BEGIN:security-rules -->
+
+# Security — MANDATORY
+
+**Every server action and API route MUST call `requireUser()` or `requireAdmin()` as its first operation.** All DB queries must be scoped with `userId: user.id` from the authenticated session. Never accept a `userId` parameter from the client.
+
+**Functions that accept a `userId` parameter MUST NOT be exported from `"use server"` files.** Place them in `src/lib/` instead — otherwise any client can invoke them with an arbitrary user ID.
+
+**User-supplied URLs (VOD links, etc.) MUST be validated:**
+
+1. On write: use `validateVodUrl()` from `src/lib/url.ts` in the server action
+2. On render: use `safeExternalUrl()` from `src/lib/url.ts` in the `href` attribute
+
+**Never expose raw API errors, status codes, or stack traces to the client.** Use `RiotApiError.userMessage` for Riot API errors and generic messages for everything else.
+
+**All cookies MUST include the `Secure` flag** (with protocol check for client-side cookies).
+
+**When adding new external resources** (CDN, images, scripts), update the CSP in `next.config.ts`. Never use `*` wildcards.
+
+Full security patterns are in the `security` OpenCode skill.
+
+<!-- END:security-rules -->

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,30 @@ import path from "path";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
+// ─── Content Security Policy ──────────────────────────────────────────────────
+const isDev = process.env.NODE_ENV === "development";
+
+const cspDirectives = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://ddragon.leagueoflegends.com https://cdn.discordapp.com https://raw.communitydragon.org",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "object-src 'none'",
+  "frame-src 'none'",
+  "worker-src 'self'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  "base-uri 'self'",
+  "upgrade-insecure-requests",
+];
+
+const cspHeader = cspDirectives.join("; ");
+
+// ─── Next.js Configuration ───────────────────────────────────────────────────
 const nextConfig: NextConfig = {
+  poweredByHeader: false,
   cacheComponents: true,
   outputFileTracingRoot: path.resolve(__dirname),
   serverExternalPackages: ["@libsql/client"],
@@ -28,6 +51,28 @@ const nextConfig: NextConfig = {
         pathname: "/latest/plugins/**",
       },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "Content-Security-Policy", value: cspHeader },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-DNS-Prefetch-Control", value: "on" },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+          },
+        ],
+      },
+    ];
   },
 };
 

--- a/src/app/(app)/admin/layout.tsx
+++ b/src/app/(app)/admin/layout.tsx
@@ -1,0 +1,13 @@
+import { redirect } from "next/navigation";
+
+import { requireUser } from "@/lib/session";
+
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  const user = await requireUser();
+
+  if (user.role !== "admin") {
+    redirect("/dashboard");
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
+++ b/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
@@ -35,6 +35,7 @@ import { Separator } from "@/components/ui/separator";
 import { useAuth } from "@/lib/auth-client";
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
 import { getChampionIconUrl } from "@/lib/riot-api";
+import { safeExternalUrl } from "@/lib/url";
 
 interface LinkedMatch {
   id: string;
@@ -452,7 +453,7 @@ export function CoachingDetailClient({
                       <div className="ml-3 flex items-center gap-2">
                         <Video className="h-3.5 w-3.5 text-electric" />
                         <a
-                          href={match.vodUrl}
+                          href={safeExternalUrl(match.vodUrl) ?? "#"}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="inline-flex items-center gap-1 truncate text-xs text-electric hover:underline"

--- a/src/app/(app)/coaching/[id]/complete/complete-session-client.tsx
+++ b/src/app/(app)/coaching/[id]/complete/complete-session-client.tsx
@@ -33,6 +33,7 @@ import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { getChampionIconUrl } from "@/lib/riot-api";
 import { PREDEFINED_TOPICS } from "@/lib/topics";
+import { safeExternalUrl } from "@/lib/url";
 
 interface VodMatch {
   id: string;
@@ -199,7 +200,7 @@ export function CompleteSessionClient({
                 <div className="flex items-center gap-2">
                   <Video className="h-3.5 w-3.5 text-electric" />
                   <a
-                    href={vodMatch.vodUrl}
+                    href={safeExternalUrl(vodMatch.vodUrl) ?? "#"}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="truncate text-xs text-electric hover:underline"

--- a/src/app/(app)/coaching/[id]/edit/edit-session-client.tsx
+++ b/src/app/(app)/coaching/[id]/edit/edit-session-client.tsx
@@ -23,6 +23,7 @@ import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { getChampionIconUrl } from "@/lib/riot-api";
 import { PREDEFINED_TOPICS } from "@/lib/topics";
+import { safeExternalUrl } from "@/lib/url";
 
 interface MatchSummary {
   id: string;
@@ -337,7 +338,7 @@ export function EditSessionClient({
                 <div className="flex items-center gap-2">
                   <Video className="h-3.5 w-3.5 text-electric" />
                   <a
-                    href={selectedMatch.vodUrl}
+                    href={safeExternalUrl(selectedMatch.vodUrl) ?? "#"}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="truncate text-xs text-electric hover:underline"

--- a/src/app/(app)/coaching/new/schedule-session-client.tsx
+++ b/src/app/(app)/coaching/new/schedule-session-client.tsx
@@ -20,6 +20,7 @@ import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { getChampionIconUrl } from "@/lib/riot-api";
 import { PREDEFINED_TOPICS } from "@/lib/topics";
+import { safeExternalUrl } from "@/lib/url";
 
 interface MatchSummary {
   id: string;
@@ -316,7 +317,7 @@ export function ScheduleSessionClient({
                 <div className="flex items-center gap-2">
                   <Video className="h-3.5 w-3.5 text-electric" />
                   <a
-                    href={selectedMatch.vodUrl}
+                    href={safeExternalUrl(selectedMatch.vodUrl) ?? "#"}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="truncate text-xs text-electric hover:underline"

--- a/src/app/(app)/dashboard/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/dashboard-client.tsx
@@ -83,7 +83,7 @@ interface DashboardClientProps {
     name?: string | null;
     riotGameName?: string | null;
     riotTagLine?: string | null;
-    puuid?: string | null;
+    isRiotLinked?: boolean;
   };
   recentMatches: DashboardMatch[];
   highlightsPerMatch: Record<string, MatchHighlightData[]>;
@@ -144,7 +144,7 @@ export function DashboardClient({
   const t = useTranslations("Dashboard");
   const { user: authUser } = useAuth();
   const locale = authUser?.locale ?? DEFAULT_LOCALE;
-  const isLinked = !!user.puuid;
+  const isLinked = !!user.isRiotLinked;
   const streak = getStreak(recentMatches);
   const rankInfo = getRankDisplay(latestRank);
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -235,7 +235,7 @@ export default async function DashboardPage() {
         name: user.name,
         riotGameName: user.riotGameName,
         riotTagLine: user.riotTagLine,
-        puuid: user.puuid,
+        isRiotLinked: !!user.puuid,
       }}
       recentMatches={recentMatches}
       highlightsPerMatch={highlightsPerMatch}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -40,7 +40,7 @@ async function SidebarWithUser() {
         image: user.image,
         riotGameName: user.riotGameName,
         riotTagLine: user.riotTagLine,
-        puuid: user.puuid,
+        isRiotLinked: !!user.puuid,
         role: user.role,
       }}
       reviewCounts={{

--- a/src/app/(app)/matches/[id]/match-detail-client.tsx
+++ b/src/app/(app)/matches/[id]/match-detail-client.tsx
@@ -41,6 +41,7 @@ import {
 import { useAuth } from "@/lib/auth-client";
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
 import { getKeystoneIconUrl } from "@/lib/riot-api";
+import { safeExternalUrl } from "@/lib/url";
 
 /** Slim participant — only fields needed for the match detail view */
 type SlimParticipant = Pick<
@@ -546,7 +547,7 @@ export function MatchDetailClient({
                           {t("ascentVod")}
                         </p>
                         <a
-                          href={match.vodUrl!}
+                          href={safeExternalUrl(match.vodUrl) ?? "#"}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="inline-flex items-center gap-1 text-sm text-electric hover:underline"

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -68,6 +68,7 @@ import { useAuth } from "@/lib/auth-client";
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
 import { getKeystoneIconUrlByName, getChampionIconUrl } from "@/lib/riot-api";
 import { SKIP_REVIEW_REASONS } from "@/lib/topics";
+import { safeExternalUrl } from "@/lib/url";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -524,7 +525,7 @@ function VodReviewCard({
             />
             {match.vodUrl && (
               <a
-                href={match.vodUrl}
+                href={safeExternalUrl(match.vodUrl) ?? "#"}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-xs text-electric hover:underline"
@@ -779,7 +780,7 @@ function CompletedCard({
         <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
           {match.vodUrl && (
             <a
-              href={match.vodUrl}
+              href={safeExternalUrl(match.vodUrl) ?? "#"}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 text-electric hover:underline"
@@ -1209,7 +1210,7 @@ export function ReviewClient({
         </div>
       )}
 
-      {user?.puuid && !user?.region && (
+      {user?.isRiotLinked && !user?.region && (
         <div className="flex items-center gap-2 rounded-lg border border-gold/30 bg-gold/10 p-3 text-sm text-gold-light">
           <Globe className="h-4 w-4 shrink-0" />
           <span>

--- a/src/app/actions/admin.ts
+++ b/src/app/actions/admin.ts
@@ -4,15 +4,7 @@ import { eq, count, max, sql } from "drizzle-orm";
 
 import { db } from "@/db";
 import { users, matches } from "@/db/schema";
-import { requireUser } from "@/lib/session";
-
-async function requireAdmin() {
-  const user = await requireUser();
-  if (user.role !== "admin") {
-    throw new Error("Unauthorized: admin access required");
-  }
-  return user;
-}
+import { requireAdmin } from "@/lib/session";
 
 export interface AdminUser {
   id: string;

--- a/src/app/actions/goals.ts
+++ b/src/app/actions/goals.ts
@@ -6,7 +6,6 @@ import { revalidatePath } from "next/cache";
 import { db } from "@/db";
 import { goals, rankSnapshots } from "@/db/schema";
 import { invalidateGoalsCaches } from "@/lib/cache";
-import { hasReachedTarget } from "@/lib/rank";
 import { requireUser } from "@/lib/session";
 
 // ─── Create a new goal ──────────────────────────────────────────────────────
@@ -104,46 +103,4 @@ export async function deleteGoal(goalId: number) {
   invalidateGoalsCaches(user.id);
 
   return { success: true };
-}
-
-// ─── Check goal achievement ─────────────────────────────────────────────────
-// Called after each rank snapshot capture (from sync route).
-// Returns true if the goal was just achieved.
-
-export async function checkGoalAchievement(userId: string): Promise<boolean> {
-  const activeGoal = await db.query.goals.findFirst({
-    where: and(eq(goals.userId, userId), eq(goals.status, "active")),
-  });
-
-  if (!activeGoal) return false;
-
-  const latestSnapshot = await db.query.rankSnapshots.findFirst({
-    where: eq(rankSnapshots.userId, userId),
-    orderBy: desc(rankSnapshots.capturedAt),
-  });
-
-  if (!latestSnapshot?.tier) return false;
-
-  const reached = hasReachedTarget(
-    latestSnapshot.tier,
-    latestSnapshot.division,
-    latestSnapshot.lp ?? 0,
-    activeGoal.targetTier,
-    activeGoal.targetDivision,
-  );
-
-  if (reached) {
-    await db
-      .update(goals)
-      .set({
-        status: "achieved",
-        achievedAt: new Date(),
-      })
-      .where(eq(goals.id, activeGoal.id));
-
-    invalidateGoalsCaches(userId);
-    return true;
-  }
-
-  return false;
 }

--- a/src/app/actions/invites.ts
+++ b/src/app/actions/invites.ts
@@ -4,7 +4,7 @@ import { eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db";
 import { invites, users } from "@/db/schema";
-import { requireUser } from "@/lib/session";
+import { requireAdmin } from "@/lib/session";
 
 function generateCode(): string {
   // 8-char alphanumeric code (URL-safe, easy to copy-paste)
@@ -16,14 +16,6 @@ function generateCode(): string {
     code += chars[byte % chars.length];
   }
   return code;
-}
-
-async function requireAdmin() {
-  const user = await requireUser();
-  if (user.role !== "admin") {
-    throw new Error("Unauthorized: admin access required");
-  }
-  return user;
 }
 
 export async function createInvite() {

--- a/src/app/actions/matches.ts
+++ b/src/app/actions/matches.ts
@@ -7,6 +7,7 @@ import { db } from "@/db";
 import { matches, matchHighlights } from "@/db/schema";
 import { invalidateReviewCaches } from "@/lib/cache";
 import { requireUser } from "@/lib/session";
+import { validateVodUrl } from "@/lib/url";
 
 /**
  * Save a complete post-game review in one action:
@@ -46,12 +47,18 @@ export async function savePostGameReview(
     );
   }
 
+  // Validate VOD URL scheme (reject javascript:, data:, etc.)
+  const sanitisedVodUrl = validateVodUrl(data.vodUrl);
+  if (data.vodUrl?.trim() && !sanitisedVodUrl) {
+    return { error: "Invalid VOD URL. Only http:// and https:// links are allowed." };
+  }
+
   // Update match fields
   await db
     .update(matches)
     .set({
       comment: data.comment || null,
-      vodUrl: data.vodUrl || null,
+      vodUrl: sanitisedVodUrl,
       reviewed: data.reviewed ?? false,
       reviewNotes: data.reviewNotes || null,
       reviewSkippedReason: data.reviewSkippedReason || null,

--- a/src/app/actions/onboarding.ts
+++ b/src/app/actions/onboarding.ts
@@ -42,6 +42,7 @@ export async function completeOnboarding() {
     path: "/",
     httpOnly: false,
     sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
     maxAge: 60,
   });
 

--- a/src/app/actions/settings.ts
+++ b/src/app/actions/settings.ts
@@ -9,7 +9,7 @@ import { users } from "@/db/schema";
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from "@/i18n/request";
 import { invalidateAllCaches, invalidateDuoCaches } from "@/lib/cache";
 import { SUPPORTED_LOCALES, type SupportedLocale } from "@/lib/format";
-import { getAccountByRiotId, PLATFORM_IDS } from "@/lib/riot-api";
+import { getAccountByRiotId, RiotApiError, PLATFORM_IDS } from "@/lib/riot-api";
 import { requireUser } from "@/lib/session";
 
 export async function linkRiotAccount(formData: FormData) {
@@ -55,7 +55,9 @@ export async function linkRiotAccount(formData: FormData) {
       tagLine: account.tagLine,
     };
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : "Failed to link Riot account";
+    console.error("linkRiotAccount error:", error);
+    const message =
+      error instanceof RiotApiError ? error.userMessage : "Failed to link Riot account";
     return { error: message };
   }
 }
@@ -161,7 +163,6 @@ export async function getDuoPartner() {
       name: true,
       riotGameName: true,
       riotTagLine: true,
-      puuid: true,
     },
   });
 
@@ -277,6 +278,7 @@ export async function updateLanguage(language: SupportedLanguage) {
     path: "/",
     httpOnly: false,
     sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
     maxAge: 60 * 60 * 24 * 365, // 1 year
   });
 

--- a/src/app/api/export/matches/route.ts
+++ b/src/app/api/export/matches/route.ts
@@ -6,6 +6,10 @@ import { getCurrentUser } from "@/lib/session";
 
 // ─── CSV Helpers ─────────────────────────────────────────────────────────────
 
+// Safety limit — prevents unbounded queries on the free-tier DB.
+// 10 000 rows ≈ ~3 years of daily play. Adjust if needed.
+const EXPORT_LIMIT = 10_000;
+
 /** Escape a value for CSV: wrap in quotes if it contains commas, quotes, or newlines. */
 function csvEscape(value: string | number | boolean | null | undefined): string {
   if (value === null || value === undefined) return "";
@@ -141,6 +145,7 @@ export async function GET(request: Request) {
   const allMatches = await db.query.matches.findMany({
     where: and(...conditions),
     orderBy: desc(matches.gameDate),
+    limit: EXPORT_LIMIT,
     columns: {
       id: true,
       gameDate: true,

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,8 +1,8 @@
 import { eq, desc } from "drizzle-orm";
 
-import { checkGoalAchievement } from "@/app/actions/goals";
 import { db } from "@/db";
 import { matches, rankSnapshots, users } from "@/db/schema";
+import { checkGoalAchievement } from "@/lib/goals";
 import { calculateAdaptiveDelay } from "@/lib/rate-limiter";
 import {
   getMatchIds,
@@ -384,8 +384,11 @@ export async function GET(request: Request) {
           message: parts.join(" ") + ".",
         });
       } catch (error) {
-        const message = error instanceof Error ? error.message : "Failed to sync matches";
-        console.error("Sync error:", message);
+        console.error("Sync error:", error);
+        const message =
+          error instanceof RiotApiError
+            ? error.userMessage
+            : "Failed to sync matches. Please try again.";
         send({ type: "error", message });
       } finally {
         // Always release the lock when done (success, error, or crash)

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -126,7 +126,7 @@ function DiscordLoginForm() {
   function handleSignIn() {
     // If invite code is provided, store it in a cookie before redirecting
     if (inviteCode.trim()) {
-      document.cookie = `invite-code=${encodeURIComponent(inviteCode.trim())}; path=/; max-age=300; SameSite=Lax`;
+      document.cookie = `invite-code=${encodeURIComponent(inviteCode.trim())}; path=/; max-age=300; SameSite=Lax${window.location.protocol === "https:" ? "; Secure" : ""}`;
     }
     void login("discord", { callbackUrl: "/dashboard" });
   }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -79,7 +79,7 @@ interface SidebarProps {
     image?: string | null;
     riotGameName?: string | null;
     riotTagLine?: string | null;
-    puuid?: string | null;
+    isRiotLinked?: boolean;
     role?: string | null;
   };
   reviewCounts?: {
@@ -137,7 +137,7 @@ function SidebarContent({
   onNavClick,
 }: SidebarProps & { onNavClick?: () => void }) {
   const t = useTranslations("Sidebar");
-  const isLinked = !!user.puuid;
+  const isLinked = !!user.isRiotLinked;
   const { isSyncing, handleSync } = useSyncMatches(isLinked);
 
   // Track whether there are unseen changelog entries

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -21,7 +21,7 @@ export interface AuthUser {
   image?: string | null;
   riotGameName?: string | null;
   riotTagLine?: string | null;
-  puuid?: string | null;
+  isRiotLinked?: boolean;
   region?: string | null;
   onboardingCompleted?: boolean;
   role?: string | null;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -40,6 +40,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           path: "/",
           httpOnly: false,
           sameSite: "lax",
+          secure: process.env.NODE_ENV === "production",
           maxAge: 60 * 60 * 24 * 365,
         });
         if (existing.puuid) {
@@ -47,6 +48,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             path: "/",
             httpOnly: false,
             sameSite: "lax",
+            secure: process.env.NODE_ENV === "production",
             maxAge: 60,
           });
         }
@@ -81,6 +83,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             path: "/",
             httpOnly: false, // Client JS needs to read it
             sameSite: "lax",
+            secure: process.env.NODE_ENV === "production",
             maxAge: 60 * 60 * 24 * 365, // 1 year
           });
 
@@ -90,6 +93,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
               path: "/",
               httpOnly: false, // Client JS needs to read it
               sameSite: "lax",
+              secure: process.env.NODE_ENV === "production",
               maxAge: 60, // Short-lived — consumed once by the client
             });
           }
@@ -172,7 +176,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           session.user.id = dbUser.id;
           session.user.riotGameName = dbUser.riotGameName;
           session.user.riotTagLine = dbUser.riotTagLine;
-          session.user.puuid = dbUser.puuid;
+          session.user.isRiotLinked = !!dbUser.puuid;
           session.user.region = dbUser.region;
           session.user.onboardingCompleted = dbUser.onboardingCompleted;
           session.user.role = dbUser.role;

--- a/src/lib/goals.ts
+++ b/src/lib/goals.ts
@@ -1,0 +1,54 @@
+// ─── Internal goal helpers (NOT a server action) ────────────────────────────
+// These functions accept a userId parameter and are only called server-to-server
+// (e.g., from the sync route). They must NEVER be exported from a "use server"
+// file, otherwise a client could invoke them with an arbitrary userId.
+
+import { eq, and, desc } from "drizzle-orm";
+
+import { db } from "@/db";
+import { goals, rankSnapshots } from "@/db/schema";
+import { invalidateGoalsCaches } from "@/lib/cache";
+import { hasReachedTarget } from "@/lib/rank";
+
+/**
+ * Check whether a user's active goal has been achieved based on their latest
+ * rank snapshot. Called after each rank snapshot capture (from sync route).
+ * Returns true if the goal was just achieved.
+ */
+export async function checkGoalAchievement(userId: string): Promise<boolean> {
+  const activeGoal = await db.query.goals.findFirst({
+    where: and(eq(goals.userId, userId), eq(goals.status, "active")),
+  });
+
+  if (!activeGoal) return false;
+
+  const latestSnapshot = await db.query.rankSnapshots.findFirst({
+    where: eq(rankSnapshots.userId, userId),
+    orderBy: desc(rankSnapshots.capturedAt),
+  });
+
+  if (!latestSnapshot?.tier) return false;
+
+  const reached = hasReachedTarget(
+    latestSnapshot.tier,
+    latestSnapshot.division,
+    latestSnapshot.lp ?? 0,
+    activeGoal.targetTier,
+    activeGoal.targetDivision,
+  );
+
+  if (reached) {
+    await db
+      .update(goals)
+      .set({
+        status: "achieved",
+        achievedAt: new Date(),
+      })
+      .where(eq(goals.id, activeGoal.id));
+
+    invalidateGoalsCaches(userId);
+    return true;
+  }
+
+  return false;
+}

--- a/src/lib/riot-api.ts
+++ b/src/lib/riot-api.ts
@@ -188,6 +188,24 @@ export class RiotApiError extends Error {
     super(message);
     this.name = "RiotApiError";
   }
+
+  /** Return a safe message that can be shown to the client (no internal details). */
+  get userMessage(): string {
+    switch (this.status) {
+      case 401:
+      case 403:
+        return "Riot API authorization failed. Please try again later.";
+      case 404:
+        return "Riot account not found. Please check your Riot ID and region.";
+      case 429:
+        return "Too many requests to Riot servers. Please wait a moment and try again.";
+      case 503:
+      case 504:
+        return "Riot servers are temporarily unavailable. Please try again later.";
+      default:
+        return "An error occurred while communicating with Riot servers.";
+    }
+  }
 }
 
 async function riotFetch<T>(url: string, retries = 5): Promise<T> {
@@ -228,7 +246,9 @@ async function riotFetch<T>(url: string, retries = 5): Promise<T> {
     }
 
     const body = await response.text().catch(() => "");
-    throw new RiotApiError(response.status, `Riot API error ${response.status}: ${body}`);
+    // Log full detail server-side, but throw a generic message for client safety
+    console.error(`Riot API error ${response.status} for ${url}: ${body}`);
+    throw new RiotApiError(response.status, `Riot API error ${response.status}`);
   }
 
   // Should never reach here, but TypeScript needs it

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -34,3 +34,11 @@ export async function requireUser() {
   }
   return user;
 }
+
+export async function requireAdmin() {
+  const user = await requireUser();
+  if (user.role !== "admin") {
+    throw new Error("Unauthorized: admin access required");
+  }
+  return user;
+}

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,33 @@
+// ─── URL safety utilities ───────────────────────────────────────────────────
+// Prevents XSS via javascript: / data: / vbscript: URIs in user-supplied URLs.
+
+const ALLOWED_SCHEMES = new Set(["http:", "https:"]);
+
+/**
+ * Returns the URL string if it uses an allowed scheme (http/https), or `null`
+ * if the URL is invalid or uses a dangerous scheme (javascript:, data:, etc.).
+ *
+ * Use this wherever user-supplied URLs are rendered as `href` attributes.
+ */
+export function safeExternalUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+
+  try {
+    const parsed = new URL(url);
+    if (ALLOWED_SCHEMES.has(parsed.protocol)) {
+      return parsed.href; // normalised
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validates a VOD URL for storage. Returns the sanitised URL or null.
+ * Empty/whitespace strings return null (clear the field).
+ */
+export function validateVodUrl(url: string | null | undefined): string | null {
+  if (!url?.trim()) return null;
+  return safeExternalUrl(url.trim());
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -9,7 +9,7 @@ declare module "next-auth" {
       image?: string | null;
       riotGameName?: string | null;
       riotTagLine?: string | null;
-      puuid?: string | null;
+      isRiotLinked?: boolean;
       region?: string | null;
       onboardingCompleted?: boolean;
       role?: string | null;


### PR DESCRIPTION
## Summary

Comprehensive security audit addressing all findings from #97. Infrastructure-only — no user-visible changes.

### HIGH severity fixes
- **Session data exposure**: Replaced raw `puuid` with `isRiotLinked: boolean` in client JWT session
- **Server action auth bypass**: Moved `checkGoalAchievement(userId)` out of `"use server"` file into `src/lib/goals.ts` — prevents client invocation with arbitrary user ID
- **XSS via VOD URLs**: Added `safeExternalUrl()` / `validateVodUrl()` in `src/lib/url.ts` — validates URL scheme on both write (server action) and render (7 client components) paths

### MEDIUM severity fixes
- **Security headers**: CSP (enforcing), HSTS, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, X-Frame-Options
- **`poweredByHeader: false`** in next.config.ts
- **Cookie `Secure` flag**: All 7 cookie-setting locations (auth callbacks, settings, onboarding, login)
- **Admin route guard**: New `src/app/(app)/admin/layout.tsx` with server-side role check + redirect
- **Shared `requireAdmin()`**: Extracted to `src/lib/session.ts`, deduplicated from `admin.ts` and `invites.ts`
- **Error sanitization**: `RiotApiError.userMessage` getter — safe user-facing messages, full errors logged server-side only
- **Export query limit**: 10,000 row cap on CSV export to prevent unbounded queries

### LOW severity / infrastructure
- **Dependabot**: Enabled vulnerability alerts and automated security updates via `gh api`
- **CI audit step**: `npm audit --omit=dev --audit-level=high` in `.github/workflows/ci.yml`
- **Security skill**: New `.opencode/skills/security/SKILL.md` with full patterns reference
- **AGENTS.md rules**: Security section with mandatory auth, URL validation, cookie, and CSP rules
- **Existing skill updates**: Added security sections to `drizzle-schema`, `riot-api`, `nextjs-auth` skills
- **Rate limiting issue**: Opened #120 (deferred — invite-only app with small user base)

### Audit results (clean)
- Zero production npm vulnerabilities (`npm audit --omit=dev` clean)
- All 13 server action files properly call `requireUser()` / `requireAdmin()` with userId scoping
- Drizzle ORM provides complete SQL injection protection — no vulnerabilities found
- `'unsafe-inline'` required in CSP `script-src` due to `next-themes` inline script (nonces incompatible with PPR)

### Verification
- `npm run build` — passes
- `npm run test:smoke` — all 31 tests pass (including admin page with new layout)
- Pre-commit hooks (format + lint) — clean

Fixes #97
Relates to #120