### PR TITLE
fix: check PR author instead of workflow actor for Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,12 +14,11 @@ jobs:
   auto-merge:
     name: Auto-merge Dependabot PR
     runs-on: ubuntu-latest
-    # Only run when CI succeeded AND the PR was opened by Dependabot
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    # Only check CI succeeded — actor check moved into the job because
+    # workflow_run.actor reflects who triggered CI, not the PR author
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - name: Get PR number
+      - name: Get PR number and verify author
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -27,13 +26,25 @@ jobs:
           # workflow_run doesn't directly give us the PR number — look it up
           # from the head branch of the triggering run
           HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
-          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
-            --head "$HEAD_BRANCH" --state open --json number --jq '.[0].number')
+          PR_JSON=$(gh pr list --repo "${{ github.repository }}" \
+            --head "$HEAD_BRANCH" --state open \
+            --json number,author --jq '.[0] // empty')
 
-          if [ -z "$PR_NUMBER" ]; then
+          if [ -z "$PR_JSON" ]; then
             echo "No open PR found for branch $HEAD_BRANCH"
             exit 0
           fi
+
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.author.login')
+
+          echo "PR #$PR_NUMBER by $PR_AUTHOR"
+
+          if [ "$PR_AUTHOR" != "app/dependabot" ]; then
+            echo "Not a Dependabot PR — skipping"
+            exit 0
+          fi
+
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Check update type


### PR DESCRIPTION
## Summary

The Dependabot auto-merge workflow was checking `github.event.workflow_run.actor.login == 'dependabot[bot]'` to identify Dependabot PRs. This doesn't work because `workflow_run.actor` is whoever triggered the CI run, not the PR author — e.g. after a close/reopen it's `beagleknight`.

**Fix:** Remove the actor check from the job `if` condition. Instead, look up the actual PR author via `gh pr list --json author` inside the job and skip if it's not `app/dependabot`.

Once merged, close/reopen the Dependabot PRs one more time to trigger fresh CI + auto-merge.