### PR TITLE
fix: re-trigger CI after Dependabot lockfile regeneration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,17 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  # Allow the Dependabot lockfile-fix workflow to re-trigger CI after pushing
+  # a corrected lockfile (pushes from GITHUB_TOKEN don't trigger workflows).
+  workflow_dispatch:
+    inputs:
+      pr_head_ref:
+        description: "PR branch name (used for concurrency grouping)"
+        required: false
+        type: string
 
 concurrency:
-  group: ci-${{ github.head_ref }}
+  group: ci-${{ github.head_ref || inputs.pr_head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -122,8 +130,8 @@ jobs:
   changelog:
     name: Changelog
     runs-on: ubuntu-latest
-    # Skip this check if the PR has the 'skip-changelog' label
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    # Skip this check if the PR has the 'skip-changelog' label or if triggered via workflow_dispatch
+    if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/dependabot-lockfile-fix.yml
+++ b/.github/workflows/dependabot-lockfile-fix.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   fix-lockfile:
@@ -46,3 +47,13 @@ jobs:
           git add package-lock.json
           git commit -m "chore: regenerate lockfile with Node $(node -v) / npm $(npm -v)"
           git push
+
+      - name: Re-trigger CI
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run CI \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.head_ref }}" \
+            --field pr_head_ref="${{ github.head_ref }}"


### PR DESCRIPTION
## Summary

- Fixes the issue where CI doesn't run after the lockfile-fix workflow pushes a corrected `package-lock.json` to a Dependabot PR
- Root cause: GitHub Actions doesn't trigger `pull_request` workflows from commits pushed with `GITHUB_TOKEN` (anti-recursion protection)
- Solution: adds `workflow_dispatch` to CI, and the lockfile-fix workflow explicitly re-triggers CI via `gh workflow run` after pushing the lockfile fix
- Also skips the Changelog check on `workflow_dispatch` triggers (no PR context available)

Follow-up to #134 and #135.