### PR TITLE
fix: split validation SQL on semicolons instead of statement-breakpoint markers

### DIFF
--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -178,10 +178,16 @@ async function migrate() {
     if (fs.existsSync(validatePath)) {
       console.log(`[migrate]   Running validation for ${hash}...`);
       const validateSql = fs.readFileSync(validatePath, "utf-8");
+      // Validation files are hand-written SQL, so split on semicolons
+      // (not Drizzle's --> statement-breakpoint markers).
       const validateStatements = validateSql
-        .split("--> statement-breakpoint")
+        .split(";")
         .map((s) => s.trim())
-        .filter((s) => s.length > 0);
+        .filter((s) => {
+          // Keep only chunks that contain actual SQL (not just comments/whitespace)
+          const withoutComments = s.replace(/--[^\n]*/g, "").trim();
+          return withoutComments.length > 0;
+        });
 
       for (const stmt of validateStatements) {
         const result = await client.execute(stmt);


### PR DESCRIPTION
## Summary

- **Root cause**: The migration runner (`scripts/migrate.ts`) split `.validate.sql` files on `--⁠> statement-breakpoint` markers, but validation files are hand-written SQL that use standard semicolons as statement delimiters. This caused the entire validation file to be sent as a single multi-statement string to libsql, which rejects it with `SQL_MANY_STATEMENTS`.
- **Fix**: Split validation SQL on semicolons and filter out comment-only chunks, so each statement is executed individually.
- Migration 0028 (`repair_riot_account_id`) was the first migration with a `.validate.sql` file, so this bug only surfaced now.

## What failed

```
[migrate] Migration failed: LibsqlError: SQL_MANY_STATEMENTS: SQL string contains more than one statement
```

The deploy failed because the 5 validation SELECT statements in `0028_repair_riot_account_id.validate.sql` were concatenated and sent as one string.

## Verification

- `npm run build` passes
- `npm run test:migration` passes — all 9 validations green