### PR TITLE
chore: add open-source community files and update README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report a bug or unexpected behavior
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual behavior
+
+A clear and concise description of what actually happened.
+
+## Environment
+
+- **Browser**: (e.g., Chrome 125, Firefox 126)
+- **OS**: (e.g., Windows 11, macOS 14.5)
+- **Locale**: (e.g., en, es)
+
+## Screenshots (optional)
+
+If applicable, add screenshots to help explain the problem.
+
+## Additional context (optional)
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem statement
+
+A clear and concise description of what problem this feature would solve.
+
+## Proposed solution
+
+A clear and concise description of the solution you'd like.
+
+## Alternatives considered
+
+A description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context, mockups, or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- Describe your changes in 1-3 sentences. -->
+
+## Related issues
+
+Fixes #
+
+## Checklist
+
+- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md)
+- [ ] My changes include a changelog entry (or this PR has the `skip-changelog` label)
+- [ ] I have added/updated translations in both `messages/en.json` and `messages/es.json` (if applicable)
+- [ ] I ran `npm run build` locally and it passes
+- [ ] I ran `npm run test:smoke` locally (if this PR touches UI)
+- [ ] I ran `npm run test:e2e` locally (if this PR touches interactive flows)
+
+## Screenshots
+
+<!-- If this PR changes UI, include before/after screenshots. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at david.morcillo@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing to LoL Tracker
+
+## Getting started
+
+### Prerequisites
+
+- Node.js 24+ (recommended: use `fnm` with the included `.tool-versions`)
+- A Discord application for OAuth login
+- A Riot Games API key (development key from [developer.riotgames.com](https://developer.riotgames.com))
+
+### Setup
+
+1. Fork and clone the repository
+2. Install dependencies: `npm install`
+3. Copy `.env.example` to `.env.local` and fill in your values
+4. Set up Discord OAuth redirect: `http://localhost:3000/api/auth/callback/discord`
+5. Create the data directory and push the schema: `mkdir data && npx drizzle-kit push`
+6. Run the dev server: `npm run dev`
+
+## Development workflow
+
+### Branch naming
+
+All changes go through pull requests — never push directly to `main`.
+
+- `feat/short-description` — new features
+- `fix/short-description` — bug fixes
+- `refactor/short-description` — refactoring
+- `chore/short-description` — infrastructure, CI, dependencies
+
+### Making changes
+
+1. Create a branch from up-to-date `main`
+2. Implement your changes
+3. Run `npm run build` before pushing (catches type errors and build issues)
+4. Run `npm run test:smoke` if your changes touch UI, styles, or accessibility
+5. Run `npm run test:e2e` if your changes touch interactive user flows
+6. Push and open a pull request
+
+### Code style
+
+Formatting and linting are enforced automatically by pre-commit hooks (lefthook):
+
+- **Formatting**: `oxfmt` (not Prettier)
+- **Linting**: `oxlint` (not ESLint)
+
+You don't need to configure anything — just commit and the hooks will check your code. If they fail, run `npm run fmt` and try again.
+
+### Internationalization (i18n)
+
+The app supports English and Spanish. If your changes add or modify user-facing text:
+
+- Add keys to both `messages/en.json` and `messages/es.json`
+- Use the `t()` function from `next-intl` (not hardcoded strings)
+- All UI copy uses sentence case (only capitalize the first word and proper nouns)
+
+### Changelog entries
+
+Every user-facing PR needs a changelog entry in both:
+
+- `changelog/en/YYYY-MM-DD-slug.mdx`
+- `changelog/es/YYYY-MM-DD-slug.mdx`
+
+Infrastructure-only PRs (CI, config, dependency bumps) should use the `skip-changelog` label instead.
+
+The changelog audience is League of Legends players, not developers. Write in a casual, direct tone about what changed in their experience.
+
+### Database migrations
+
+If your changes modify the database schema:
+
+1. Run `npx drizzle-kit generate` to create migration SQL
+2. Review the generated SQL in `drizzle/`
+3. Apply locally: `npx drizzle-kit push`
+4. Commit the migration files with your code
+
+**Important**: if a migration creates a new table from existing data, it must include `INSERT INTO ... SELECT FROM` to populate it. The seed script is not a substitute for data migrations.
+
+## Pull request checklist
+
+- [ ] Description of what changed and why
+- [ ] Links to related GitHub issues (`Fixes #N` or `Relates to #N`)
+- [ ] Changelog entry (or `skip-changelog` label)
+- [ ] `npm run build` passes locally
+- [ ] `npm run test:smoke` passes (if touching UI)
+- [ ] `npm run test:e2e` passes (if touching interactive flows)
+- [ ] Translations updated in both `en.json` and `es.json` (if adding UI text)
+- [ ] Screenshots included (if changing UI — before/after)
+
+## Project structure overview
+
+- `src/app/` — Next.js app router pages and layouts
+- `src/components/` — Reusable UI components (shadcn/ui v4)
+- `src/lib/` — Shared utilities, database queries, API clients
+- `src/server/` — Server actions
+- `drizzle/` — Database migration files
+- `messages/` — i18n translation files (`en.json`, `es.json`)
+- `changelog/` — Changelog MDX entries (`en/`, `es/`)
+- `scripts/` — Build and maintenance scripts
+- `e2e/` — Playwright end-to-end tests
+
+## Getting help
+
+- Check existing GitHub issues for context
+- Open a new issue if you find a bug or want to suggest a feature
+- Use the issue templates provided
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/). See `CODE_OF_CONDUCT.md` for details.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # LoL Tracker
 
+[![CI](https://github.com/beagleknight/lol-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/beagleknight/lol-tracker/actions/workflows/ci.yml)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
+
 A personal League of Legends match tracker built with Next.js 16, featuring automatic match syncing via the Riot Games API, coaching session logging, and performance analytics.
+
+## Features
+
+- **Automatic match syncing** — links your Riot account and keeps your match history up to date
+- **Multi-account support** — track multiple Riot accounts (smurfs) under one login
+- **Performance analytics** — win rates, champion stats, role breakdowns, and trends over time
+- **AI-powered coaching** — get personalized feedback and action items from match reviews
+- **Duo partner tracking** — find and analyze your performance with duo partners
+- **Bilingual** — full English and Spanish support
 
 ## Prerequisites
 
-- Node.js 24+ (recommended: use [fnm](https://github.com/Schniz/fnm))
+- Node.js 24+ (recommended: use [fnm](https://github.com/Schniz/fnm) with the included `.tool-versions`)
 - A [Discord application](https://discord.com/developers/applications) for OAuth login
 - A [Riot Games API key](https://developer.riotgames.com)
 
@@ -58,7 +70,21 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) in your browser.
 
-## Important Notes
+## Self-hosting
+
+LoL Tracker is designed to run on [Vercel](https://vercel.com) with [Turso](https://turso.tech) as the production database, but you can adapt it to other platforms.
+
+**Each instance requires its own credentials:**
+
+- **Riot Games API key** — register at [developer.riotgames.com](https://developer.riotgames.com). Development keys expire every 24 hours; for a persistent deployment, apply for a production key and register your product on the Riot Developer Portal.
+- **Discord OAuth app** — create one at [discord.com/developers](https://discord.com/developers/applications). Set the redirect URI to `https://your-domain.com/api/auth/callback/discord`.
+- **Turso database** — create a database at [turso.tech](https://turso.tech) and set `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` in your hosting environment.
+
+See `.env.example` for the full list of environment variables.
+
+Migrations are applied automatically on deploy via `scripts/migrate.ts`. No manual migration step is needed.
+
+## Important notes
 
 - The production build uses the `--webpack` flag because Turbopack has issues bundling `@libsql/client`.
 
@@ -69,16 +95,34 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 | `npm run dev`            | Start dev server (webpack)                 |
 | `npm run build`          | Production build (webpack)                 |
 | `npm run start`          | Start production server                    |
+| `npm run test:smoke`     | Run Playwright smoke tests (a11y + pages)  |
+| `npm run test:e2e`       | Run Playwright end-to-end tests            |
 | `npx drizzle-kit push`   | Push schema changes to the database        |
 | `npx drizzle-kit studio` | Open Drizzle Studio to browse the database |
 
-## Tech Stack
+## Tech stack
 
 - **Framework:** Next.js 16 (React 19)
 - **Database:** SQLite/Turso via @libsql/client + Drizzle ORM
 - **Auth:** NextAuth v5 with Discord provider
 - **UI:** shadcn/ui v4, Tailwind CSS v4
+- **AI:** Google Gemini via Vercel AI SDK
+- **i18n:** next-intl (English + Spanish)
+- **Testing:** Playwright, axe-core
+- **Linting:** oxlint, oxfmt
 - **API:** Riot Games API for match data
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, coding guidelines, and the pull request workflow.
+
+## Security
+
+To report a security vulnerability, please email david.morcillo@gmail.com. Do **not** open a public issue. See [SECURITY.md](SECURITY.md) for details.
+
+## Legal
+
+LoL Tracker is not endorsed by Riot Games and does not reflect the views or opinions of Riot Games or anyone officially involved in producing or managing Riot Games properties. Riot Games and all associated properties are trademarks or registered trademarks of Riot Games, Inc.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security policy
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability in LoL Tracker, please report it responsibly by emailing **david.morcillo@gmail.com**. Do **not** open a public GitHub issue for security vulnerabilities.
+
+### What to include in your report
+
+- **Description** of the vulnerability
+- **Steps to reproduce** the issue
+- **Impact assessment** — what an attacker could achieve by exploiting it
+- **Suggested fix**, if you have one
+
+### Response timeline
+
+- **Acknowledgment** within 48 hours of your report
+- **Status updates** every 5 business days until the issue is resolved
+
+## Scope
+
+The following areas are in scope for security reports:
+
+- Authentication flows
+- API key handling
+- User data privacy
+- Authorization checks
+- XSS, CSRF, and injection vulnerabilities
+
+## Out of scope
+
+The following are **not** in scope:
+
+- Denial of service (DoS/DDoS) attacks
+- Social engineering (phishing, etc.)
+- Vulnerabilities in third-party dependencies — please report these upstream to the maintainers of the affected package
+
+## Credit
+
+If you report a vulnerability responsibly, we are happy to credit you in the release notes when the fix ships. Let us know in your report whether you would like to be credited and how you would like to be identified.


### PR DESCRIPTION
## Summary

- Add standard open-source community files in preparation for going public: Code of Conduct (Contributor Covenant v2.1), contributing guide, security disclosure policy, issue templates (bug report + feature request), and PR template
- Update README with CI/license badges, feature list, self-hosting instructions, contributing/security links, and Riot Games legal disclaimer

Fixes #172

## Changelog

Infrastructure-only (community files and documentation) — no user-facing changes.