### PR TITLE
fix: add skip-changelog label to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
       - beagleknight
     labels:
       - dependencies
+      - skip-changelog
     # Also check GitHub Actions versions
   - package-ecosystem: github-actions
     directory: /
@@ -31,3 +32,4 @@ updates:
     labels:
       - dependencies
       - github-actions
+      - skip-changelog


### PR DESCRIPTION
## Summary

- Adds `skip-changelog` label to both npm and GitHub Actions ecosystems in `.github/dependabot.yml`
- Dependabot PRs don't include changelog entries, so the changelog CI check was failing on every dependency update

New Dependabot PRs will automatically get the label and skip the changelog check.

**Note:** Already manually added `skip-changelog` to the 3 existing open Dependabot PRs (#124, #125, #126).