### PR TITLE
fix: use router.back() for in-app back navigation

### DIFF
--- a/changelog/en/2026-04-03-back-button-fix.mdx
+++ b/changelog/en/2026-04-03-back-button-fix.mdx
@@ -1,0 +1,8 @@
+---
+version: "2026.04.9"
+date: "2026-04-03"
+title: "Back button now returns to the correct page"
+tags: ["fix"]
+---
+
+The in-app back arrow (←) on match detail, coaching, and goal pages used to always navigate to a fixed destination (e.g., `/matches`) regardless of where you came from. Now it takes you back to the actual previous page — dashboard, review, scout, or wherever you navigated from.

--- a/changelog/es/2026-04-03-back-button-fix.mdx
+++ b/changelog/es/2026-04-03-back-button-fix.mdx
@@ -1,0 +1,8 @@
+---
+version: "2026.04.9"
+date: "2026-04-03"
+title: "El botón de volver ahora regresa a la página correcta"
+tags: ["fix"]
+---
+
+La flecha de retroceso (←) en las páginas de detalle de partida, coaching y objetivos siempre navegaba a un destino fijo (por ejemplo, `/matches`) sin importar de dónde venías. Ahora te lleva de vuelta a la página anterior real — dashboard, revisión, scout, o donde sea que hayas navegado.

