### PR TITLE
fix: backfill riot_account_id, detect duo across all accounts, add discoverable toggle

### DIFF
--- a/changelog/en/2026-04-06-duo-multi-account-fixes.mdx
+++ b/changelog/en/2026-04-06-duo-multi-account-fixes.mdx
@@ -1,0 +1,12 @@
+---
+version: "2026.04.11"
+date: "2026-04-06"
+title: "Duo partner detection across accounts and privacy toggle"
+tags: ["fix", "feature"]
+---
+
+Two improvements to duo tracking after the multi-account update:
+
+- **Duo detection across all accounts**: When your duo partner plays on a smurf or alt account, those games are now detected too. Previously only their active account was checked, so smurf games were missed.
+- **Discoverable toggle**: Each linked account now has a visibility setting for duo partner search. Primary accounts are discoverable by default; smurf accounts are hidden. Toggle it anytime in Settings > Accounts.
+- **Data backfill**: If you had match history before the multi-account update, it's now properly linked to your primary account. No action needed — this happens automatically.

--- a/changelog/es/2026-04-06-duo-multi-account-fixes.mdx
+++ b/changelog/es/2026-04-06-duo-multi-account-fixes.mdx
@@ -1,0 +1,12 @@
+---
+version: "2026.04.11"
+date: "2026-04-06"
+title: "Detección de dúo entre cuentas y control de privacidad"
+tags: ["fix", "feature"]
+---
+
+Dos mejoras en el seguimiento de dúo después de la actualización multicuenta:
+
+- **Detección de dúo en todas las cuentas**: Cuando tu compañero de dúo juega en una smurf o cuenta alternativa, esas partidas ahora también se detectan. Antes solo se comprobaba su cuenta activa, así que las partidas en smurfs pasaban desapercibidas.
+- **Control de visibilidad**: Cada cuenta vinculada ahora tiene un ajuste de visibilidad para la búsqueda de compañero de dúo. Las cuentas principales son visibles por defecto; las smurfs están ocultas. Cámbialo en cualquier momento en Ajustes > Cuentas.
+- **Datos corregidos**: Si tenías historial de partidas antes de la actualización multicuenta, ahora está correctamente vinculado a tu cuenta principal. No necesitas hacer nada — ocurre automáticamente.

--- a/drizzle/0024_backfill_riot_account_id.sql
+++ b/drizzle/0024_backfill_riot_account_id.sql
@@ -1,0 +1,33 @@
+-- Backfill riot_account_id on rows that were created before multi-account migration.
+-- Uses the user's primary riot account as the value.
+-- This is safe to re-run (only touches rows where riot_account_id IS NULL).
+
+UPDATE `matches` SET `riot_account_id` = (
+  SELECT ra.id FROM `riot_accounts` ra
+  WHERE ra.user_id = `matches`.`user_id` AND ra.is_primary = 1
+  LIMIT 1
+) WHERE `riot_account_id` IS NULL;
+--> statement-breakpoint
+UPDATE `rank_snapshots` SET `riot_account_id` = (
+  SELECT ra.id FROM `riot_accounts` ra
+  WHERE ra.user_id = `rank_snapshots`.`user_id` AND ra.is_primary = 1
+  LIMIT 1
+) WHERE `riot_account_id` IS NULL;
+--> statement-breakpoint
+UPDATE `goals` SET `riot_account_id` = (
+  SELECT ra.id FROM `riot_accounts` ra
+  WHERE ra.user_id = `goals`.`user_id` AND ra.is_primary = 1
+  LIMIT 1
+) WHERE `riot_account_id` IS NULL;
+--> statement-breakpoint
+UPDATE `match_highlights` SET `riot_account_id` = (
+  SELECT ra.id FROM `riot_accounts` ra
+  WHERE ra.user_id = `match_highlights`.`user_id` AND ra.is_primary = 1
+  LIMIT 1
+) WHERE `riot_account_id` IS NULL;
+--> statement-breakpoint
+UPDATE `ai_insights` SET `riot_account_id` = (
+  SELECT ra.id FROM `riot_accounts` ra
+  WHERE ra.user_id = `ai_insights`.`user_id` AND ra.is_primary = 1
+  LIMIT 1
+) WHERE `riot_account_id` IS NULL;

--- a/drizzle/0025_discoverable_column.sql
+++ b/drizzle/0025_discoverable_column.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `riot_accounts` ADD `discoverable` integer DEFAULT true NOT NULL;
+--> statement-breakpoint
+UPDATE `riot_accounts` SET `discoverable` = 0 WHERE `is_primary` = 0;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,20 @@
       "when": 1775692800000,
       "tag": "0023_role_preferences_per_account",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1775779200000,
