### PR TITLE
Add Dependabot config and auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/Madrid
+    # Group minor/patch updates into a single PR to reduce noise
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    # Major version bumps get individual PRs for manual review
+    open-pull-requests-limit: 10
+    reviewers:
+      - beagleknight
+    labels:
+      - dependencies
+    # Also check GitHub Actions versions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/Madrid
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,87 @@
+name: Dependabot auto-merge
+
+on:
+  # Triggers after the CI workflow completes — ensures all checks passed
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge Dependabot PR
+    runs-on: ubuntu-latest
+    # Only run when CI succeeded AND the PR was opened by Dependabot
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    steps:
+      - name: Get PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # workflow_run doesn't directly give us the PR number — look it up
+          # from the head branch of the triggering run
+          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
+            --head "$HEAD_BRANCH" --state open --json number --jq '.[0].number')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR found for branch $HEAD_BRANCH"
+            exit 0
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Check update type
+        id: check
+        if: steps.pr.outputs.number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          PR_TITLE=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" \
+            --json title --jq '.title')
+
+          echo "PR #$PR_NUMBER: $PR_TITLE"
+
+          # Dependabot PR titles follow the pattern:
+          #   "Bump <pkg> from <old> to <new>"
+          #   "Update <pkg> requirement from ..."
+          # Major bumps go from e.g. 3.x to 4.x (first digit changes)
+          # We also check labels — Dependabot adds semver labels automatically
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" \
+            --json labels --jq '.labels[].name')
+
+          echo "Labels: $LABELS"
+
+          if echo "$LABELS" | grep -q "semver-major"; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+            echo "Major version bump detected — skipping auto-merge"
+          else
+            echo "type=minor-or-patch" >> "$GITHUB_OUTPUT"
+            echo "Patch/minor update — will auto-merge"
+          fi
+
+      - name: Approve and merge
+        if: steps.pr.outputs.number && steps.check.outputs.type == 'minor-or-patch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          gh pr review "$PR_NUMBER" --repo "${{ github.repository }}" --approve \
+            --body "Auto-approved: Dependabot patch/minor update. CI passed."
+          gh pr merge "$PR_NUMBER" --repo "${{ github.repository }}" --squash \
+            --body "Auto-merged by Dependabot auto-merge workflow after CI passed."
+
+      - name: Comment on major bump
+        if: steps.pr.outputs.number && steps.check.outputs.type == 'major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" \
+            --body "This is a **major version bump** — skipping auto-merge. Please review manually."

--- a/tests/e2e/settings-flow.spec.ts
+++ b/tests/e2e/settings-flow.spec.ts
@@ -126,10 +126,13 @@ test.describe("Settings flow", () => {
     await expect(searchInput).toBeVisible({ timeout: 10_000 });
 
     // Search for the duo partner by name.
-    // Use click + pressSequentially instead of fill for reliable React onChange
-    // triggering on CI (Base UI inputs sometimes miss fill events).
+    // Use fill() for atomic value setting — pressSequentially races with React's
+    // controlled input re-renders on slow CI, causing keystrokes to be clobbered.
     await searchInput.click();
-    await searchInput.pressSequentially("Duo", { delay: 50 });
+    await searchInput.fill("Duo");
+
+    // Verify the input accepted the value (guards against controlled input issues)
+    await expect(searchInput).toHaveValue("Duo");
 
     // Wait for search results to appear (300ms debounce + server action)
     await expect(page.getByText("DuoPartner#EUW")).toBeVisible({ timeout: 15_000 });


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to schedule weekly dependency checks (npm + GitHub Actions), grouping patch/minor updates into single PRs
- Adds `.github/workflows/dependabot-auto-merge.yml` that auto-approves and squash-merges Dependabot PRs **only after CI passes** — major version bumps are skipped and flagged for manual review
- Uses `workflow_run` trigger (fires after the CI workflow completes) since the repo is on GitHub's free tier and doesn't have branch protection / native auto-merge

### How it works

1. Dependabot opens a PR (weekly, Mondays 09:00 Madrid time)
2. CI runs (typecheck, lint, format, build, smoke, e2e, changelog, audit)
3. If CI passes **and** the PR is from Dependabot:
   - **Patch/minor**: auto-approved + squash-merged
   - **Major**: comment posted requesting manual review
4. If CI fails, nothing happens — PR stays open for investigation

### Labels

`skip-changelog` — infrastructure-only, no user-visible change.