### PR TITLE
chore(deps-dev): bump typescript from 5.9.3 to 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "oxlint-tsgolint": "^0.19.0",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
-        "typescript": "^5"
+        "typescript": "^6.0.2"
       },
       "engines": {
         "node": ">=24"
@@ -8574,9 +8574,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "oxlint-tsgolint": "^0.19.0",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
-    "typescript": "^5"
+    "typescript": "^6.0.2"
   },
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
## Summary

- Upgrades TypeScript from 5.9.3 to 6.0.2 (major version bump)
- Previously blocked by `next-intl@4.8.3` which had a `typescript@"^5.0.0"` peer dependency — resolved by the `next-intl@4.9.0` update in PR #128
- Build passes cleanly with zero code changes required

Supersedes #129 (which was closed due to the `next-intl` peer dep conflict).