--- a/messages/en.json
+++ b/messages/en.json
@@ -722,6 +722,7 @@
     "pageIndicator": "Page {current} of {total}"
   },
   "Common": {
+    "backToPreviousPage": "Back to previous page",
     "resultW": "W",
     "resultL": "L",
     "resultR": "R",

--- a/messages/es.json
+++ b/messages/es.json
@@ -722,6 +722,7 @@
     "pageIndicator": "Página {current} de {total}"
   },
   "Common": {
+    "backToPreviousPage": "Volver a la página anterior",
     "resultW": "V",
     "resultL": "D",
     "resultR": "R",

--- a/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
+++ b/src/app/(app)/coaching/[id]/coaching-detail-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  ArrowLeft,
   Loader2,
   GraduationCap,
   Trash2,
@@ -26,6 +25,7 @@ import { toast } from "sonner";
 import type { CoachingSession, CoachingActionItem } from "@/db/schema";
 
 import { updateActionItemStatus, deleteCoachingSession } from "@/app/actions/coaching";
+import { BackButton } from "@/components/back-button";
 import { HighlightsDisplay, type HighlightItem } from "@/components/highlights-editor";
 import { ResultBadge, ResultBar } from "@/components/result-badge";
 import { Badge } from "@/components/ui/badge";
@@ -262,11 +262,7 @@ export function CoachingDetailClient({
     <div className="max-w-3xl space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <Link href="/coaching">
-          <Button variant="ghost" size="icon" aria-label="Back to coaching">
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-        </Link>
+        <BackButton />
         <div className="flex-1">
           <div className="flex items-center gap-2">
             <GraduationCap className="h-5 w-5 text-gold" />

--- a/src/app/(app)/coaching/[id]/complete/complete-session-client.tsx
+++ b/src/app/(app)/coaching/[id]/complete/complete-session-client.tsx
@@ -1,15 +1,6 @@
 "use client";
 
-import {
-  Loader2,
-  Plus,
-  X,
-  ArrowLeft,
-  Video,
-  GraduationCap,
-  Clock,
-  CheckCircle,
-} from "lucide-react";
+import { Loader2, Plus, X, Video, GraduationCap, Clock, CheckCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
 import Image from "next/image";
@@ -21,6 +12,7 @@ import { toast } from "sonner";
 import type { CoachingSession } from "@/db/schema";
 
 import { completeCoachingSession } from "@/app/actions/coaching";
+import { BackButton } from "@/components/back-button";
 import { HighlightsDisplay, type HighlightItem } from "@/components/highlights-editor";
 import { ResultBadge } from "@/components/result-badge";
 import { Badge } from "@/components/ui/badge";
@@ -154,11 +146,7 @@ export function CompleteSessionClient({
     <div className="max-w-3xl space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <Link href={`/coaching/${session.id}`}>
-          <Button variant="ghost" size="icon" aria-label="Back to session">
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-        </Link>
+        <BackButton />
         <div>
           <h1 className="text-gradient-gold text-2xl font-bold tracking-tight">{t("title")}</h1>
           <p className="text-muted-foreground">{t("subtitle")}</p>

--- a/src/app/(app)/coaching/[id]/edit/edit-session-client.tsx
+++ b/src/app/(app)/coaching/[id]/edit/edit-session-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Loader2, ArrowLeft, Video, Check, Calendar, Clock, X } from "lucide-react";
+import { Loader2, Video, Check, Calendar, Clock, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import type { CoachingSession } from "@/db/schema";
 
 import { updateCoachingSession } from "@/app/actions/coaching";
+import { BackButton } from "@/components/back-button";
 import { HighlightsDisplay, type HighlightItem } from "@/components/highlights-editor";
 import { ResultBar } from "@/components/result-badge";
 import { Badge } from "@/components/ui/badge";
@@ -159,11 +160,7 @@ export function EditSessionClient({
     <div className="max-w-3xl space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <Link href={`/coaching/${session.id}`}>
-          <Button variant="ghost" size="icon" aria-label="Back to session">
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-        </Link>
+        <BackButton />
         <div>
           <h1 className="text-gradient-gold text-2xl font-bold tracking-tight">{t("title")}</h1>
           <p className="text-muted-foreground">{t("subtitle")}</p>

--- a/src/app/(app)/coaching/new/schedule-session-client.tsx
+++ b/src/app/(app)/coaching/new/schedule-session-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Loader2, ArrowLeft, Video, Check, Calendar, X } from "lucide-react";
+import { Loader2, Video, Check, Calendar, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import Link from "next/link";
@@ -9,6 +9,7 @@ import { useState, useTransition, useMemo, useCallback } from "react";
 import { toast } from "sonner";
 
 import { scheduleCoachingSession } from "@/app/actions/coaching";
+import { BackButton } from "@/components/back-button";
 import { HighlightsDisplay, type HighlightItem } from "@/components/highlights-editor";
 import { ResultBar } from "@/components/result-badge";
 import { Badge } from "@/components/ui/badge";
@@ -137,11 +138,7 @@ export function ScheduleSessionClient({
     <div className="max-w-3xl space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <Link href="/coaching">
-          <Button variant="ghost" size="icon" aria-label="Back to coaching">
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-        </Link>
+        <BackButton />
         <div>
           <h1 className="text-gradient-gold text-2xl font-bold tracking-tight">{t("title")}</h1>
           <p className="text-muted-foreground">{t("subtitle")}</p>

--- a/src/app/(app)/goals/new/new-goal-client.tsx
+++ b/src/app/(app)/goals/new/new-goal-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Target, ArrowLeft, Loader2, AlertCircle } from "lucide-react";
+import { Target, Loader2, AlertCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -8,6 +8,7 @@ import { useState, useTransition } from "react";
 import { toast } from "sonner";
 
 import { createGoal } from "@/app/actions/goals";
+import { BackButton } from "@/components/back-button";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -89,11 +90,7 @@ export function NewGoalClient({ currentRank }: NewGoalClientProps) {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center gap-4">
-        <Link href="/goals">
-          <Button variant="ghost" size="icon" aria-label="Back to goals">
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-        </Link>
+        <BackButton />
         <div>
           <h1 className="text-gradient-gold text-2xl font-bold tracking-tight">
             {t("newGoalTitle")}

--- a/src/app/(app)/matches/[id]/match-detail-client.tsx
+++ b/src/app/(app)/matches/[id]/match-detail-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  ArrowLeft,
   GraduationCap,
   ClipboardEdit,
   Link as LinkIcon,
@@ -22,6 +21,7 @@ import type { RiotMatchParticipant } from "@/lib/riot-api";
 import { ReadOnlyMatchupNotes } from "@/app/(app)/scout/matchup-notes";
 import { generatePostGameInsight, type InsightResult } from "@/app/actions/ai-insights";
 import { AiInsightDrawer } from "@/components/ai-insight-card";
+import { BackButton } from "@/components/back-button";
 import { ChampionLink } from "@/components/champion-link";
 import { HighlightsDisplay, type HighlightItem } from "@/components/highlights-editor";
 import { PositionIcon, getRoleRelevance, getPositionLabel } from "@/components/position-icon";
@@ -216,11 +216,7 @@ export function MatchDetailClient({
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <Link href="/matches">
-          <Button variant="ghost" size="icon" aria-label="Back to matches">
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-        </Link>
+        <BackButton />
         <div className="flex-1">
           <div className="flex items-center gap-3">
             <ChampionLink

--- a/src/components/back-button.tsx
+++ b/src/components/back-button.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+
+export function BackButton() {
+  const router = useRouter();
+  const t = useTranslations("Common");
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label={t("backToPreviousPage")}
+      onClick={() => router.back()}
+    >
+      <ArrowLeft className="h-4 w-4" />
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

- Replace hardcoded `<Link href="...">` back buttons with a shared `BackButton` component that uses `router.back()`, so users return to the actual previous page instead of a fixed destination
- Extracts a reusable `BackButton` component with proper i18n aria-labels (en + es)
- Affected pages: match detail, coaching (new/detail/edit/complete), and new goal
- Error pages intentionally keep hardcoded links for recovery navigation

Fixes #118