### PR TITLE
fix: skip lifecycle scripts in Dependabot lockfile regeneration

### DIFF
--- a/.github/workflows/dependabot-lockfile-fix.yml
+++ b/.github/workflows/dependabot-lockfile-fix.yml
@@ -25,7 +25,7 @@ jobs:
           node-version-file: ".tool-versions"
 
       - name: Regenerate lockfile
-        run: npm install --package-lock-only
+        run: npm install --package-lock-only --ignore-scripts
 
       - name: Check for lockfile changes
         id: diff


### PR DESCRIPTION
## Summary

- Adds `--ignore-scripts` to the `npm install` command in the Dependabot lockfile fix workflow
- The `prepare` lifecycle script runs `lefthook install`, which isn't available in CI and causes the workflow to fail with exit code 127

One-line fix for the workflow added in #134.