### PR TITLE
chore: add inbound rate limiting to API routes and server actions

### DIFF
--- a/drizzle/0021_cold_the_hunter.sql
+++ b/drizzle/0021_cold_the_hunter.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `rate_limit_events` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` text NOT NULL,
+	`action` text NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `rate_limit_events_user_action_created_idx` ON `rate_limit_events` (`user_id`,`action`,`created_at`);

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,1388 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "176f52b5-c5eb-4b07-ab44-fbaf9bc9ec62",
+  "prevId": "9a9f2708-51fc-4295-aa16-b97a4baa55da",
+  "tables": {
+    "ai_insights": {
+      "name": "ai_insights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_insights_user_created_idx": {
+          "name": "ai_insights_user_created_idx",
+          "columns": ["user_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_insights_user_type_context_unq": {
+          "name": "ai_insights_user_type_context_unq",
+          "columns": ["user_id", "type", "context_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ai_insights_user_id_users_id_fk": {
+          "name": "ai_insights_user_id_users_id_fk",
+          "tableFrom": "ai_insights",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coaching_action_items": {
+      "name": "coaching_action_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "action_items_user_status_idx": {
+          "name": "action_items_user_status_idx",
+          "columns": ["user_id", "status"],
+          "isUnique": false
+        },
+        "action_items_session_idx": {
+          "name": "action_items_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coaching_action_items_session_id_coaching_sessions_id_fk": {
+          "name": "coaching_action_items_session_id_coaching_sessions_id_fk",
+          "tableFrom": "coaching_action_items",
+          "tableTo": "coaching_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coaching_action_items_user_id_users_id_fk": {
+          "name": "coaching_action_items_user_id_users_id_fk",
+          "tableFrom": "coaching_action_items",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coaching_session_matches": {
+      "name": "coaching_session_matches",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "coaching_session_matches_match_user_idx": {
+          "name": "coaching_session_matches_match_user_idx",
+          "columns": ["match_id", "user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coaching_session_matches_session_id_coaching_sessions_id_fk": {
+          "name": "coaching_session_matches_session_id_coaching_sessions_id_fk",
+          "tableFrom": "coaching_session_matches",
+          "tableTo": "coaching_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coaching_session_matches_user_id_users_id_fk": {
+          "name": "coaching_session_matches_user_id_users_id_fk",
+          "tableFrom": "coaching_session_matches",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "coaching_session_matches_session_id_match_id_pk": {
+          "columns": ["session_id", "match_id"],
+          "name": "coaching_session_matches_session_id_match_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coaching_sessions": {
+      "name": "coaching_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coach_name": {
+          "name": "coach_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scheduled'"
+        },
+        "vod_match_id": {
+          "name": "vod_match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "focus_areas": {
+          "name": "focus_areas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "coaching_sessions_user_date_idx": {
+          "name": "coaching_sessions_user_date_idx",
+          "columns": ["user_id", "date"],
+          "isUnique": false
+        },
+        "coaching_sessions_user_status_idx": {
+          "name": "coaching_sessions_user_status_idx",
+          "columns": ["user_id", "status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "coaching_sessions_user_id_users_id_fk": {
+          "name": "coaching_sessions_user_id_users_id_fk",
+          "tableFrom": "coaching_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "goals": {
+      "name": "goals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_tier": {
+          "name": "target_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_division": {
+          "name": "target_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_tier": {
+          "name": "start_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_division": {
+          "name": "start_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_lp": {
+          "name": "start_lp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "achieved_at": {
+          "name": "achieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "goals_user_status_idx": {
+          "name": "goals_user_status_idx",
+          "columns": ["user_id", "status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invites": {
+      "name": "invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invites_code_unique": {
+          "name": "invites_code_unique",
+          "columns": ["code"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_users_id_fk": {
+          "name": "invites_created_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_used_by_users_id_fk": {
+          "name": "invites_used_by_users_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "users",
+          "columnsFrom": ["used_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "match_highlights": {
+      "name": "match_highlights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "match_highlights_match_user_idx": {
+          "name": "match_highlights_match_user_idx",
+          "columns": ["match_id", "user_id"],
+          "isUnique": false
+        },
+        "match_highlights_user_idx": {
+          "name": "match_highlights_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "match_highlights_user_id_users_id_fk": {
+          "name": "match_highlights_user_id_users_id_fk",
+          "tableFrom": "match_highlights",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matches": {
+      "name": "matches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "odometer": {
+          "name": "odometer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_date": {
+          "name": "game_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "champion_id": {
+          "name": "champion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "champion_name": {
+          "name": "champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rune_keystone_id": {
+          "name": "rune_keystone_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rune_keystone_name": {
+          "name": "rune_keystone_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matchup_champion_id": {
+          "name": "matchup_champion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matchup_champion_name": {
+          "name": "matchup_champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cs": {
+          "name": "cs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cs_per_min": {
+          "name": "cs_per_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "game_duration_seconds": {
+          "name": "game_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gold_earned": {
+          "name": "gold_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "vision_score": {
+          "name": "vision_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "review_notes": {
+          "name": "review_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_skipped_reason": {
+          "name": "review_skipped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vod_url": {
+          "name": "vod_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "queue_id": {
+          "name": "queue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_match_json": {
+          "name": "raw_match_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_puuid": {
+          "name": "duo_partner_puuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_champion_name": {
+          "name": "duo_partner_champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_kills": {
+          "name": "duo_partner_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_deaths": {
+          "name": "duo_partner_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_assists": {
+          "name": "duo_partner_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "matches_user_game_date_idx": {
+          "name": "matches_user_game_date_idx",
+          "columns": ["user_id", "game_date"],
+          "isUnique": false
+        },
+        "matches_user_reviewed_idx": {
+          "name": "matches_user_reviewed_idx",
+          "columns": ["user_id", "reviewed"],
+          "isUnique": false
+        },
+        "matches_user_duo_partner_idx": {
+          "name": "matches_user_duo_partner_idx",
+          "columns": ["user_id", "duo_partner_puuid"],
+          "isUnique": false
+        },
+        "matches_user_position_idx": {
+          "name": "matches_user_position_idx",
+          "columns": ["user_id", "position"],
+          "isUnique": false
+        },
+        "matches_user_odometer_unq": {
+          "name": "matches_user_odometer_unq",
+          "columns": ["user_id", "odometer"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "matches_user_id_users_id_fk": {
+          "name": "matches_user_id_users_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "matches_id_user_id_pk": {
+          "columns": ["id", "user_id"],
+          "name": "matches_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "matchup_notes": {
+      "name": "matchup_notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "champion_name": {
+          "name": "champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matchup_champion_name": {
+          "name": "matchup_champion_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "matchup_notes_user_matchup_idx": {
+          "name": "matchup_notes_user_matchup_idx",
+          "columns": ["user_id", "matchup_champion_name"],
+          "isUnique": false
+        },
+        "matchup_notes_user_champ_matchup_unq": {
+          "name": "matchup_notes_user_champ_matchup_unq",
+          "columns": ["user_id", "champion_name", "matchup_champion_name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "matchup_notes_user_id_users_id_fk": {
+          "name": "matchup_notes_user_id_users_id_fk",
+          "tableFrom": "matchup_notes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_snapshots": {
+      "name": "rank_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "division": {
+          "name": "division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lp": {
+          "name": "lp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "rank_snapshots_user_captured_idx": {
+          "name": "rank_snapshots_user_captured_idx",
+          "columns": ["user_id", "captured_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rank_snapshots_user_id_users_id_fk": {
+          "name": "rank_snapshots_user_id_users_id_fk",
+          "tableFrom": "rank_snapshots",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limit_events": {
+      "name": "rate_limit_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limit_events_user_action_created_idx": {
+          "name": "rate_limit_events_user_action_created_idx",
+          "columns": ["user_id", "action", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rate_limit_events_user_id_users_id_fk": {
+          "name": "rate_limit_events_user_id_users_id_fk",
+          "tableFrom": "rate_limit_events",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_locks": {
+      "name": "sync_locks",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_locks_user_id_users_id_fk": {
+          "name": "sync_locks_user_id_users_id_fk",
+          "tableFrom": "sync_locks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "riot_game_name": {
+          "name": "riot_game_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "riot_tag_line": {
+          "name": "riot_tag_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "puuid": {
+          "name": "puuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summoner_id": {
+          "name": "summoner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duo_partner_user_id": {
+          "name": "duo_partner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "primary_role": {
+          "name": "primary_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secondary_role": {
+          "name": "secondary_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coaching_cadence_days": {
+          "name": "coaching_cadence_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 14
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'en-GB'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "columns": ["discord_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1775308665703,
       "tag": "0020_remarkable_scream",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1775330856785,
+      "tag": "0021_cold_the_hunter",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/actions/ai-insights.ts
+++ b/src/app/actions/ai-insights.ts
@@ -11,6 +11,7 @@ import { buildMatchupContext } from "@/lib/ai/context";
 import { buildPostGameContext } from "@/lib/ai/context";
 import { buildMatchupPrompt, buildPostGamePrompt } from "@/lib/ai/prompts";
 import { aiModel, isAiConfigured, AI_MODEL_ID } from "@/lib/ai/provider";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { requireUser } from "@/lib/session";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
@@ -149,6 +150,14 @@ export async function generateMatchupInsight(
     }
   }
 
+  // Rate limit check (after cache — cached results don't count)
+  const rateCheck = await checkRateLimit(user.id, "ai_insight");
+  if (!rateCheck.allowed) {
+    return {
+      error: `Rate limit exceeded. Try again in ${rateCheck.retryAfter} seconds.`,
+    };
+  }
+
   // Check daily limit
   const used = await getDailyUsage(user.id);
   if (used >= DAILY_LIMIT) {
@@ -249,6 +258,14 @@ export async function generatePostGameInsight(
         completionTokens: existing.completionTokens,
       };
     }
+  }
+
+  // Rate limit check (after cache — cached results don't count)
+  const rateCheck = await checkRateLimit(user.id, "ai_insight");
+  if (!rateCheck.allowed) {
+    return {
+      error: `Rate limit exceeded. Try again in ${rateCheck.retryAfter} seconds.`,
+    };
   }
 
   // Check daily limit

--- a/src/app/actions/settings.ts
+++ b/src/app/actions/settings.ts
@@ -9,11 +9,20 @@ import { users } from "@/db/schema";
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from "@/i18n/request";
 import { invalidateAllCaches, invalidateDuoCaches } from "@/lib/cache";
 import { SUPPORTED_LOCALES, type SupportedLocale } from "@/lib/format";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { getAccountByRiotId, RiotApiError, PLATFORM_IDS } from "@/lib/riot-api";
 import { requireUser } from "@/lib/session";
 
 export async function linkRiotAccount(formData: FormData) {
   const user = await requireUser();
+
+  // Rate limit check
+  const rateCheck = await checkRateLimit(user.id, "riot_lookup");
+  if (!rateCheck.allowed) {
+    return {
+      error: `Rate limit exceeded. Try again in ${rateCheck.retryAfter} seconds.`,
+    };
+  }
 
   const riotId = formData.get("riotId") as string;
   if (!riotId || !riotId.includes("#")) {

--- a/src/app/api/export/matches/route.ts
+++ b/src/app/api/export/matches/route.ts
@@ -2,6 +2,7 @@ import { eq, and, desc, sql } from "drizzle-orm";
 
 import { db } from "@/db";
 import { matches } from "@/db/schema";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { getCurrentUser } from "@/lib/session";
 
 // ─── CSV Helpers ─────────────────────────────────────────────────────────────
@@ -105,6 +106,15 @@ export async function GET(request: Request) {
   const user = await getCurrentUser();
   if (!user) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Rate limit check
+  const rateCheck = await checkRateLimit(user.id, "export");
+  if (!rateCheck.allowed) {
+    return Response.json(
+      { error: `Rate limit exceeded. Try again in ${rateCheck.retryAfter} seconds.` },
+      { status: 429, headers: { "Retry-After": String(rateCheck.retryAfter) } },
+    );
   }
 
   // Parse filter params (same as matches page)

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -3,6 +3,7 @@ import { eq, desc } from "drizzle-orm";
 import { db } from "@/db";
 import { matches, rankSnapshots, users } from "@/db/schema";
 import { checkGoalAchievement } from "@/lib/goals";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { calculateAdaptiveDelay } from "@/lib/rate-limiter";
 import {
   getMatchIds,
@@ -73,6 +74,17 @@ export async function GET(request: Request) {
           // Stream may already be closed (client disconnected) — ignore
         }
       };
+
+      // ── Rate limit check ───────────────────────────────────────────
+      const rateCheck = await checkRateLimit(user.id, "sync");
+      if (!rateCheck.allowed) {
+        send({
+          type: "error",
+          message: `You can only sync once every 5 minutes. Try again in ${rateCheck.retryAfter} seconds.`,
+        });
+        controller.close();
+        return;
+      }
 
       // ── Acquire sync lock ────────────────────────────────────────────
       let lockAcquired = false;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -326,6 +326,29 @@ export const aiInsights = sqliteTable(
   ],
 );
 
+// ─── Rate Limit Events ──────────────────────────────────────────────────────
+
+export const rateLimitEvents = sqliteTable(
+  "rate_limit_events",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    action: text("action").notNull(), // e.g. "sync", "export", "ai_insight", "riot_lookup"
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("rate_limit_events_user_action_created_idx").on(
+      table.userId,
+      table.action,
+      table.createdAt,
+    ),
+  ],
+);
+
 // ─── Sync Locks ─────────────────────────────────────────────────────────────
 
 export const syncLocks = sqliteTable("sync_locks", {
@@ -352,3 +375,4 @@ export type MatchupNote = typeof matchupNotes.$inferSelect;
 export type AiInsight = typeof aiInsights.$inferSelect;
 export type Invite = typeof invites.$inferSelect;
 export type SyncLock = typeof syncLocks.$inferSelect;
+export type RateLimitEvent = typeof rateLimitEvents.$inferSelect;

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,114 @@
+// Inbound rate limiting backed by Turso/SQLite.
+//
+// Sliding-window approach: count events in the last `windowMs` for a given
+// (userId, action) pair. If the count exceeds `maxRequests`, deny the request.
+//
+// Cleanup piggybacks on checks — expired rows are deleted on every call to
+// keep the table small without a separate cron job.
+
+import { and, eq, gt, lt, sql } from "drizzle-orm";
+
+import { db } from "@/db";
+import { rateLimitEvents } from "@/db/schema";
+
+// ─── Rate limit tiers ────────────────────────────────────────────────────────
+
+interface RateLimitTier {
+  /** Sliding window duration in milliseconds */
+  windowMs: number;
+  /** Max allowed requests within the window */
+  maxRequests: number;
+}
+
+/**
+ * Rate limit configuration per action.
+ *
+ * | Action       | Window | Max |
+ * |--------------|--------|-----|
+ * | sync         | 5 min  |  1  |
+ * | export       | 1 min  |  3  |
+ * | ai_insight   | 1 min  |  5  |
+ * | riot_lookup  | 1 min  |  5  |
+ */
+const RATE_LIMIT_TIERS: Record<string, RateLimitTier> = {
+  sync: { windowMs: 5 * 60 * 1000, maxRequests: 1 },
+  export: { windowMs: 60 * 1000, maxRequests: 3 },
+  ai_insight: { windowMs: 60 * 1000, maxRequests: 5 },
+  riot_lookup: { windowMs: 60 * 1000, maxRequests: 5 },
+};
+
+/** Max window across all tiers — used for cleanup threshold */
+const MAX_WINDOW_MS = Math.max(...Object.values(RATE_LIMIT_TIERS).map((t) => t.windowMs));
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export interface RateLimitResult {
+  allowed: boolean;
+  /** Seconds until the oldest event in the window expires. Only set when denied. */
+  retryAfter?: number;
+}
+
+/**
+ * Check whether a user is allowed to perform an action, and record the event
+ * if allowed.
+ *
+ * This is the only function consumers need — it checks + records atomically.
+ *
+ * @throws if `action` has no configured tier (programming error).
+ */
+export async function checkRateLimit(userId: string, action: string): Promise<RateLimitResult> {
+  const tier = RATE_LIMIT_TIERS[action];
+  if (!tier) {
+    throw new Error(`No rate limit tier configured for action "${action}"`);
+  }
+
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - tier.windowMs);
+
+  // Piggyback cleanup: delete all events older than the largest window
+  const cleanupThreshold = new Date(now.getTime() - MAX_WINDOW_MS);
+  await db.delete(rateLimitEvents).where(lt(rateLimitEvents.createdAt, cleanupThreshold));
+
+  // Count events in the current window for this user+action
+  const [countResult] = await db
+    .select({
+      total: sql<number>`count(*)`,
+      oldest: sql<number>`min(${rateLimitEvents.createdAt})`,
+    })
+    .from(rateLimitEvents)
+    .where(
+      and(
+        eq(rateLimitEvents.userId, userId),
+        eq(rateLimitEvents.action, action),
+        gt(rateLimitEvents.createdAt, windowStart),
+      ),
+    );
+
+  const currentCount = countResult?.total ?? 0;
+
+  if (currentCount >= tier.maxRequests) {
+    // Calculate retry-after from the oldest event in the window
+    const oldestTimestamp = countResult?.oldest;
+    let retryAfter = Math.ceil(tier.windowMs / 1000);
+
+    if (oldestTimestamp) {
+      // oldestTimestamp is a unix timestamp in ms (SQLite integer via Drizzle timestamp mode)
+      const oldestMs = typeof oldestTimestamp === "number" ? oldestTimestamp : 0;
+      if (oldestMs > 0) {
+        const expiresAtMs = oldestMs + tier.windowMs;
+        retryAfter = Math.max(1, Math.ceil((expiresAtMs - now.getTime()) / 1000));
+      }
+    }
+
+    return { allowed: false, retryAfter };
+  }
+
+  // Record the event
+  await db.insert(rateLimitEvents).values({
+    userId,
+    action,
+    createdAt: now,
+  });
+
+  return { allowed: true };
+}


### PR DESCRIPTION
## Summary

- Add DB-backed sliding window rate limiting to protect expensive endpoints from abuse
- New `rate_limit_events` table with composite index on `(user_id, action, created_at)`
- New `src/lib/rate-limit.ts` module with `checkRateLimit()` — checks + records atomically, piggybacks cleanup on every call
- Applied rate limits: sync (1/5min), export (3/min), AI insights (5/min), Riot account lookup (5/min)

Fixes #120

## Rate limit tiers

| Action | Window | Max | Applied in |
|--------|--------|-----|------------|
| `sync` | 5 min | 1 | `/api/sync/route.ts` — before sync lock |
| `export` | 1 min | 3 | `/api/export/matches/route.ts` — returns 429 with Retry-After |
| `ai_insight` | 1 min | 5 | `ai-insights.ts` — after cache check (cached results bypass) |
| `riot_lookup` | 1 min | 5 | `settings.ts` — on `linkRiotAccount` |

## Design decisions

- **DB-backed (not in-memory)** — works correctly across Vercel serverless instances
- **Follows the sync-lock pattern** — proven DB-backed cross-request state pattern already in the codebase
- **Cleanup piggybacks on checks** — no cron job needed, expired events cleaned on every rate limit check
- **Cache-aware for AI** — rate limit check runs after cache lookup, so cached responses don't consume quota
- **No middleware** — can't access Turso from Vercel edge runtime
- **No new dependencies** — pure Drizzle/SQLite