### PR TITLE
fix: repair NULL riot_account_id causing invisible matches

### DIFF
--- a/changelog/en/2026-04-11-fix-missing-matches.mdx
+++ b/changelog/en/2026-04-11-fix-missing-matches.mdx
@@ -1,0 +1,10 @@
+---
+version: "2026.04.13"
+date: "2026-04-11"
+title: "Fixed missing matches for some players"
+tags: ["fix"]
+---
+
+Some players were only seeing a handful of their matches instead of the full list. The rest of the matches were stored correctly but weren't linked to the right account after a recent update, making them invisible.
+
+This fix restores all missing matches automatically — no action needed on your part. If you were affected, your full match history, analytics, and review queue should now show everything.

--- a/changelog/es/2026-04-11-fix-missing-matches.mdx
+++ b/changelog/es/2026-04-11-fix-missing-matches.mdx
@@ -1,0 +1,10 @@
+---
+version: "2026.04.13"
+date: "2026-04-11"
+title: "Corregidas partidas que no aparecían para algunos jugadores"
+tags: ["fix"]
+---
+
+Algunos jugadores solo veían unas pocas partidas en lugar de la lista completa. El resto de las partidas estaban guardadas correctamente pero no estaban vinculadas a la cuenta correcta tras una actualización reciente, haciéndolas invisibles.
+
+Esta corrección restaura todas las partidas que faltaban automáticamente — no necesitas hacer nada. Si te afectaba, tu historial completo de partidas, analíticas y cola de revisión deberían mostrar todo ahora.

--- a/drizzle/0028_repair_riot_account_id.sql
+++ b/drizzle/0028_repair_riot_account_id.sql
@@ -1,0 +1,41 @@
+-- Repair migration: backfill riot_account_id on rows that are still NULL.
+--
+-- Migration 0026 should have done this, but may have partially failed or
+-- skipped rows where the riot_accounts record wasn't yet created at the
+-- time the UPDATE ran. This causes matches (and other entities) to be
+-- invisible to users because all user-facing queries filter by
+-- riotAccountId via accountScope().
+--
+-- Bug report: GitHub issue #190 — user sees 6 of 100 matches.
+--
+-- Safe to re-run: only touches rows WHERE riot_account_id IS NULL.
+
+UPDATE `matches` SET `riot_account_id` = (
+  SELECT ra.id FROM `riot_accounts` ra
+  WHERE ra.user_id = `matches`.`user_id` AND ra.is_primary = 1
+  LIMIT 1
+) WHERE `riot_account_id` IS NULL;--> statement-breakpoint
+
+UPDATE `rank_snapshots` SET `riot_account_id` = (
+  SELECT ra.id FROM `riot_accounts` ra
+  WHERE ra.user_id = `rank_snapshots`.`user_id` AND ra.is_primary = 1
+  LIMIT 1
+) WHERE `riot_account_id` IS NULL;--> statement-breakpoint
+
+UPDATE `goals` SET `riot_account_id` = (
+  SELECT ra.id FROM `riot_accounts` ra
+  WHERE ra.user_id = `goals`.`user_id` AND ra.is_primary = 1
+  LIMIT 1
+) WHERE `riot_account_id` IS NULL;--> statement-breakpoint
+
+UPDATE `match_highlights` SET `riot_account_id` = (
+  SELECT ra.id FROM `riot_accounts` ra
+  WHERE ra.user_id = `match_highlights`.`user_id` AND ra.is_primary = 1
+  LIMIT 1
+) WHERE `riot_account_id` IS NULL;--> statement-breakpoint
+
+UPDATE `ai_insights` SET `riot_account_id` = (
+  SELECT ra.id FROM `riot_accounts` ra
+  WHERE ra.user_id = `ai_insights`.`user_id` AND ra.is_primary = 1
+  LIMIT 1
+) WHERE `riot_account_id` IS NULL;

--- a/drizzle/0028_repair_riot_account_id.validate.sql
+++ b/drizzle/0028_repair_riot_account_id.validate.sql
@@ -1,0 +1,29 @@
+-- Validation: no matches with NULL riot_account_id for users who have a riot account
+SELECT m.id, m.user_id
+FROM matches m
+JOIN users u ON u.id = m.user_id
+WHERE u.puuid IS NOT NULL AND m.riot_account_id IS NULL;
+
+-- Validation: no rank_snapshots with NULL riot_account_id for users who have a riot account
+SELECT rs.id, rs.user_id
+FROM rank_snapshots rs
+JOIN users u ON u.id = rs.user_id
+WHERE u.puuid IS NOT NULL AND rs.riot_account_id IS NULL;
+
+-- Validation: no goals with NULL riot_account_id for users who have a riot account
+SELECT g.id, g.user_id
+FROM goals g
+JOIN users u ON u.id = g.user_id
+WHERE u.puuid IS NOT NULL AND g.riot_account_id IS NULL;
+
+-- Validation: no match_highlights with NULL riot_account_id for users who have a riot account
+SELECT mh.id, mh.user_id
+FROM match_highlights mh
+JOIN users u ON u.id = mh.user_id
+WHERE u.puuid IS NOT NULL AND mh.riot_account_id IS NULL;
+
+-- Validation: no ai_insights with NULL riot_account_id for users who have a riot account
+SELECT ai.id, ai.user_id
+FROM ai_insights ai
+JOIN users u ON u.id = ai.user_id
+WHERE u.puuid IS NOT NULL AND ai.riot_account_id IS NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1775952000000,
       "tag": "0027_user_tiers",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1776038400000,
