### PR TITLE
chore: add path filters to CI to skip unnecessary jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       app: ${{ steps.filter.outputs.app }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - "src/**"
+              - "tests/**"
+              - "package.json"
+              - "package-lock.json"
+              - "tsconfig.json"
+              - "next.config.ts"
+              - ".tool-versions"
+              - "playwright.config.ts"
+              - "drizzle/**"
+              - "scripts/**"
+              - "messages/**"
+              - "public/**"
+              - ".github/workflows/ci.yml"
+
   typecheck:
     name: Typecheck
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -23,6 +53,8 @@ jobs:
 
   lint:
     name: Lint
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -35,6 +67,8 @@ jobs:
 
   format:
     name: Format
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -47,6 +81,8 @@ jobs:
 
   build:
     name: Build
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     env:
       # Stub values so next build compiles without real credentials.
@@ -63,6 +99,8 @@ jobs:
 
   smoke:
     name: Smoke Tests
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     env:
       AUTH_SECRET: smoke-test-secret-at-least-32-characters
@@ -92,6 +130,8 @@ jobs:
 
   e2e:
     name: E2E Tests
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     env:
       AUTH_SECRET: smoke-test-secret-at-least-32-characters
@@ -140,6 +180,8 @@ jobs:
 
   audit:
     name: Security audit
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Add a `changes` detection job using `dorny/paths-filter@v3` to skip app-related CI jobs when only non-app files change (e.g., `.github/` workflow files other than `ci.yml`)
- App jobs (typecheck, lint, format, build, smoke, e2e, audit) now depend on the `changes` job and only run when app-related files are modified
- Changes to `ci.yml` itself are included in the app filter so the pipeline still validates itself
- The changelog job remains independent with its own label-based condition

Fixes #127