### PR TITLE
chore: add migration safety guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,20 @@ jobs:
       - run: npm ci
       - run: npm run fmt:check
 
+  migration:
+    name: Migration integrity
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".tool-versions"
+          cache: npm
+      - run: npm ci
+      - run: npm run test:migration
+
   build:
     name: Build
     needs: changes

--- a/.opencode/skills/drizzle-schema/SKILL.md
+++ b/.opencode/skills/drizzle-schema/SKILL.md
@@ -83,10 +83,52 @@ Always add indexes when:
 1. Modify `src/db/schema.ts`
 2. Generate migration: `npx drizzle-kit generate`
 3. Review the generated SQL in `drizzle/XXXX_*.sql`
-4. Apply locally: restart dev server (local SQLite picks up schema changes automatically)
-5. **Apply to production Turso**: Write a standalone `scripts/apply-migration-XXXX.ts` script that uses `@libsql/client` directly with `cleanEnv()` banner stripping, then run via `npx @dotenvx/dotenvx run --env-file=.env.local -- npx tsx scripts/apply-migration-XXXX.ts`. See `vercel-turso-deploy` skill for the script template.
-6. Verify migration succeeded before pushing code
-7. **Push code only after production DB has the new schema** — Vercel does NOT run migrations on deploy
+4. **Review for data migration completeness** — see the "Data migration safety" section below
+5. Apply locally: restart dev server (local SQLite picks up schema changes automatically)
+6. **Apply to production Turso**: Write a standalone `scripts/apply-migration-XXXX.ts` script that uses `@libsql/client` directly with `cleanEnv()` banner stripping, then run via `npx @dotenvx/dotenvx run --env-file=.env.local -- npx tsx scripts/apply-migration-XXXX.ts`. See `vercel-turso-deploy` skill for the script template.
+7. Verify migration succeeded before pushing code
+8. **Push code only after production DB has the new schema** — Vercel does NOT run migrations on deploy
+
+### Data migration safety — MANDATORY
+
+**Incident reference**: Migration 0022 created the `riot_accounts` table but never copied existing user data from the `users` table. All production users lost their linked accounts and match history. CI didn't catch it because the seed script creates `riot_accounts` rows directly, masking the gap.
+
+**Rules for every migration:**
+
+1. **CREATE TABLE from existing data → include INSERT INTO ... SELECT FROM.**
+   When a new table replaces or extends data from an existing table, the migration SQL MUST copy existing data:
+
+   ```sql
+   -- BAD: creates an empty table, production users lose data
+   CREATE TABLE `riot_accounts` (...);
+
+   -- GOOD: creates the table AND migrates existing data
+   CREATE TABLE `riot_accounts` (...);
+   INSERT INTO `riot_accounts` (id, user_id, puuid, ...)
+   SELECT lower(hex(randomblob(16))), id, puuid, ...
+   FROM `users` WHERE `puuid` IS NOT NULL;
+   ```
+
+2. **New FK column → backfill existing rows.**
+   A new foreign key column that's NULL for all existing rows will make existing data invisible to queries that filter/join on it:
+
+   ```sql
+   ALTER TABLE `matches` ADD `riot_account_id` text REFERENCES riot_accounts(id);
+   -- MUST also backfill:
+   UPDATE `matches` SET `riot_account_id` = (
+     SELECT ra.id FROM `riot_accounts` ra
+     WHERE ra.user_id = `matches`.`user_id` AND ra.is_primary = 1
+   ) WHERE `riot_account_id` IS NULL;
+   ```
+
+3. **Seed script creates data for new table? That's a red flag.**
+   If the seed script directly inserts rows into a new table/column, ask: "Does the migration also handle this for existing production data?" The seed script creates demo data for testing — it does NOT run in production.
+
+4. **Mental production test.**
+   Before committing: "If I run this migration against a production database with 1000 users and 50,000 matches, will all existing data still be accessible through the new schema?" If the answer is no, the migration is incomplete.
+
+5. **Write a `.validate.sql` companion file.**
+   For any migration that creates tables or moves data, write `drizzle/XXXX_name.validate.sql` with assertions that verify data integrity. The migration runner executes these after applying the migration. See `scripts/migrate.ts` for the validation mechanism.
 
 ## Data sync (db-push / db-pull)
 

