### PR TITLE
fix: add missing invite record for NewPlayer in seed data

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -277,12 +277,17 @@ async function seed() {
     });
   }
 
-  // ─── Invite ──────────────────────────────────────────────────────────────
-  console.log("Creating invite...");
+  // ─── Invites ─────────────────────────────────────────────────────────────
+  console.log("Creating invites...");
   await client.execute({
     sql: `INSERT INTO invites (code, created_by, used_by, used_at, created_at)
           VALUES (?, ?, ?, ?, ?)`,
     args: ["DEMO-INVITE-001", MAIN_USER_ID, DUO_USER_ID, ts(now), ts(now)],
+  });
+  await client.execute({
+    sql: `INSERT INTO invites (code, created_by, used_by, used_at, created_at)
+          VALUES (?, ?, ?, ?, ?)`,
+    args: ["DEMO-INVITE-002", MAIN_USER_ID, NEW_PLAYER_ID, ts(now), ts(now)],
   });
 
   // ─── Matches ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `DEMO-INVITE-002` consumed by NewPlayer in the seed script, so the admin invite list realistically shows one consumed invite per non-admin user

Fixes #148

## Changelog

No user-facing change (seed data only).