+      "tag": "0028_repair_riot_account_id",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -923,6 +923,7 @@
     "columnRiotId": "Riot ID",
     "columnRegion": "Region",
     "columnMatches": "Matches",
+    "matchCountMismatchTooltip": "User sees {scoped} matches but {total} exist in database — possible riot_account_id backfill issue",
     "columnLastSync": "Last sync",
     "columnJoined": "Joined",
     "columnStatus": "Status",

--- a/messages/es.json
+++ b/messages/es.json
@@ -923,6 +923,7 @@
     "columnRiotId": "Riot ID",
     "columnRegion": "Región",
     "columnMatches": "Partidas",
+    "matchCountMismatchTooltip": "El usuario ve {scoped} partidas pero existen {total} en la base de datos — posible problema de backfill de riot_account_id",
     "columnLastSync": "Última sync",
     "columnJoined": "Registro",
     "columnStatus": "Estado",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lol-tracker",
-  "version": "2026.04.12",
+  "version": "2026.04.13",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -202,7 +202,21 @@ function UsersSection() {
                         {u.region ? PLATFORM_LABELS[u.region] || u.region : t("noRegion")}
                       </span>
                       <span>
-                        {u.matchCount} {t("columnMatches").toLowerCase()}
+                        {u.scopedMatchCount !== u.matchCount ? (
+                          <span
+                            className="text-amber-400"
+                            title={t("matchCountMismatchTooltip", {
+                              scoped: u.scopedMatchCount,
+                              total: u.matchCount,
+                            })}
+                          >
+                            {u.scopedMatchCount}/{u.matchCount} {t("columnMatches").toLowerCase()}
+                          </span>
+                        ) : (
+                          <>
+                            {u.matchCount} {t("columnMatches").toLowerCase()}
+                          </>
+                        )}
                       </span>
                       <span>
                         {t("columnJoined")}: {formatDate(u.createdAt, locale)}

--- a/src/app/actions/admin.ts
+++ b/src/app/actions/admin.ts
@@ -18,6 +18,7 @@ export interface AdminUser {
   deactivatedAt: Date | null;
   createdAt: Date;
   matchCount: number;
+  scopedMatchCount: number;
   lastSync: Date | null;
 }
 
@@ -38,6 +39,7 @@ export async function getUsers(): Promise<AdminUser[]> {
       deactivatedAt: users.deactivatedAt,
       createdAt: users.createdAt,
       matchCount: count(matches.id),
+      scopedMatchCount: sql<number>`SUM(CASE WHEN ${matches.riotAccountId} = ${users.activeRiotAccountId} THEN 1 ELSE 0 END)`,
       lastSync: max(matches.syncedAt),
     })
     .from(users)
@@ -57,6 +59,7 @@ export async function getUsers(): Promise<AdminUser[]> {
     deactivatedAt: r.deactivatedAt,
     createdAt: r.createdAt,
     matchCount: r.matchCount,
+    scopedMatchCount: r.scopedMatchCount ?? 0,
     lastSync: r.lastSync ? new Date(r.lastSync) : null,
   }));
 }

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -334,6 +334,7 @@ export async function GET(request: Request) {
               .onConflictDoUpdate({
                 target: [matches.id, matches.userId],
                 set: {
+                  riotAccountId: activeRiotAccountId,
                   gameDate: playerData.gameDate,
                   result: playerData.result,
                   championId: playerData.championId,


### PR DESCRIPTION
## Summary

- **Repair migration (0028)**: Backfills `riot_account_id` on all rows where it is still NULL across `matches`, `rank_snapshots`, `goals`, `match_highlights`, and `ai_insights`. This is the root cause — migration 0026 should have done this but likely failed partially for some users.
- **Sync upsert safety net**: Adds `riotAccountId` to the `onConflictDoUpdate` block in the sync route, so future re-syncs fix stale NULL values instead of preserving them forever.
- **Admin visibility**: The admin panel now shows scoped vs total match count (e.g., `6/100 matches` in amber) when the counts diverge, making this class of bug immediately visible.

Fixes #190

## Root cause

All user-facing pages filter matches by `eq(matches.riotAccountId, user.activeRiotAccountId)` via `accountScope()`. Matches with `riot_account_id = NULL` never match this filter and are invisible. The admin panel counted by `userId` only, so it showed all 100 matches while the user saw only 6.

Migration 0026 was supposed to backfill all NULL values but either ran partially or the user's riot_account record wasn't created at migration time (due to missing fields in the `WHERE` clause).

## Changes

| File | Change |
|------|--------|
| `drizzle/0028_repair_riot_account_id.sql` | Backfill migration for all 5 affected tables |
| `drizzle/0028_repair_riot_account_id.validate.sql` | Validation queries (zero rows = success) |
| `drizzle/meta/_journal.json` | Register migration 0028 |
| `src/app/api/sync/route.ts` | Add `riotAccountId` to upsert's `set` block |
| `src/app/actions/admin.ts` | Add `scopedMatchCount` (SUM CASE) to admin query |
| `src/app/(app)/admin/page.tsx` | Show scoped/total count with amber warning |
| `messages/en.json` / `messages/es.json` | i18n key for mismatch tooltip |

## Verification

- `npm run test:migration` — 9/9 validations pass (including riot_account_id checks)
- `npm run build` — clean build, no type errors
- `npm run test:smoke` — 41/41 pass (including admin page a11y)

## Changelog

- Version 2026.04.13: Fixed missing matches for some players