--- a/.opencode/skills/pr-workflow/SKILL.md
+++ b/.opencode/skills/pr-workflow/SKILL.md
@@ -185,17 +185,18 @@ Fixes #N
 
 Seven checks run automatically on every PR to `main`:
 
-| Check         | Command                           | What it catches                                               |
-| ------------- | --------------------------------- | ------------------------------------------------------------- |
-| **Typecheck** | `tsc --noEmit`                    | Type errors                                                   |
-| **Lint**      | `oxlint`                          | Code quality, unused vars, React rules, jsx-a11y, TypeScript  |
-| **Format**    | `oxfmt --check .`                 | Formatting consistency (import sorting, Tailwind class order) |
-| **Build**     | `next build --webpack`            | Compilation errors, broken imports                            |
-| **Smoke**     | `playwright test --project=smoke` | Axe-core a11y violations on every page                        |
-| **E2E**       | `playwright test --project=e2e`   | End-to-end user flows                                         |
-| **Changelog** | `git diff` on `changelog/`        | Missing changelog entry (skipped with `skip-changelog` label) |
+| Check             | Command                           | What it catches                                               |
+| ----------------- | --------------------------------- | ------------------------------------------------------------- |
+| **Typecheck**     | `tsc --noEmit`                    | Type errors                                                   |
+| **Lint**          | `oxlint`                          | Code quality, unused vars, React rules, jsx-a11y, TypeScript  |
+| **Format**        | `oxfmt --check .`                 | Formatting consistency (import sorting, Tailwind class order) |
+| **Migration**     | `tsx scripts/test-migration.ts`   | Migrations that break pre-existing data                       |
+| **Build**         | `next build --webpack`            | Compilation errors, broken imports                            |
+| **Smoke**         | `playwright test --project=smoke` | Axe-core a11y violations on every page, data integrity        |
+| **E2E**           | `playwright test --project=e2e`   | End-to-end user flows                                         |
+| **Changelog**     | `git diff` on `changelog/`        | Missing changelog entry (skipped with `skip-changelog` label) |
 
-All seven must pass before merging.
+All checks must pass before merging.
 
 ### 6. Merge
 
