### PR TITLE
fix: use commit SHA-based URLs for PR description images

### DIFF
--- a/.opencode/skills/ui-screenshots/SKILL.md
+++ b/.opencode/skills/ui-screenshots/SKILL.md
@@ -171,11 +171,21 @@ Image styling is handled by `changelog-prose img` in `globals.css` (max-width, b
 
 #### PR description
 
-Use GitHub raw image URLs pointing to the branch:
+Use GitHub raw image URLs pointing to the **commit SHA** (NOT the branch name):
 
 ```markdown
-![Before](https://github.com/beagleknight/lol-tracker/blob/<branch>/public/changelog/<slug>/before-review.png?raw=true)
+![Before](https://github.com/beagleknight/lol-tracker/blob/<commit-sha>/public/changelog/<slug>/before-review.png?raw=true)
 ```
+
+**How to get the commit SHA**: After committing the screenshot files, run:
+
+```bash
+git rev-parse HEAD
+```
+
+Use the full 40-character SHA in the URL. This ensures the image URL is permanent — it survives branch deletion after the PR is merged.
+
+**WARNING: Do NOT use branch names in image URLs.** Branch-based URLs (e.g., `.../blob/feat/my-feature/...`) break as soon as the branch is deleted after merge. Since all PRs are squash-merged and branches are deleted, every branch-based image URL will eventually return 404. Commit SHAs are immutable and permanent.
 
 Do NOT use `raw.githubusercontent.com` URLs — they don't render reliably in PR descriptions.
 
@@ -297,7 +307,7 @@ npm run test:e2e
 3. [ ] All images stored in `public/changelog/<slug>/`
 4. [ ] **No demo-only UI in changelogs** — login screen, demo user buttons, seed data labels must NEVER appear
 5. [ ] Changelog MDX (both `en/` and `es/`) includes embedded screenshots
-6. [ ] PR description includes before/after images with correct GitHub blob URLs
+6. [ ] PR description includes before/after images with commit SHA-based GitHub blob URLs (NOT branch names)
 7. [ ] `npx oxfmt --write <file>` run on EVERY file created or edited
 8. [ ] `npx oxfmt --check src/ messages/ changelog/ .opencode/` passes
 9. [ ] `npm run test:smoke` passes locally before pushing


### PR DESCRIPTION
## Summary

- Updated `ui-screenshots` skill to use **commit SHA-based URLs** instead of branch names in PR description image references
- Batch-fixed image URLs in **all 13 affected merged PRs** — replaced deleted/at-risk branch names with permanent commit SHAs

Fixes #177

## Problem

PR description images use GitHub blob URLs like:
```
https://github.com/.../blob/<branch>/public/changelog/<slug>/<file>.png?raw=true
```

After merge, feature branches are deleted, and these URLs return 404. This affected 8 PRs with broken images and 5 more at risk.

## Changes

### Skill update (`.opencode/skills/ui-screenshots/SKILL.md`)

- Replaced the branch-based URL template with a commit SHA-based one
- Added `git rev-parse HEAD` workflow step to capture the SHA after committing screenshots
- Added a warning explaining why branch-based URLs break
- Updated the PR checklist to mention SHA-based URLs

### Batch-fixed 13 merged PRs

Replaced branch names with permanent commit SHAs in all image URLs via `gh pr edit`:

| PR | Branch replaced | Images fixed |
|----|----------------|-------------|
| #183 | `fix/riot-disclaimer-changelog-screenshots` | 1 |
| #176 | `fix/riot-disclaimer` | 2 |
| #155 | `feat/multi-account-smurf-support` | 3 |
| #152 | `feat/user-tiers` | 6 |
| #151 | `feat/feedback-page` | 2 |
| #147 | `feat/canny-feedback-widget` | 3 |
| #142 | `feat/coaching-cadence-settings` | 4 |
| #101 | `feat/multi-region-onboarding-backend` | 7 |
| #115 | `fix/off-role-polish` | 6 |
| #114 | `feat/unified-coaching-widget` | 2 |
| #108 | `feat/duo-partner-search` | 2 |
| #104 | `feat/onboarding-wizard` | 2 |
| #98 | `feat/79-80-position-role-preferences` | 6 |

**Total: 46 image URLs fixed across 13 PRs**