+      "tag": "0024_backfill_riot_account_id",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1775779200001,
+      "tag": "0025_discoverable_column",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -708,7 +708,12 @@
       "accountCount": "{count} of {max} accounts",
       "rolesLabel": "Roles",
       "rolesDescription": "Primary and secondary roles for this account",
-      "roleSaved": "Roles updated for this account."
+      "roleSaved": "Roles updated for this account.",
+      "discoverableToggle": "Toggle duo search visibility",
+      "discoverableLabel": "Discoverable",
+      "hiddenLabel": "Hidden",
+      "discoverableOn": "This account is now visible in duo partner search.",
+      "discoverableOff": "This account is now hidden from duo partner search."
     },
     "invites": {
       "title": "Invite friends",

--- a/messages/es.json
+++ b/messages/es.json
@@ -708,7 +708,12 @@
       "accountCount": "{count} de {max} cuentas",
       "rolesLabel": "Roles",
       "rolesDescription": "Roles principal y secundario para esta cuenta",
-      "roleSaved": "Roles actualizados para esta cuenta."
+      "roleSaved": "Roles actualizados para esta cuenta.",
+      "discoverableToggle": "Alternar visibilidad en búsqueda de dúo",
+      "discoverableLabel": "Visible",
+      "hiddenLabel": "Oculta",
+      "discoverableOn": "Esta cuenta ahora es visible en la búsqueda de compañero de dúo.",
+      "discoverableOff": "Esta cuenta ahora está oculta en la búsqueda de compañero de dúo."
     },
     "invites": {
       "title": "Invitar amigos",

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -303,8 +303,8 @@ async function seed() {
   console.log("Creating riot accounts...");
 
   await client.execute({
-    sql: `INSERT INTO riot_accounts (id, user_id, puuid, riot_game_name, riot_tag_line, summoner_id, region, is_primary, label, primary_role, secondary_role, created_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    sql: `INSERT INTO riot_accounts (id, user_id, puuid, riot_game_name, riot_tag_line, summoner_id, region, is_primary, discoverable, label, primary_role, secondary_role, created_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       MAIN_RIOT_ACCOUNT_ID,
       MAIN_USER_ID,
@@ -313,6 +313,7 @@ async function seed() {
       MAIN_USER.riotTagLine,
       MAIN_USER.summonerId,
       MAIN_USER.region,
+      1,
       1,
       null,
       MAIN_USER.primaryRole,
@@ -323,8 +324,8 @@ async function seed() {
 
   // Smurf account for main user (to show account switcher in demo)
   await client.execute({
-    sql: `INSERT INTO riot_accounts (id, user_id, puuid, riot_game_name, riot_tag_line, summoner_id, region, is_primary, label, primary_role, secondary_role, created_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    sql: `INSERT INTO riot_accounts (id, user_id, puuid, riot_game_name, riot_tag_line, summoner_id, region, is_primary, discoverable, label, primary_role, secondary_role, created_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       MAIN_SMURF_ACCOUNT_ID,
       MAIN_USER_ID,
@@ -334,6 +335,7 @@ async function seed() {
       "demo-summoner-smurf",
       "euw1",
       0,
+      0,
       "Smurf",
       "TOP",
       "JUNGLE",
@@ -342,8 +344,8 @@ async function seed() {
   });
 
   await client.execute({
-    sql: `INSERT INTO riot_accounts (id, user_id, puuid, riot_game_name, riot_tag_line, summoner_id, region, is_primary, label, primary_role, secondary_role, created_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    sql: `INSERT INTO riot_accounts (id, user_id, puuid, riot_game_name, riot_tag_line, summoner_id, region, is_primary, discoverable, label, primary_role, secondary_role, created_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       DUO_RIOT_ACCOUNT_ID,
       DUO_USER_ID,
@@ -352,6 +354,7 @@ async function seed() {
       DUO_USER.riotTagLine,
       DUO_USER.summonerId,
       DUO_USER.region,
+      1,
       1,
       null,
       DUO_USER.primaryRole,

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -14,6 +14,8 @@ import {
   Pencil,
   Check,
   X,
+  Eye,
+  EyeOff,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useSearchParams, useRouter } from "next/navigation";
@@ -26,6 +28,7 @@ import {
   setAccountAsPrimary,
   updateAccountLabel,
   updateAccountRolePreferences,
+  toggleAccountDiscoverable,
   getUserRiotAccounts,
 } from "@/app/actions/riot-accounts";
 import {
@@ -130,6 +133,7 @@ export default function SettingsPage() {
       riotTagLine: string;
       region: string;
       isPrimary: boolean;
+      discoverable: boolean;
       label: string | null;
       primaryRole: string | null;
       secondaryRole: string | null;
@@ -604,6 +608,56 @@ export default function SettingsPage() {
                                 {account.label || t("riotAccounts.editLabelButton")}
                               </button>
                             )}
+
+                            {/* Discoverable toggle */}
+                            <button
+                              type="button"
+                              aria-label={t("riotAccounts.discoverableToggle")}
+                              title={
+                                account.discoverable
+                                  ? t("riotAccounts.discoverableOn")
+                                  : t("riotAccounts.discoverableOff")
+                              }
+                              className={`inline-flex items-center gap-1 text-xs transition-colors ${
+                                account.discoverable
+                                  ? "text-emerald-400 hover:text-emerald-300"
+                                  : "text-muted-foreground hover:text-foreground"
+                              }`}
+                              disabled={isPending}
+                              onClick={() => {
+                                startTransition(async () => {
+                                  const result = await toggleAccountDiscoverable(
+                                    account.id,
+                                    !account.discoverable,
+                                  );
+                                  if (result.error) {
+                                    toast.error(result.error);
+                                  } else {
+                                    setRiotAccounts((prev) =>
+                                      prev.map((a) =>
+                                        a.id === account.id
+                                          ? { ...a, discoverable: !a.discoverable }
+                                          : a,
+                                      ),
+                                    );
+                                    toast.success(
+                                      !account.discoverable
+                                        ? t("riotAccounts.discoverableOn")
+                                        : t("riotAccounts.discoverableOff"),
+                                    );
+                                  }
+                                });
+                              }}
+                            >
+                              {account.discoverable ? (
+                                <Eye className="h-3 w-3" />
+                              ) : (
+                                <EyeOff className="h-3 w-3" />
+                              )}
+                              {account.discoverable
+                                ? t("riotAccounts.discoverableLabel")
+                                : t("riotAccounts.hiddenLabel")}
+                            </button>
 
                             {/* Roles inline */}
                             <div className="flex items-center gap-1.5">

--- a/src/app/actions/duo.ts
+++ b/src/app/actions/duo.ts
@@ -7,7 +7,7 @@ import { cacheLife, cacheTag } from "next/cache";
 import type { RiotMatch } from "@/lib/riot-api";
 
 import { db } from "@/db";
-import { matches, users, type MatchResult } from "@/db/schema";
+import { matches, riotAccounts, users, type MatchResult } from "@/db/schema";
 import { duoTag, invalidateDuoBackfillCaches } from "@/lib/cache";
 import { duoStatsSelect, championSynergySelect } from "@/lib/match-queries";
 import { requireUser } from "@/lib/session";
@@ -316,13 +316,13 @@ export async function backfillDuoGames(): Promise<{
     return { processed: 0, duoFound: 0 };
   }
 
-  const partner = await db.query.users.findFirst({
-    where: eq(users.id, user.duoPartnerUserId),
+  // Look up all partner puuids (all linked accounts) for smurf detection
+  const partnerAccounts = await db.query.riotAccounts.findMany({
+    where: eq(riotAccounts.userId, user.duoPartnerUserId),
     columns: { puuid: true },
   });
-  if (!partner?.puuid) return { processed: 0, duoFound: 0 };
-
-  const partnerPuuid = partner.puuid;
+  const partnerPuuids = partnerAccounts.map((a) => a.puuid);
+  if (partnerPuuids.length === 0) return { processed: 0, duoFound: 0 };
 
   // Get all matches with raw JSON that don't already have duo partner set
   const backfillConditions = [
@@ -354,14 +354,14 @@ export async function backfillDuoGames(): Promise<{
       if (!player) continue;
 
       const partnerOnTeam = participants.find(
-        (p) => p.puuid === partnerPuuid && p.teamId === player.teamId,
+        (p) => partnerPuuids.includes(p.puuid) && p.teamId === player.teamId,
       );
 
       if (partnerOnTeam) {
         await db
           .update(matches)
           .set({
-            duoPartnerPuuid: partnerPuuid,
+            duoPartnerPuuid: partnerOnTeam.puuid,
             duoPartnerChampionName: partnerOnTeam.championName,
             duoPartnerKills: partnerOnTeam.kills,
             duoPartnerDeaths: partnerOnTeam.deaths,

--- a/src/app/actions/riot-accounts.ts
+++ b/src/app/actions/riot-accounts.ts
@@ -80,6 +80,7 @@ export async function addRiotAccount(formData: FormData) {
       riotTagLine: account.tagLine,
       region,
       isPrimary,
+      discoverable: isPrimary, // Primary accounts are discoverable by default, smurfs are hidden
       label: isPrimary ? null : null, // User can set a label later
       // Copy user-level role preferences to first account
       primaryRole: isPrimary ? user.primaryRole : null,
@@ -374,6 +375,7 @@ export async function getUserRiotAccounts() {
       riotTagLine: true,
       region: true,
       isPrimary: true,
+      discoverable: true,
       label: true,
       primaryRole: true,
       secondaryRole: true,
@@ -382,4 +384,29 @@ export async function getUserRiotAccounts() {
   });
 
   return accounts;
+}
+
+// ─── Toggle Account Discoverability ─────────────────────────────────────────
+
+/**
+ * Toggle whether a Riot account appears in duo partner search results.
+ * Primary accounts default to discoverable; non-primary default to hidden.
+ */
+export async function toggleAccountDiscoverable(accountId: string, discoverable: boolean) {
+  const user = await requireUser();
+
+  // Verify ownership
+  const account = await db.query.riotAccounts.findFirst({
+    where: and(eq(riotAccounts.id, accountId), eq(riotAccounts.userId, user.id)),
+  });
+
+  if (!account) {
+    return { error: "Riot account not found." };
+  }
+
+  await db.update(riotAccounts).set({ discoverable }).where(eq(riotAccounts.id, accountId));
+
+  revalidatePath("/settings");
+
+  return { success: true };
 }

--- a/src/app/actions/settings.ts
+++ b/src/app/actions/settings.ts
@@ -237,7 +237,8 @@ export async function updateRegion(region: string) {
 
 /**
  * Search registered users by Riot ID (gameName or tagLine).
- * Returns max 5 results. Does NOT return puuid (privacy).
+ * Returns max 5 results. Only returns accounts marked as discoverable.
+ * Does NOT return puuid (privacy).
  */
 export async function searchUsers(query: string) {
   const user = await requireUser();
@@ -249,19 +250,24 @@ export async function searchUsers(query: string) {
 
   const pattern = `%${trimmed}%`;
 
+  // Search discoverable riot accounts instead of the users table cache.
+  // This respects the per-account discoverable flag and shows all
+  // discoverable accounts (not just the user's active one).
   const result = await db
     .select({
       id: users.id,
       name: users.name,
-      riotGameName: users.riotGameName,
-      riotTagLine: users.riotTagLine,
+      riotGameName: riotAccounts.riotGameName,
+      riotTagLine: riotAccounts.riotTagLine,
     })
-    .from(users)
+    .from(riotAccounts)
+    .innerJoin(users, eq(users.id, riotAccounts.userId))
     .where(
       and(
-        ne(users.id, user.id),
+        ne(riotAccounts.userId, user.id),
+        eq(riotAccounts.discoverable, true),
         isNotNull(users.puuid),
-        or(like(users.riotGameName, pattern), like(users.riotTagLine, pattern)),
+        or(like(riotAccounts.riotGameName, pattern), like(riotAccounts.riotTagLine, pattern)),
       ),
     )
     .limit(5);

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,7 +1,7 @@
 import { eq, desc } from "drizzle-orm";
 
 import { db } from "@/db";
-import { matches, rankSnapshots, users } from "@/db/schema";
+import { matches, rankSnapshots, riotAccounts, users } from "@/db/schema";
 import { checkGoalAchievement } from "@/lib/goals";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { calculateAdaptiveDelay } from "@/lib/rate-limiter";
@@ -242,14 +242,15 @@ export async function GET(request: Request) {
         });
         let nextOdometer = (maxOdoResult?.odometer || 0) + 1;
 
-        // Look up duo partner puuid (if user has one configured)
-        let duoPartnerPuuid: string | null = null;
+        // Look up duo partner puuids (if user has one configured)
+        // Check all linked accounts so smurf games are detected too
+        let duoPartnerPuuids: string[] = [];
         if (user.duoPartnerUserId) {
-          const partner = await db.query.users.findFirst({
-            where: eq(users.id, user.duoPartnerUserId),
+          const partnerAccounts = await db.query.riotAccounts.findMany({
+            where: eq(riotAccounts.userId, user.duoPartnerUserId),
             columns: { puuid: true },
           });
-          duoPartnerPuuid = partner?.puuid || null;
+          duoPartnerPuuids = partnerAccounts.map((a) => a.puuid);
         }
 
         let syncedCount = 0;
@@ -270,13 +271,14 @@ export async function GET(request: Request) {
             const matchup = findMatchupChampion(matchData, user.puuid!);
 
             // Check if duo partner was on the same team
-            const detectedDuoPuuid = duoPartnerPuuid
-              ? findDuoPartner(matchData, user.puuid!, duoPartnerPuuid)
-              : null;
+            const detectedDuoPuuid =
+              duoPartnerPuuids.length > 0
+                ? findDuoPartner(matchData, user.puuid!, duoPartnerPuuids)
+                : null;
 
             // Extract duo partner stats for denormalized columns
             const duoPartnerData = detectedDuoPuuid
-              ? extractDuoPartnerData(matchData, user.puuid!, duoPartnerPuuid!)
+              ? extractDuoPartnerData(matchData, user.puuid!, detectedDuoPuuid)
               : null;
 
             await db

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -61,6 +61,7 @@ export const riotAccounts = sqliteTable(
     summonerId: text("summoner_id"),
     region: text("region").notNull(), // Riot platform region: euw1, na1, kr, eun1, etc.
     isPrimary: integer("is_primary", { mode: "boolean" }).notNull().default(false),
+    discoverable: integer("discoverable", { mode: "boolean" }).notNull().default(true), // Whether this account appears in duo partner search results
     label: text("label"), // User-friendly nickname, e.g. "Main", "Smurf"
     primaryRole: text("primary_role"), // Preferred primary position: TOP, JUNGLE, MIDDLE, BOTTOM, UTILITY
     secondaryRole: text("secondary_role"), // Preferred secondary position

--- a/src/lib/riot-api.ts
+++ b/src/lib/riot-api.ts
@@ -433,18 +433,21 @@ export function findMatchupChampion(
 
 /**
  * Check if a duo partner was on the same team in a match.
+ * Accepts a single puuid or an array of puuids (for multi-account support).
  * Returns the partner's puuid if found on same team, null otherwise.
  */
 export function findDuoPartner(
   match: RiotMatch,
   playerPuuid: string,
-  duoPartnerPuuid: string,
+  duoPartnerPuuids: string | string[],
 ): string | null {
   const player = match.info.participants.find((p) => p.puuid === playerPuuid);
   if (!player) return null;
 
+  const puuids = Array.isArray(duoPartnerPuuids) ? duoPartnerPuuids : [duoPartnerPuuids];
+
   const partner = match.info.participants.find(
-    (p) => p.puuid === duoPartnerPuuid && p.teamId === player.teamId,
+    (p) => puuids.includes(p.puuid) && p.teamId === player.teamId,
   );
 
   return partner ? partner.puuid : null;


### PR DESCRIPTION
## Summary

Fixes three issues introduced by the multi-account migration (#155):

- **Backfill pre-migration data** — Migration 0024 sets `riot_account_id` on all existing rows in `matches`, `rank_snapshots`, `goals`, `match_highlights`, and `ai_insights` using the user's primary riot account. Without this, all historical data is invisible because queries now filter by `riotAccountId`. Fixes #157
- **Duo detection across all accounts** — `findDuoPartner()` now accepts an array of puuids. The sync route and `backfillDuoGames()` look up all partner puuids from `riotAccounts` instead of just `users.puuid`, so smurf account games are detected. Fixes #156
- **Discoverable toggle for duo search privacy** — New `discoverable` column on `riot_accounts` (default `true` for primary, `false` for non-primary). `searchUsers()` now joins `riotAccounts` and filters by `discoverable=true`. Users can toggle per-account visibility in Settings > Accounts. Fixes #158

## Changes

### Migrations
- `0024_backfill_riot_account_id.sql` — UPDATE statements for 5 tables
- `0025_discoverable_column.sql` — ALTER TABLE + UPDATE for default values

### Backend
- `src/db/schema.ts` — `discoverable` column on `riotAccounts`
- `src/lib/riot-api.ts` — `findDuoPartner()` accepts `string | string[]`
- `src/app/api/sync/route.ts` — queries all partner puuids from `riotAccounts`
- `src/app/actions/duo.ts` — `backfillDuoGames()` uses all partner puuids
- `src/app/actions/settings.ts` — `searchUsers()` joins `riotAccounts`, filters `discoverable`
- `src/app/actions/riot-accounts.ts` — `toggleAccountDiscoverable()` action, `discoverable` in `getUserRiotAccounts()`

### Frontend
- `src/app/(app)/settings/page.tsx` — Eye/EyeOff toggle per account in the bottom row

### Other
- `messages/en.json` + `messages/es.json` — i18n keys for discoverable toggle
- `scripts/seed.ts` — `discoverable` column in seed data
- Changelog entries (en + es)

## Testing
- `npm run build` — passes
- `npm run test:smoke` — 36/36 pass
- `npm run test:e2e` — 22/22 pass