@@ -262,3 +263,13 @@ npm run build
 git push -u origin chore/description
 gh pr create --title "chore: description" --body "..." --label skip-changelog
 ```
+
+### PR includes migration files (`drizzle/*.sql`)
+
+**MANDATORY checklist** — complete ALL items before pushing:
+
+1. **Data migration review**: Does the migration create a new table or add an FK column? If yes, does it include `INSERT INTO ... SELECT FROM` (or `UPDATE ... SET`) to populate it from existing data? A `CREATE TABLE` without data migration is a production outage.
+2. **Validation file**: Write a `drizzle/XXXX_name.validate.sql` companion file with queries that return 0 rows when data is correct. The migration runner (`scripts/migrate.ts`) executes these automatically after applying each migration.
+3. **Migration integration test**: Run `npm run test:migration` to verify migrations handle pre-existing data correctly. This test applies migrations in two phases (before/after a split point), inserting fixture data in between.
+4. **Seed script independence**: The seed script (`scripts/seed.ts`) must NOT compensate for missing migration logic. If the seed creates data for a new table, the migration must also create that data for existing production rows.
+5. **Mental production test**: Imagine running this migration against a production database with real users. User logs in → navigates to dashboard → sees their data. If any step breaks, the migration is incomplete.

--- a/.opencode/skills/pr-workflow/SKILL.md
+++ b/.opencode/skills/pr-workflow/SKILL.md
@@ -185,16 +185,16 @@ Fixes #N
 
 Seven checks run automatically on every PR to `main`:
 
-| Check             | Command                           | What it catches                                               |
-| ----------------- | --------------------------------- | ------------------------------------------------------------- |
-| **Typecheck**     | `tsc --noEmit`                    | Type errors                                                   |
-| **Lint**          | `oxlint`                          | Code quality, unused vars, React rules, jsx-a11y, TypeScript  |
-| **Format**        | `oxfmt --check .`                 | Formatting consistency (import sorting, Tailwind class order) |
-| **Migration**     | `tsx scripts/test-migration.ts`   | Migrations that break pre-existing data                       |
-| **Build**         | `next build --webpack`            | Compilation errors, broken imports                            |
-| **Smoke**         | `playwright test --project=smoke` | Axe-core a11y violations on every page, data integrity        |
-| **E2E**           | `playwright test --project=e2e`   | End-to-end user flows                                         |
-| **Changelog**     | `git diff` on `changelog/`        | Missing changelog entry (skipped with `skip-changelog` label) |
+| Check         | Command                           | What it catches                                               |
+| ------------- | --------------------------------- | ------------------------------------------------------------- |
+| **Typecheck** | `tsc --noEmit`                    | Type errors                                                   |
+| **Lint**      | `oxlint`                          | Code quality, unused vars, React rules, jsx-a11y, TypeScript  |
+| **Format**    | `oxfmt --check .`                 | Formatting consistency (import sorting, Tailwind class order) |
+| **Migration** | `tsx scripts/test-migration.ts`   | Migrations that break pre-existing data                       |
+| **Build**     | `next build --webpack`            | Compilation errors, broken imports                            |
+| **Smoke**     | `playwright test --project=smoke` | Axe-core a11y violations on every page, data integrity        |
+| **E2E**       | `playwright test --project=e2e`   | End-to-end user flows                                         |
+| **Changelog** | `git diff` on `changelog/`        | Missing changelog entry (skipped with `skip-changelog` label) |
 
 All checks must pass before merging.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,26 @@ Full workflow details are in the `vercel-turso-deploy` OpenCode skill.
 
 <!-- END:turso-migration-rules -->
 
+<!-- BEGIN:migration-safety-rules -->
+
+# Migration data safety — MANDATORY
+
+**Every migration that creates a new table from existing data MUST include `INSERT INTO ... SELECT FROM` to populate it.** A CREATE TABLE without the corresponding data migration is a production outage waiting to happen.
+
+**Incident reference**: Migration 0022 created `riot_accounts` but never copied existing user Riot data into it. All production users lost visibility of their linked accounts and match history. The seed script masked the bug because it creates riot_accounts rows directly — CI tests passed because they run against a freshly seeded database, not a migrated one.
+
+Before committing ANY migration file (`drizzle/*.sql`), answer these questions:
+
+1. **Does this migration create a new table?** If yes, does existing data need to be migrated into it? Write the `INSERT INTO ... SELECT FROM` in the same migration file.
+2. **Does this migration add a foreign key column?** If yes, are existing rows backfilled? A new FK column that's NULL for all existing rows means all existing data becomes invisible to queries that join/filter on it.
+3. **Does this migration move data from one table to another** (e.g., denormalization, table split)? Both the source read and destination write must be in the migration.
+4. **Does the seed script create data for this new table/column directly?** If yes, that's a red flag — the migration itself should be creating that data for existing production rows. The seed script should only create demo/test fixtures, not compensate for missing migration logic.
+5. **If I run this migration against a production database with real users, will the app still work immediately after?** Test mentally: user logs in → navigates to dashboard → sees their data. If any step breaks, the migration is incomplete.
+
+**The seed script is NOT a substitute for data migrations.** The seed script creates demo data for local dev and CI tests. Production databases are populated by migrations and user activity — never by the seed script.
+
+<!-- END:migration-safety-rules -->
+
 <!-- BEGIN:env-safety-rules -->
 
 # Environment variable safety — MANDATORY

--- a/drizzle/0026_migrate_existing_riot_accounts.validate.sql
+++ b/drizzle/0026_migrate_existing_riot_accounts.validate.sql
@@ -1,0 +1,17 @@
+-- Validation for migration 0026: migrate existing Riot accounts
+--
+-- Each query should return 0 rows. Any rows indicate a data integrity issue
+-- that would cause production users to lose visibility of their accounts.
+
+-- Every user with a puuid must have at least one riot_accounts row
+SELECT u.id AS user_id, u.puuid
+FROM users u
+WHERE u.puuid IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM riot_accounts ra WHERE ra.user_id = u.id
+  );
+--> statement-breakpoint
+-- Every user with a puuid must have active_riot_account_id set
+SELECT id AS user_id
+FROM users
+WHERE puuid IS NOT NULL AND active_riot_account_id IS NULL;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "db:push": "tsx scripts/db-push.ts",
     "db:migrate": "tsx scripts/migrate.ts",
     "db:seed": "tsx scripts/seed.ts",
+    "test:migration": "tsx scripts/test-migration.ts",
     "test:smoke": "playwright test --project=smoke",
     "test:e2e": "playwright test --project=e2e",
     "prepare": "lefthook install"

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -173,6 +173,33 @@ async function migrate() {
       args: [hash, Date.now()],
     });
 
+    // ── Run post-migration validation if a .validate.sql file exists ────
+    const validatePath = path.resolve(__dirname, `../drizzle/${hash}.validate.sql`);
+    if (fs.existsSync(validatePath)) {
+      console.log(`[migrate]   Running validation for ${hash}...`);
+      const validateSql = fs.readFileSync(validatePath, "utf-8");
+      const validateStatements = validateSql
+        .split("--> statement-breakpoint")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+
+      for (const stmt of validateStatements) {
+        const result = await client.execute(stmt);
+        // Each validation query should return 0 rows if data is correct.
+        // Any rows returned indicate a data integrity issue.
+        if (result.rows.length > 0) {
+          console.error(`[migrate] ✗ Validation failed for ${hash}:`);
+          console.error(`[migrate]   Query: ${stmt.slice(0, 200)}`);
+          console.error(
+            `[migrate]   Found ${result.rows.length} row(s) that violate the assertion.`,
+          );
+          console.error(`[migrate]   First row: ${JSON.stringify(result.rows[0])}`);
+          process.exit(1);
+        }
+      }
+      console.log(`[migrate]   ✓ All validations passed for ${hash}`);
+    }
+
     appliedCount++;
     console.log(`[migrate] ✓ Applied ${hash}`);
   }

--- a/scripts/test-migration.ts
+++ b/scripts/test-migration.ts
@@ -1,0 +1,352 @@
+// scripts/test-migration.ts
+// Migration integration test — verifies that migrations correctly handle
+// pre-existing data, not just empty databases.
+//
+// This catches bugs like migration 0022 (created riot_accounts table but
+// never migrated existing user data into it). The seed script masks such
+// gaps because it creates the "ideal end state" directly.
+//
+// How it works:
+// 1. Creates a fresh in-memory SQLite database
+// 2. Applies migrations 0000–0021 (the "before multi-account" schema)
+// 3. Inserts fixture data that matches a real production user
+// 4. Applies remaining migrations (0022+)
+// 5. Runs validation queries to verify data integrity
+//
+// Usage:
+//   npx tsx scripts/test-migration.ts
+//
+// Exit code 0 = all validations passed, 1 = failure.
+
+import { createClient } from "@libsql/client";
+import fs from "fs";
+import path from "path";
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+// The migration index where multi-account support was introduced.
+// We apply 0000–(SPLIT_POINT-1) first, insert fixtures, then apply the rest.
+const SPLIT_POINT = 22; // 0022_odd_maggott.sql = CREATE TABLE riot_accounts
+
+async function applyMigrations(
+  client: ReturnType<typeof createClient>,
+  entries: JournalEntry[],
+  label: string,
+) {
+  for (const entry of entries) {
+    const sqlPath = path.resolve(__dirname, `../drizzle/${entry.tag}.sql`);
+    if (!fs.existsSync(sqlPath)) {
+      throw new Error(`SQL file not found: ${sqlPath}`);
+    }
+
+    const sqlContent = fs.readFileSync(sqlPath, "utf-8");
+    const statements = sqlContent
+      .split("--> statement-breakpoint")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+
+    for (const stmt of statements) {
+      try {
+        await client.execute(stmt);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // Skip "already exists" for idempotency (matches migrate.ts behavior)
+        if (msg.includes("already exists") || msg.includes("duplicate column name")) {
+          continue;
+        }
+        throw new Error(
+          `Failed in ${label}, migration ${entry.tag}: ${msg}\n  Statement: ${stmt.slice(0, 200)}`,
+        );
+      }
+    }
+  }
+}
+
+async function insertPreMigrationFixtures(client: ReturnType<typeof createClient>) {
+  // Simulate a production user who linked their Riot account before multi-account migration.
+  // This user has data in: users, matches, rank_snapshots, goals, match_highlights, ai_insights.
+  const userId = "test-user-001";
+  const puuid = "test-puuid-abc123";
+  const now = Math.floor(Date.now() / 1000);
+
+  // User with Riot data in the old schema (stored directly on users table)
+  await client.execute({
+    sql: `INSERT INTO users (id, discord_id, name, image, puuid, riot_game_name, riot_tag_line,
+          summoner_id, region, onboarding_completed, role, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      userId,
+      "discord-12345",
+      "TestPlayer",
+      "https://example.com/avatar.png",
+      puuid,
+      "TestPlayer",
+      "EUW",
+      "summoner-id-001",
+      "euw1",
+      1,
+      "user",
+      now,
+      now,
+    ],
+  });
+
+  // A second user WITHOUT Riot data (should not crash migrations)
+  await client.execute({
+    sql: `INSERT INTO users (id, discord_id, name, onboarding_completed, role, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    args: ["test-user-002", "discord-67890", "NoRiotUser", 0, "user", now, now],
+  });
+
+  // Matches for the linked user
+  for (let i = 0; i < 3; i++) {
+    await client.execute({
+      sql: `INSERT INTO matches (id, odometer, user_id, game_date, result, champion_id, champion_name,
+            kills, deaths, assists, cs, game_duration_seconds, synced_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        `EUW1_TEST_${i}`,
+        i + 1,
+        userId,
+        now - i * 3600,
+        i % 2 === 0 ? "Victory" : "Defeat",
+        1,
+        "Ahri",
+        5 + i,
+        3,
+        7,
+        180,
+        1800,
+        now,
+      ],
+    });
+  }
+
+  // Rank snapshot
+  await client.execute({
+    sql: `INSERT INTO rank_snapshots (user_id, captured_at, tier, division, lp, wins, losses)
+          VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    args: [userId, now, "GOLD", "II", 45, 30, 25],
+  });
+
+  // Goal
+  await client.execute({
+    sql: `INSERT INTO goals (user_id, title, target_tier, target_division, start_tier, start_division, start_lp, status, created_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [userId, "Reach Platinum", "PLATINUM", "IV", "GOLD", "II", 45, "active", now],
+  });
+
+  // Match highlight
+  await client.execute({
+    sql: `INSERT INTO match_highlights (match_id, user_id, type, text, created_at)
+          VALUES (?, ?, ?, ?, ?)`,
+    args: ["EUW1_TEST_0", userId, "highlight", "Great roam at 12 min", now],
+  });
+
+  // AI insight
+  await client.execute({
+    sql: `INSERT INTO ai_insights (user_id, type, context_key, content, model, created_at)
+          VALUES (?, ?, ?, ?, ?, ?)`,
+    args: [userId, "matchup", "ahri-vs-zed", "Focus on wave management", "gemini-2.5-flash", now],
+  });
+}
+
+interface Validation {
+  name: string;
+  query: string;
+  check: (rows: Array<Record<string, unknown>>) => string | null; // null = pass, string = error
+}
+
+function buildValidations(): Validation[] {
+  return [
+    {
+      name: "Every user with puuid has a riot_accounts row",
+      query: `
+        SELECT u.id, u.puuid
+        FROM users u
+        WHERE u.puuid IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM riot_accounts ra WHERE ra.user_id = u.id
+          )
+      `,
+      check: (rows) =>
+        rows.length > 0
+          ? `${rows.length} user(s) with puuid but no riot_accounts row: ${rows.map((r) => r.id).join(", ")}`
+          : null,
+    },
+    {
+      name: "Every user with puuid has active_riot_account_id set",
+      query: `
+        SELECT id FROM users
+        WHERE puuid IS NOT NULL AND active_riot_account_id IS NULL
+      `,
+      check: (rows) =>
+        rows.length > 0
+          ? `${rows.length} user(s) with puuid but NULL active_riot_account_id: ${rows.map((r) => r.id).join(", ")}`
+          : null,
+    },
+    {
+      name: "Every match for a user with riot_accounts has riot_account_id set",
+      query: `
+        SELECT m.id, m.user_id
+        FROM matches m
+        JOIN users u ON u.id = m.user_id
+        WHERE u.puuid IS NOT NULL AND m.riot_account_id IS NULL
+      `,
+      check: (rows) =>
+        rows.length > 0
+          ? `${rows.length} match(es) with NULL riot_account_id: ${rows.map((r) => r.id).join(", ")}`
+          : null,
+    },
+    {
+      name: "Every rank_snapshot for a user with riot_accounts has riot_account_id set",
+      query: `
+        SELECT rs.id, rs.user_id
+        FROM rank_snapshots rs
+        JOIN users u ON u.id = rs.user_id
+        WHERE u.puuid IS NOT NULL AND rs.riot_account_id IS NULL
+      `,
+      check: (rows) =>
+        rows.length > 0 ? `${rows.length} rank_snapshot(s) with NULL riot_account_id` : null,
+    },
+    {
+      name: "Every goal for a user with riot_accounts has riot_account_id set",
+      query: `
+        SELECT g.id, g.user_id
+        FROM goals g
+        JOIN users u ON u.id = g.user_id
+        WHERE u.puuid IS NOT NULL AND g.riot_account_id IS NULL
+      `,
+      check: (rows) =>
+        rows.length > 0 ? `${rows.length} goal(s) with NULL riot_account_id` : null,
+    },
+    {
+      name: "Every match_highlight for a user with riot_accounts has riot_account_id set",
+      query: `
+        SELECT mh.id, mh.user_id
+        FROM match_highlights mh
+        JOIN users u ON u.id = mh.user_id
+        WHERE u.puuid IS NOT NULL AND mh.riot_account_id IS NULL
+      `,
+      check: (rows) =>
+        rows.length > 0 ? `${rows.length} match_highlight(s) with NULL riot_account_id` : null,
+    },
+    {
+      name: "Every ai_insight for a user with riot_accounts has riot_account_id set",
+      query: `
+        SELECT ai.id, ai.user_id
+        FROM ai_insights ai
+        JOIN users u ON u.id = ai.user_id
+        WHERE u.puuid IS NOT NULL AND ai.riot_account_id IS NULL
+      `,
+      check: (rows) =>
+        rows.length > 0 ? `${rows.length} ai_insight(s) with NULL riot_account_id` : null,
+    },
+    {
+      name: "Users without Riot data have no riot_accounts rows",
+      query: `
+        SELECT ra.id, ra.user_id
+        FROM riot_accounts ra
+        JOIN users u ON u.id = ra.user_id
+        WHERE u.puuid IS NULL
+      `,
+      check: (rows) =>
+        rows.length > 0
+          ? `${rows.length} orphaned riot_accounts row(s) for users without puuid`
+          : null,
+    },
+    {
+      name: "riot_accounts.is_primary is set for migrated accounts",
+      query: `
+        SELECT ra.id FROM riot_accounts ra
+        WHERE ra.is_primary = 0
+          AND (SELECT COUNT(*) FROM riot_accounts ra2 WHERE ra2.user_id = ra.user_id AND ra2.is_primary = 1) = 0
+      `,
+      check: (rows) =>
+        rows.length > 0
+          ? `${rows.length} riot_accounts without any primary account for their user`
+          : null,
+    },
+  ];
+}
+
+async function main() {
+  console.log("[test-migration] Starting migration integration test...\n");
+
+  // Use in-memory SQLite for speed and isolation
+  const client = createClient({ url: ":memory:" });
+
+  // Load journal
+  const journalPath = path.resolve(__dirname, "../drizzle/meta/_journal.json");
+  const journal: Journal = JSON.parse(fs.readFileSync(journalPath, "utf-8"));
+
+  const beforeEntries = journal.entries.filter((e) => e.idx < SPLIT_POINT);
+  const afterEntries = journal.entries.filter((e) => e.idx >= SPLIT_POINT);
+
+  console.log(
+    `[test-migration] Phase 1: Applying migrations 0000–${String(SPLIT_POINT - 1).padStart(4, "0")} (${beforeEntries.length} migrations)...`,
+  );
+  await applyMigrations(client, beforeEntries, "phase-1");
+  console.log("[test-migration] Phase 1 complete.\n");
+
+  console.log("[test-migration] Phase 2: Inserting pre-migration fixture data...");
+  await insertPreMigrationFixtures(client);
+  console.log(
+    "[test-migration] Phase 2 complete. Inserted: 2 users, 3 matches, 1 rank snapshot, 1 goal, 1 highlight, 1 AI insight.\n",
+  );
+
+  console.log(
+    `[test-migration] Phase 3: Applying migrations ${String(SPLIT_POINT).padStart(4, "0")}–${String(journal.entries.length - 1).padStart(4, "0")} (${afterEntries.length} migrations)...`,
+  );
+  await applyMigrations(client, afterEntries, "phase-3");
+  console.log("[test-migration] Phase 3 complete.\n");
+
+  console.log("[test-migration] Phase 4: Running validation queries...\n");
+  const validations = buildValidations();
+  let passed = 0;
+  let failed = 0;
+
+  for (const v of validations) {
+    const result = await client.execute(v.query);
+    const rows = result.rows as unknown as Array<Record<string, unknown>>;
+    const error = v.check(rows);
+    if (error) {
+      console.error(`  ✗ ${v.name}`);
+      console.error(`    → ${error}`);
+      failed++;
+    } else {
+      console.log(`  ✓ ${v.name}`);
+      passed++;
+    }
+  }
+
+  console.log(
+    `\n[test-migration] Results: ${passed} passed, ${failed} failed out of ${validations.length} validations.`,
+  );
+
+  if (failed > 0) {
+    console.error(
+      "\n[test-migration] FAILED — migrations do not correctly handle pre-existing data.",
+    );
+    process.exit(1);
+  }
+
+  console.log("\n[test-migration] PASSED — all migrations correctly migrate pre-existing data.");
+}
+
+main().catch((err) => {
+  console.error("[test-migration] Unexpected error:", err);
+  process.exit(1);
+});

--- a/tests/smoke/data-integrity.spec.ts
+++ b/tests/smoke/data-integrity.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Data integrity smoke tests.
+ *
+ * These verify that seeded data actually renders on key pages — not just
+ * that pages return HTTP 200. This catches bugs where migrations create
+ * tables but fail to migrate existing data (e.g. migration 0022 incident).
+ *
+ * Uses the same pre-authenticated session as other smoke tests (DemoPlayer).
+ */
+
+test.describe("Data integrity", () => {
+  test("Dashboard shows recent matches", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    // At least one match card link should be visible
+    const matchLinks = page.locator('a[href^="/matches/EUW1_"]');
+    await expect(matchLinks.first()).toBeVisible();
+    expect(await matchLinks.count()).toBeGreaterThanOrEqual(1);
+  });
+
+  test("Matches page shows match cards with stats", async ({ page }) => {
+    await page.goto("/matches");
+
+    // Summary line should show game count (e.g. "47 games · 26W 21L · 55% WR")
+    // Use .first() because the page may have a desktop and mobile version
+    await expect(page.getByText(/\d+ games/).first()).toBeVisible();
+
+    // At least one match card link should exist
+    const matchLinks = page.locator('a[href^="/matches/EUW1_"]');
+    await expect(matchLinks.first()).toBeVisible();
+    expect(await matchLinks.count()).toBeGreaterThanOrEqual(1);
+  });
+
+  test("Settings page shows linked Riot account", async ({ page }) => {
+    await page.goto("/settings");
+
+    // A Riot ID with # separator should be visible (e.g. "DemoPlayer#EUW")
+    // Wait for it to appear as account data loads asynchronously
+    await expect(page.getByText(/#/).first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("Analytics page shows game data", async ({ page }) => {
+    await page.goto("/analytics");
+
+    // "N games analyzed" text should be visible
+    // Use .first() because the page may have desktop and mobile versions
+    await expect(page.getByText(/\d+ games analyzed/).first()).toBeVisible();
+
+    // At least one chart SVG should render
+    const charts = page.locator(".recharts-surface");
+    await expect(charts.first()).toBeVisible();
+    expect(await charts.count()).toBeGreaterThanOrEqual(1);
+  });
+
+  test("CSV export contains match data", async ({ request }) => {
+    const response = await request.get("/api/export/matches");
+    expect(response.status()).toBe(200);
+
+    const body = await response.text();
+    const lines = body.trim().split("\n");
+    // Header + at least 1 data row
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Summary

Post-incident safety guardrails to prevent data loss from incomplete migrations (like the migration 0022 incident where `riot_accounts` was created but never populated).

- **Migration integration test** (`scripts/test-migration.ts`): applies migrations in two phases with fixture data in between, verifying data is correctly migrated — not just that tables are created on empty databases
- **Data integrity smoke tests** (`tests/smoke/data-integrity.spec.ts`): verifies seeded data actually renders on Dashboard, Matches, Settings, and Analytics pages
- **Post-migration validation** (`.validate.sql` files): migration runner now executes companion validation queries after each migration, aborting the deploy if assertions fail
- **Agent/skill guidance**: updated AGENTS.md, drizzle-schema skill, and pr-workflow skill with mandatory migration checklists
- **CI job**: new "Migration integrity" job runs on every PR

Relates to #161