### PR TITLE
fix: allow sync continuation batches to bypass rate limit

### DIFF
--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -3,7 +3,7 @@ import { eq, desc } from "drizzle-orm";
 import { db } from "@/db";
 import { matches, rankSnapshots, riotAccounts, users } from "@/db/schema";
 import { checkGoalAchievement } from "@/lib/goals";
-import { checkRateLimit } from "@/lib/rate-limit";
+import { checkRateLimit, hasRecentEvent } from "@/lib/rate-limit";
 import { calculateAdaptiveDelay } from "@/lib/rate-limiter";
 import {
   getMatchIds,
@@ -55,8 +55,10 @@ export async function GET(request: Request) {
   }
 
   // Optional ?limit=N — sync at most N matches per request (for batched sync)
+  // Optional ?continuation=true — skip rate limit for continuation batches
   const url = new URL(request.url);
   const limitParam = url.searchParams.get("limit");
+  const isContinuation = url.searchParams.get("continuation") === "true";
   const batchLimit = limitParam
     ? Math.min(Math.max(parseInt(limitParam, 10) || MAX_BATCH_LIMIT, 1), MAX_BATCH_LIMIT)
     : null;
@@ -77,14 +79,28 @@ export async function GET(request: Request) {
       };
 
       // ── Rate limit check ───────────────────────────────────────────
-      const rateCheck = await checkRateLimit(user.id, "sync");
-      if (!rateCheck.allowed) {
-        send({
-          type: "error",
-          message: `You can only sync once every 5 minutes. Try again in ${rateCheck.retryAfter} seconds.`,
-        });
-        controller.close();
-        return;
+      // Continuation batches (automatic follow-ups from a batched sync)
+      // skip the normal rate limit but must prove a recent sync happened.
+      if (isContinuation) {
+        const recent = await hasRecentEvent(user.id, "sync", 5 * 60 * 1000);
+        if (!recent) {
+          send({
+            type: "error",
+            message: "Invalid continuation request.",
+          });
+          controller.close();
+          return;
+        }
+      } else {
+        const rateCheck = await checkRateLimit(user.id, "sync");
+        if (!rateCheck.allowed) {
+          send({
+            type: "error",
+            message: `You can only sync once every 5 minutes. Try again in ${rateCheck.retryAfter} seconds.`,
+          });
+          controller.close();
+          return;
+        }
       }
 
       // ── Acquire sync lock ────────────────────────────────────────────

--- a/src/hooks/use-sync-matches.ts
+++ b/src/hooks/use-sync-matches.ts
@@ -78,8 +78,12 @@ export function useSyncMatches(isLinked: boolean = false) {
       let cumulativeSynced = 0;
       let cumulativeFailed = 0;
 
-      const runBatch = async (limit?: number): Promise<void> => {
-        const url = limit ? `/api/sync?limit=${limit}` : "/api/sync";
+      const runBatch = async (limit?: number, continuation = false): Promise<void> => {
+        const params = new URLSearchParams();
+        if (limit) params.set("limit", String(limit));
+        if (continuation) params.set("continuation", "true");
+        const qs = params.toString();
+        const url = qs ? `/api/sync?${qs}` : "/api/sync";
         const res = await fetch(url);
 
         if (!res.ok || !res.body) {
@@ -226,7 +230,7 @@ export function useSyncMatches(isLinked: boolean = false) {
             id: toastIdRef.current,
           });
           await new Promise((resolve) => setTimeout(resolve, CONTINUATION_DELAY_MS));
-          await runBatch(CONTINUATION_BATCH_SIZE);
+          await runBatch(CONTINUATION_BATCH_SIZE, true);
           return;
         }
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -112,3 +112,30 @@ export async function checkRateLimit(userId: string, action: string): Promise<Ra
 
   return { allowed: true };
 }
+
+/**
+ * Check whether a user has a recent rate-limit event for a given action,
+ * without recording a new one. Used to validate continuation requests —
+ * e.g., batched sync continuations that should bypass the rate limit but
+ * only if a recent initial sync already passed it.
+ *
+ * @param withinMs — look-back window in milliseconds (default: 30 seconds)
+ */
+export async function hasRecentEvent(
+  userId: string,
+  action: string,
+  withinMs = 30_000,
+): Promise<boolean> {
+  const threshold = new Date(Date.now() - withinMs);
+  const [result] = await db
+    .select({ total: sql<number>`count(*)` })
+    .from(rateLimitEvents)
+    .where(
+      and(
+        eq(rateLimitEvents.userId, userId),
+        eq(rateLimitEvents.action, action),
+        gt(rateLimitEvents.createdAt, threshold),
+      ),
+    );
+  return (result?.total ?? 0) > 0;
+}


### PR DESCRIPTION
## Summary

- Continuation batches in batched sync were being rejected by the 5-minute rate limiter, breaking multi-batch syncs. A user with 40+ new matches would sync 20, then the automatic continuation would fail with "try again in 5 minutes."
- Added `?continuation=true` query param support to `/api/sync`. Continuation requests skip the rate limit but must prove a recent sync event exists (within the 5-minute window) to prevent abuse.
- Added `hasRecentEvent()` to the rate-limit module for read-only event lookups.

Relates to #51

## Changes

- `src/lib/rate-limit.ts` — new `hasRecentEvent()` function
- `src/app/api/sync/route.ts` — reads `?continuation=true`, skips rate limit with validation
- `src/hooks/use-sync-matches.ts` — passes `continuation=true` on follow-up batches