### PR TITLE
feat: admin impersonation (view as user) for debugging

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -955,6 +955,8 @@
     "copyCode": "Copy invite code",
     "deleteInvite": "Delete invite",
     "noInvites": "No invites yet. Generate one to invite a new user.",
+    "viewAsButton": "View as",
+    "impersonateButton": "View as {name}",
     "toasts": {
       "deactivateSuccess": "User deactivated.",
       "reactivateSuccess": "User reactivated.",
@@ -968,8 +970,14 @@
       "deleteSuccess": "Invite deleted.",
       "deleteError": "Failed to delete invite.",
       "codeCopied": "Invite code copied to clipboard.",
-      "linkCopied": "Invite link copied to clipboard."
+      "linkCopied": "Invite link copied to clipboard.",
+      "impersonateError": "Failed to start impersonation."
     }
+  },
+  "Impersonation": {
+    "banner": "Viewing as {name} — logged in as {admin} (read-only)",
+    "stopButton": "Stop",
+    "unknownUser": "Unknown user"
   },
   "Feedback": {
     "pageTitle": "Feedback & suggestions",

--- a/messages/en.json
+++ b/messages/en.json
@@ -977,6 +977,7 @@
   "Impersonation": {
     "banner": "Viewing as {name} — logged in as {admin} (read-only)",
     "stopButton": "Stop",
+    "stopError": "Failed to stop impersonation",
     "unknownUser": "Unknown user"
   },
   "Feedback": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -977,6 +977,7 @@
   "Impersonation": {
     "banner": "Viendo como {name} — sesión de {admin} (solo lectura)",
     "stopButton": "Detener",
+    "stopError": "Error al detener la suplantación",
     "unknownUser": "Usuario desconocido"
   },
   "Feedback": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -955,6 +955,8 @@
     "copyCode": "Copiar código de invitación",
     "deleteInvite": "Eliminar invitación",
     "noInvites": "No hay invitaciones aún. Genera una para invitar a un nuevo usuario.",
+    "viewAsButton": "Ver como",
+    "impersonateButton": "Ver como {name}",
     "toasts": {
       "deactivateSuccess": "Usuario desactivado.",
       "reactivateSuccess": "Usuario reactivado.",
@@ -968,8 +970,14 @@
       "deleteSuccess": "Invitación eliminada.",
       "deleteError": "Error al eliminar invitación.",
       "codeCopied": "Código de invitación copiado al portapapeles.",
-      "linkCopied": "Enlace de invitación copiado al portapapeles."
+      "linkCopied": "Enlace de invitación copiado al portapapeles.",
+      "impersonateError": "Error al iniciar la suplantación."
     }
+  },
+  "Impersonation": {
+    "banner": "Viendo como {name} — sesión de {admin} (solo lectura)",
+    "stopButton": "Detener",
+    "unknownUser": "Usuario desconocido"
   },
   "Feedback": {
     "pageTitle": "Sugerencias y comentarios",

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -178,10 +178,16 @@ async function migrate() {
     if (fs.existsSync(validatePath)) {
       console.log(`[migrate]   Running validation for ${hash}...`);
       const validateSql = fs.readFileSync(validatePath, "utf-8");
+      // Validation files are hand-written SQL, so split on semicolons
+      // (not Drizzle's --> statement-breakpoint markers).
       const validateStatements = validateSql
-        .split("--> statement-breakpoint")
+        .split(";")
         .map((s) => s.trim())
-        .filter((s) => s.length > 0);
+        .filter((s) => {
+          // Keep only chunks that contain actual SQL (not just comments/whitespace)
+          const withoutComments = s.replace(/--[^\n]*/g, "").trim();
+          return withoutComments.length > 0;
+        });
 
       for (const stmt of validateStatements) {
         const result = await client.execute(stmt);

--- a/src/app/(app)/admin/layout.tsx
+++ b/src/app/(app)/admin/layout.tsx
@@ -1,11 +1,13 @@
 import { redirect } from "next/navigation";
 
-import { requireUser } from "@/lib/session";
+import { getRealUser } from "@/lib/session";
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
-  const user = await requireUser();
+  // Always use the REAL user (ignoring impersonation) so admins
+  // can access the admin panel while impersonating another user.
+  const user = await getRealUser();
 
-  if (user.role !== "admin") {
+  if (!user || user.role !== "admin") {
     redirect("/dashboard");
   }
 

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -14,7 +14,7 @@ import {
   Users,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { isRedirectError } from "next/dist/client/components/redirect-error";
+import { useRouter } from "next/navigation";
 import { useState, useTransition, useEffect, useCallback } from "react";
 import { toast } from "sonner";
 
@@ -52,7 +52,8 @@ interface InviteItem {
 
 function UsersSection() {
   const t = useTranslations("Admin");
-  const { user: currentUser } = useAuth();
+  const { user: currentUser, updateSession } = useAuth();
+  const router = useRouter();
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [isPending, startTransition] = useTransition();
@@ -117,10 +118,11 @@ function UsersSection() {
     startTransition(async () => {
       try {
         await startImpersonation(userId);
+        // Refresh the client session BEFORE navigating so the target page
+        // renders with the impersonated user's data (no stale-session flicker).
+        await updateSession();
+        router.push("/dashboard");
       } catch (err) {
-        // redirect() throws a NEXT_REDIRECT error — let it propagate so the
-        // redirect actually happens instead of showing a false error toast.
-        if (isRedirectError(err)) throw err;
         toast.error(err instanceof Error ? err.message : t("toasts.impersonateError"));
       }
     });

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -14,6 +14,7 @@ import {
   Users,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { useState, useTransition, useEffect, useCallback } from "react";
 import { toast } from "sonner";
 
@@ -117,6 +118,9 @@ function UsersSection() {
       try {
         await startImpersonation(userId);
       } catch (err) {
+        // redirect() throws a NEXT_REDIRECT error — let it propagate so the
+        // redirect actually happens instead of showing a false error toast.
+        if (isRedirectError(err)) throw err;
         toast.error(err instanceof Error ? err.message : t("toasts.impersonateError"));
       }
     });

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -3,6 +3,7 @@
 import {
   Copy,
   Crown,
+  Eye,
   Loader2,
   Plus,
   Shield,
@@ -21,6 +22,7 @@ import {
   deactivateUser,
   reactivateUser,
   updateUserRole,
+  startImpersonation,
   type AdminUser,
 } from "@/app/actions/admin";
 import { createInvite, getInvites, deleteInvite } from "@/app/actions/invites";
@@ -106,6 +108,16 @@ function UsersSection() {
         await loadUsers();
       } catch {
         toast.error(t("toasts.roleChangeError"));
+      }
+    });
+  }
+
+  function handleImpersonate(userId: string) {
+    startTransition(async () => {
+      try {
+        await startImpersonation(userId);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : t("toasts.impersonateError"));
       }
     });
   }
@@ -227,6 +239,23 @@ function UsersSection() {
                   {/* Actions */}
                   {!isYou && (
                     <div className="flex shrink-0 gap-1.5">
+                      {u.role !== "admin" && !isDeactivated && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleImpersonate(u.id)}
+                          disabled={isPending}
+                          className="gap-1.5 text-amber-400 hover:bg-amber-400/10"
+                          aria-label={t("impersonateButton", { name: u.name || "Unknown" })}
+                        >
+                          {isPending ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <Eye className="h-3.5 w-3.5" />
+                          )}
+                          {t("viewAsButton")}
+                        </Button>
+                      )}
                       {u.role !== "admin" && (
                         <Button
                           variant="outline"

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -6,6 +6,7 @@ import { connection } from "next/server";
 import { Suspense } from "react";
 
 import { AppSidebar } from "@/components/app-sidebar";
+import { ImpersonationBanner } from "@/components/impersonation-banner";
 import { Toaster } from "@/components/ui/sonner";
 import { db } from "@/db";
 import { matches, riotAccounts } from "@/db/schema";
@@ -94,6 +95,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             >
               Skip to main content
             </a>
+            <ImpersonationBanner />
             <Suspense>
               <SidebarWithUser />
             </Suspense>

--- a/src/app/actions/admin.ts
+++ b/src/app/actions/admin.ts
@@ -2,7 +2,6 @@
 
 import { eq, count, max, sql } from "drizzle-orm";
 import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 
 import { db } from "@/db";
 import { users, matches } from "@/db/schema";
@@ -159,12 +158,15 @@ export async function startImpersonation(targetUserId: string) {
     maxAge: 60 * 60, // 1 hour — auto-expires as a safety net
   });
 
-  redirect("/dashboard");
+  // Don't redirect here — let the client update the session first
+  // to avoid a flash of stale (admin) session data on the target page.
+  return { success: true };
 }
 
 export async function stopImpersonation() {
   const cookieStore = await cookies();
   cookieStore.delete(IMPERSONATE_COOKIE);
 
-  redirect("/admin");
+  // Same as above — client handles navigation after session refresh.
+  return { success: true };
 }

--- a/src/app/actions/admin.ts
+++ b/src/app/actions/admin.ts
@@ -1,10 +1,12 @@
 "use server";
 
 import { eq, count, max, sql } from "drizzle-orm";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
 import { db } from "@/db";
 import { users, matches } from "@/db/schema";
-import { requireAdmin } from "@/lib/session";
+import { IMPERSONATE_COOKIE, requireAdmin } from "@/lib/session";
 
 export interface AdminUser {
   id: string;
@@ -116,4 +118,53 @@ export async function updateUserRole(userId: string, role: "premium" | "free") {
   await db.update(users).set({ role, updatedAt: new Date() }).where(eq(users.id, userId));
 
   return { success: true };
+}
+
+// ─── Impersonation ──────────────────────────────────────────────────────────
+
+export async function startImpersonation(targetUserId: string) {
+  const admin = await requireAdmin();
+
+  // Cannot impersonate yourself
+  if (targetUserId === admin.id) {
+    throw new Error("Cannot impersonate yourself");
+  }
+
+  // Look up target user
+  const target = await db.query.users.findFirst({
+    where: eq(users.id, targetUserId),
+  });
+
+  if (!target) {
+    throw new Error("User not found");
+  }
+
+  // Cannot impersonate another admin
+  if (target.role === "admin") {
+    throw new Error("Cannot impersonate another admin");
+  }
+
+  // Cannot impersonate deactivated users
+  if (target.deactivatedAt) {
+    throw new Error("Cannot impersonate a deactivated user");
+  }
+
+  // Set the impersonation cookie (httpOnly, secure, short-lived)
+  const cookieStore = await cookies();
+  cookieStore.set(IMPERSONATE_COOKIE, targetUserId, {
+    path: "/",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: 60 * 60, // 1 hour — auto-expires as a safety net
+  });
+
+  redirect("/dashboard");
+}
+
+export async function stopImpersonation() {
+  const cookieStore = await cookies();
+  cookieStore.delete(IMPERSONATE_COOKIE);
+
+  redirect("/admin");
 }

--- a/src/app/actions/ai-insights.ts
+++ b/src/app/actions/ai-insights.ts
@@ -12,7 +12,7 @@ import { buildPostGameContext } from "@/lib/ai/context";
 import { buildMatchupPrompt, buildPostGamePrompt } from "@/lib/ai/prompts";
 import { aiModel, isAiConfigured, AI_MODEL_ID } from "@/lib/ai/provider";
 import { checkRateLimit } from "@/lib/rate-limit";
-import { isPremium, requireUser } from "@/lib/session";
+import { blockIfImpersonating, isPremium, requireUser } from "@/lib/session";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -132,6 +132,7 @@ export async function generateMatchupInsight(
   forceRegenerate = false,
 ): Promise<InsightResult | InsightError> {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   if (!isAiConfigured()) {
     return { error: "AI insights are not configured." };
@@ -259,6 +260,7 @@ export async function generatePostGameInsight(
   forceRegenerate = false,
 ): Promise<InsightResult | InsightError> {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   if (!isAiConfigured()) {
     return { error: "AI insights are not configured." };

--- a/src/app/actions/coaching.ts
+++ b/src/app/actions/coaching.ts
@@ -6,7 +6,7 @@ import { revalidatePath } from "next/cache";
 import { db } from "@/db";
 import { coachingSessions, coachingSessionMatches, coachingActionItems } from "@/db/schema";
 import { invalidateCoachingCaches } from "@/lib/cache";
-import { requireUser } from "@/lib/session";
+import { blockIfImpersonating, requireUser } from "@/lib/session";
 
 // ─── Phase 1: Schedule a coaching session ────────────────────────────────────
 
@@ -17,6 +17,7 @@ export async function scheduleCoachingSession(data: {
   focusAreas?: string[]; // optional pre-session focus topics
 }) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   const focusAreasJson = data.focusAreas?.length ? JSON.stringify(data.focusAreas) : null;
 
@@ -64,6 +65,7 @@ export async function completeCoachingSession(
   },
 ) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   const session = await db.query.coachingSessions.findFirst({
     where: and(eq(coachingSessions.id, sessionId), eq(coachingSessions.userId, user.id)),
@@ -132,6 +134,7 @@ export async function updateCoachingSession(
   },
 ) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   const session = await db.query.coachingSessions.findFirst({
     where: and(eq(coachingSessions.id, sessionId), eq(coachingSessions.userId, user.id)),
@@ -187,6 +190,7 @@ export async function updateCoachingSession(
 
 export async function deleteCoachingSession(sessionId: number) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   await db
     .delete(coachingSessions)
@@ -206,6 +210,7 @@ export async function updateActionItemStatus(
   status: "pending" | "in_progress" | "completed",
 ) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   await db
     .update(coachingActionItems)
@@ -227,6 +232,7 @@ export async function updateActionItemStatus(
 
 export async function deleteActionItem(itemId: number) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   await db
     .delete(coachingActionItems)
@@ -246,6 +252,7 @@ export async function deleteActionItem(itemId: number) {
 
 export async function createActionItem(data: { description: string; topic?: string }) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   if (!data.description.trim()) {
     return { error: "Description is required." };

--- a/src/app/actions/duo.ts
+++ b/src/app/actions/duo.ts
@@ -10,7 +10,7 @@ import { db } from "@/db";
 import { matches, riotAccounts, users, type MatchResult } from "@/db/schema";
 import { duoTag, invalidateDuoBackfillCaches } from "@/lib/cache";
 import { duoStatsSelect, championSynergySelect } from "@/lib/match-queries";
-import { requireUser } from "@/lib/session";
+import { blockIfImpersonating, requireUser } from "@/lib/session";
 
 const PAGE_SIZE = 10;
 
@@ -312,6 +312,7 @@ export async function backfillDuoGames(): Promise<{
   duoFound: number;
 }> {
   const user = await requireUser();
+  await blockIfImpersonating();
   if (!user.duoPartnerUserId || !user.puuid) {
     return { processed: 0, duoFound: 0 };
   }

--- a/src/app/actions/goals.ts
+++ b/src/app/actions/goals.ts
@@ -6,7 +6,7 @@ import { revalidatePath } from "next/cache";
 import { db } from "@/db";
 import { goals, rankSnapshots } from "@/db/schema";
 import { invalidateGoalsCaches } from "@/lib/cache";
-import { requireUser } from "@/lib/session";
+import { blockIfImpersonating, requireUser } from "@/lib/session";
 
 // ─── Create a new goal ──────────────────────────────────────────────────────
 
@@ -16,6 +16,7 @@ export async function createGoal(data: {
   deadline: string | null; // ISO string or null
 }) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Check for existing active goal
   const activeGoalConditions = [eq(goals.userId, user.id), eq(goals.status, "active")];
@@ -76,6 +77,7 @@ export async function createGoal(data: {
 
 export async function retireGoal(goalId: number) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   const goal = await db.query.goals.findFirst({
     where: and(eq(goals.id, goalId), eq(goals.userId, user.id), eq(goals.status, "active")),
@@ -104,6 +106,7 @@ export async function retireGoal(goalId: number) {
 
 export async function deleteGoal(goalId: number) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   await db.delete(goals).where(and(eq(goals.id, goalId), eq(goals.userId, user.id)));
 

--- a/src/app/actions/matches.ts
+++ b/src/app/actions/matches.ts
@@ -6,7 +6,7 @@ import { revalidatePath } from "next/cache";
 import { db } from "@/db";
 import { matches, matchHighlights } from "@/db/schema";
 import { invalidateReviewCaches } from "@/lib/cache";
-import { requireUser } from "@/lib/session";
+import { blockIfImpersonating, requireUser } from "@/lib/session";
 import { validateVodUrl } from "@/lib/url";
 
 /**
@@ -29,6 +29,7 @@ export async function savePostGameReview(
   },
 ) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Save highlights/lowlights
   await db
@@ -76,6 +77,7 @@ export async function savePostGameReview(
 
 export async function bulkMarkReviewed(skipReason: string) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   const conditions = [eq(matches.userId, user.id), eq(matches.reviewed, false)];
   if (user.activeRiotAccountId) {

--- a/src/app/actions/matchup-notes.ts
+++ b/src/app/actions/matchup-notes.ts
@@ -6,7 +6,7 @@ import { updateTag } from "next/cache";
 import { db } from "@/db";
 import { matchupNotes } from "@/db/schema";
 import { scoutTag } from "@/lib/cache";
-import { requireUser } from "@/lib/session";
+import { blockIfImpersonating, requireUser } from "@/lib/session";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -104,6 +104,7 @@ export async function upsertMatchupNote(
   content: string,
 ): Promise<{ success: boolean; error?: string }> {
   const user = await requireUser();
+  await blockIfImpersonating();
   const trimmed = content.trim();
 
   if (!matchupChampionName.trim()) {
@@ -157,6 +158,7 @@ export async function upsertMatchupNote(
  */
 export async function deleteMatchupNote(id: number): Promise<{ success: boolean; error?: string }> {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   await db
     .delete(matchupNotes)

--- a/src/app/actions/onboarding.ts
+++ b/src/app/actions/onboarding.ts
@@ -6,7 +6,7 @@ import { cookies } from "next/headers";
 
 import { db } from "@/db";
 import { users } from "@/db/schema";
-import { requireUser } from "@/lib/session";
+import { blockIfImpersonating, requireUser } from "@/lib/session";
 
 /**
  * Complete the onboarding flow.
@@ -18,6 +18,7 @@ import { requireUser } from "@/lib/session";
  */
 export async function completeOnboarding() {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   if (user.onboardingCompleted) {
     return { error: "Onboarding already completed." };

--- a/src/app/actions/riot-accounts.ts
+++ b/src/app/actions/riot-accounts.ts
@@ -8,7 +8,7 @@ import { users, riotAccounts } from "@/db/schema";
 import { invalidateAllCaches } from "@/lib/cache";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { getAccountByRiotId, RiotApiError, PLATFORM_IDS } from "@/lib/riot-api";
-import { isPremium, requireUser } from "@/lib/session";
+import { blockIfImpersonating, isPremium, requireUser } from "@/lib/session";
 
 const MAX_RIOT_ACCOUNTS_PREMIUM = 5;
 const MAX_RIOT_ACCOUNTS_FREE = 1;
@@ -22,6 +22,7 @@ const MAX_RIOT_ACCOUNTS_FREE = 1;
  */
 export async function addRiotAccount(formData: FormData) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Rate limit check
   const rateCheck = await checkRateLimit(user.id, "riot_lookup");
@@ -131,6 +132,7 @@ export async function addRiotAccount(formData: FormData) {
  */
 export async function removeRiotAccount(accountId: string) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Find the account and verify ownership
   const account = await db.query.riotAccounts.findFirst({
@@ -203,6 +205,7 @@ export async function removeRiotAccount(accountId: string) {
  */
 export async function switchActiveAccount(accountId: string) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Verify ownership
   const account = await db.query.riotAccounts.findFirst({
@@ -246,6 +249,7 @@ export async function switchActiveAccount(accountId: string) {
  */
 export async function setAccountAsPrimary(accountId: string) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Verify ownership
   const account = await db.query.riotAccounts.findFirst({
@@ -281,6 +285,7 @@ export async function setAccountAsPrimary(accountId: string) {
  */
 export async function updateAccountLabel(accountId: string, label: string | null) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   const trimmed = label?.trim() || null;
   if (trimmed && trimmed.length > 30) {
@@ -318,6 +323,7 @@ export async function updateAccountRolePreferences(
   secondaryRole: string | null,
 ) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Validate positions
   if (primaryRole && !VALID_POSITIONS.includes(primaryRole as (typeof VALID_POSITIONS)[number])) {
@@ -399,6 +405,7 @@ export async function getUserRiotAccounts() {
  */
 export async function toggleAccountDiscoverable(accountId: string, discoverable: boolean) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Verify ownership
   const account = await db.query.riotAccounts.findFirst({

--- a/src/app/actions/settings.ts
+++ b/src/app/actions/settings.ts
@@ -11,12 +11,13 @@ import { invalidateAllCaches, invalidateDuoCaches } from "@/lib/cache";
 import { SUPPORTED_LOCALES, type SupportedLocale } from "@/lib/format";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { getAccountByRiotId, RiotApiError, PLATFORM_IDS } from "@/lib/riot-api";
-import { requireUser } from "@/lib/session";
+import { blockIfImpersonating, requireUser } from "@/lib/session";
 
 const MAX_RIOT_ACCOUNTS = 5;
 
 export async function linkRiotAccount(formData: FormData) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Rate limit check
   const rateCheck = await checkRateLimit(user.id, "riot_lookup");
@@ -112,6 +113,7 @@ export async function linkRiotAccount(formData: FormData) {
 
 export async function unlinkRiotAccount() {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   if (!user.activeRiotAccountId) {
     return { error: "No active Riot account to unlink." };
@@ -214,6 +216,7 @@ export async function unlinkRiotAccount() {
  */
 export async function updateRegion(region: string) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   if (!PLATFORM_IDS.includes(region)) {
     return { error: "Invalid region." };
@@ -303,6 +306,7 @@ export async function getDuoPartner() {
  */
 export async function setDuoPartner(partnerUserId: string) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Verify the partner exists and has a linked Riot account
   const partner = await db.query.users.findFirst({
@@ -336,6 +340,7 @@ export async function setDuoPartner(partnerUserId: string) {
  */
 export async function clearDuoPartner() {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   await db
     .update(users)
@@ -358,6 +363,7 @@ export async function clearDuoPartner() {
  */
 export async function updateLocale(locale: SupportedLocale) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Validate locale is supported
   const valid = SUPPORTED_LOCALES.some((l) => l.value === locale);
@@ -386,6 +392,7 @@ export async function updateLocale(locale: SupportedLocale) {
  */
 export async function updateLanguage(language: SupportedLanguage) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Validate language is supported
   const valid = SUPPORTED_LANGUAGES.some((l) => l.value === language);
@@ -430,6 +437,7 @@ const VALID_CADENCE_DAYS = [7, 14, 21, 30] as const;
  */
 export async function updateCoachingCadence(days: number) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   if (!VALID_CADENCE_DAYS.includes(days as (typeof VALID_CADENCE_DAYS)[number])) {
     return { error: "Invalid coaching cadence." };
@@ -458,6 +466,7 @@ export async function updateRolePreferences(
   secondaryRole: string | null,
 ) {
   const user = await requireUser();
+  await blockIfImpersonating();
 
   // Validate positions
   if (primaryRole && !VALID_POSITIONS.includes(primaryRole as (typeof VALID_POSITIONS)[number])) {

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,7 +1,7 @@
 import { eq, desc } from "drizzle-orm";
 
 import { db } from "@/db";
-import { matches, rankSnapshots, riotAccounts, users } from "@/db/schema";
+import { matches, rankSnapshots, riotAccounts } from "@/db/schema";
 import { checkGoalAchievement } from "@/lib/goals";
 import { checkRateLimit, hasRecentEvent } from "@/lib/rate-limit";
 import { calculateAdaptiveDelay } from "@/lib/rate-limiter";
@@ -17,7 +17,7 @@ import {
   getLastRateLimitInfo,
   RiotApiError,
 } from "@/lib/riot-api";
-import { getCurrentUser } from "@/lib/session";
+import { blockIfImpersonating, getCurrentUser } from "@/lib/session";
 import {
   acquireSyncLock,
   releaseSyncLock,
@@ -45,6 +45,16 @@ export async function GET(request: Request) {
 
   if (!user) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Block sync during admin impersonation (read-only mode)
+  try {
+    await blockIfImpersonating();
+  } catch {
+    return Response.json(
+      { error: "Sync is disabled while viewing as another user." },
+      { status: 403 },
+    );
   }
 
   if (!user.puuid) {

--- a/src/components/impersonation-banner.tsx
+++ b/src/components/impersonation-banner.tsx
@@ -2,7 +2,9 @@
 
 import { Eye, X } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { useTransition } from "react";
+import { toast } from "sonner";
 
 import { stopImpersonation } from "@/app/actions/admin";
 import { Button } from "@/components/ui/button";
@@ -14,6 +16,18 @@ export function ImpersonationBanner() {
   const [isPending, startTransition] = useTransition();
 
   if (!user?.isImpersonating) return null;
+
+  function handleStop() {
+    startTransition(async () => {
+      try {
+        await stopImpersonation();
+      } catch (err) {
+        // redirect() throws a NEXT_REDIRECT error — let it propagate
+        if (isRedirectError(err)) throw err;
+        toast.error(t("stopError"));
+      }
+    });
+  }
 
   return (
     <div className="fixed top-0 right-0 left-0 z-50 flex items-center justify-center gap-3 bg-amber-500/90 px-4 py-2 text-sm font-medium text-black backdrop-blur-sm md:left-64">
@@ -27,7 +41,7 @@ export function ImpersonationBanner() {
       <Button
         variant="outline"
         size="sm"
-        onClick={() => startTransition(() => stopImpersonation())}
+        onClick={handleStop}
         disabled={isPending}
         className="ml-2 h-7 gap-1 border-black/20 bg-black/10 text-black hover:bg-black/20 hover:text-black"
       >

--- a/src/components/impersonation-banner.tsx
+++ b/src/components/impersonation-banner.tsx
@@ -2,7 +2,7 @@
 
 import { Eye, X } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { isRedirectError } from "next/dist/client/components/redirect-error";
+import { useRouter } from "next/navigation";
 import { useTransition } from "react";
 import { toast } from "sonner";
 
@@ -11,8 +11,9 @@ import { Button } from "@/components/ui/button";
 import { useAuth } from "@/lib/auth-client";
 
 export function ImpersonationBanner() {
-  const { user } = useAuth();
+  const { user, updateSession } = useAuth();
   const t = useTranslations("Impersonation");
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
   if (!user?.isImpersonating) return null;
@@ -21,10 +22,12 @@ export function ImpersonationBanner() {
     startTransition(async () => {
       try {
         await stopImpersonation();
+        // Refresh the client session BEFORE navigating so the admin page
+        // renders with the real admin identity (no stale-session flicker).
+        await updateSession();
+        router.push("/admin");
       } catch (err) {
-        // redirect() throws a NEXT_REDIRECT error — let it propagate
-        if (isRedirectError(err)) throw err;
-        toast.error(t("stopError"));
+        toast.error(err instanceof Error ? err.message : t("stopError"));
       }
     });
   }

--- a/src/components/impersonation-banner.tsx
+++ b/src/components/impersonation-banner.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Eye, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useTransition } from "react";
+
+import { stopImpersonation } from "@/app/actions/admin";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/lib/auth-client";
+
+export function ImpersonationBanner() {
+  const { user } = useAuth();
+  const t = useTranslations("Impersonation");
+  const [isPending, startTransition] = useTransition();
+
+  if (!user?.isImpersonating) return null;
+
+  return (
+    <div className="fixed top-0 right-0 left-0 z-50 flex items-center justify-center gap-3 bg-amber-500/90 px-4 py-2 text-sm font-medium text-black backdrop-blur-sm md:left-64">
+      <Eye className="h-4 w-4 shrink-0" />
+      <span>
+        {t("banner", {
+          name: user.name || t("unknownUser"),
+          admin: user.realAdminName || "Admin",
+        })}
+      </span>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => startTransition(() => stopImpersonation())}
+        disabled={isPending}
+        className="ml-2 h-7 gap-1 border-black/20 bg-black/10 text-black hover:bg-black/20 hover:text-black"
+      >
+        <X className="h-3.5 w-3.5" />
+        {t("stopButton")}
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -31,6 +31,10 @@ export interface AuthUser {
   primaryRole?: string | null;
   secondaryRole?: string | null;
   coachingCadenceDays?: number | null;
+  /** True when an admin is impersonating this user */
+  isImpersonating?: boolean;
+  /** The real admin's display name during impersonation */
+  realAdminName?: string | null;
 }
 
 export interface UseAuthReturn {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,6 +7,9 @@ import { db } from "@/db";
 import { users, invites, riotAccounts } from "@/db/schema";
 import { isDemoMode, demoCredentialsProvider } from "@/lib/fake-auth";
 
+// Duplicated from session.ts to avoid circular import (session.ts imports auth.ts)
+const IMPERSONATE_COOKIE = "admin-impersonate";
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
   providers: [
     // Auth.js auto-reads AUTH_DISCORD_ID and AUTH_DISCORD_SECRET from
@@ -168,35 +171,57 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     },
     async session({ session, token }) {
       if (token.sub) {
-        // Look up our internal user by discord ID
+        // Look up our internal user by discord ID (the real JWT user)
         const dbUser = await db.query.users.findFirst({
           where: eq(users.discordId, token.discordId as string),
         });
-        if (dbUser) {
-          session.user.id = dbUser.id;
-          session.user.riotGameName = dbUser.riotGameName;
-          session.user.riotTagLine = dbUser.riotTagLine;
-          session.user.isRiotLinked = !!dbUser.puuid;
-          session.user.region = dbUser.region;
-          session.user.activeRiotAccountId = dbUser.activeRiotAccountId;
-          session.user.onboardingCompleted = dbUser.onboardingCompleted;
-          session.user.role = dbUser.role;
-          session.user.locale = dbUser.locale;
-          session.user.language = dbUser.language;
-          session.user.coachingCadenceDays = dbUser.coachingCadenceDays;
+        if (!dbUser) return session;
 
-          // Read role preferences from the active riot account (per-account)
-          if (dbUser.activeRiotAccountId) {
-            const activeAccount = await db.query.riotAccounts.findFirst({
-              where: eq(riotAccounts.id, dbUser.activeRiotAccountId),
-            });
-            session.user.primaryRole = activeAccount?.primaryRole ?? null;
-            session.user.secondaryRole = activeAccount?.secondaryRole ?? null;
-          } else {
-            // Fallback to user-level roles for backwards compatibility
-            session.user.primaryRole = dbUser.primaryRole;
-            session.user.secondaryRole = dbUser.secondaryRole;
+        // Check for impersonation — only admins may impersonate
+        let effectiveUser = dbUser;
+        let impersonating = false;
+        const cookieStore = await cookies();
+        const targetUserId = cookieStore.get(IMPERSONATE_COOKIE)?.value;
+
+        if (targetUserId && dbUser.role === "admin" && dbUser.id !== targetUserId) {
+          const targetUser = await db.query.users.findFirst({
+            where: eq(users.id, targetUserId),
+          });
+          if (targetUser && !targetUser.deactivatedAt) {
+            effectiveUser = targetUser;
+            impersonating = true;
           }
+        }
+
+        session.user.id = effectiveUser.id;
+        session.user.riotGameName = effectiveUser.riotGameName;
+        session.user.riotTagLine = effectiveUser.riotTagLine;
+        session.user.isRiotLinked = !!effectiveUser.puuid;
+        session.user.region = effectiveUser.region;
+        session.user.activeRiotAccountId = effectiveUser.activeRiotAccountId;
+        session.user.onboardingCompleted = effectiveUser.onboardingCompleted;
+        session.user.role = impersonating ? effectiveUser.role : dbUser.role;
+        session.user.locale = effectiveUser.locale;
+        session.user.language = effectiveUser.language;
+        session.user.coachingCadenceDays = effectiveUser.coachingCadenceDays;
+
+        // Read role preferences from the active riot account (per-account)
+        if (effectiveUser.activeRiotAccountId) {
+          const activeAccount = await db.query.riotAccounts.findFirst({
+            where: eq(riotAccounts.id, effectiveUser.activeRiotAccountId),
+          });
+          session.user.primaryRole = activeAccount?.primaryRole ?? null;
+          session.user.secondaryRole = activeAccount?.secondaryRole ?? null;
+        } else {
+          // Fallback to user-level roles for backwards compatibility
+          session.user.primaryRole = effectiveUser.primaryRole;
+          session.user.secondaryRole = effectiveUser.secondaryRole;
+        }
+
+        // Signal impersonation state to the client
+        if (impersonating) {
+          session.user.isImpersonating = true;
+          session.user.realAdminName = dbUser.name;
         }
       }
       return session;

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -4,11 +4,39 @@ import { redirect } from "next/navigation";
 import { cache } from "react";
 
 import { db } from "@/db";
-import { type User, users } from "@/db/schema";
+import { type User, users, riotAccounts } from "@/db/schema";
 import { auth } from "@/lib/auth";
 
 // ─── Impersonation cookie name ──────────────────────────────────────────────
 export const IMPERSONATE_COOKIE = "admin-impersonate";
+
+// ─── Resolve role preferences from the active Riot account ─────────────────
+// The users table has a cached `primaryRole`/`secondaryRole`, but the
+// authoritative source is the per-account value on `riotAccounts`.
+// This helper reads from the active account when available, falling back
+// to the users table cache. Both the session callback (client path) and
+// getCurrentUser (server path) must use the same resolution logic.
+async function resolveRolePreferences(
+  user: User,
+): Promise<{ primaryRole: string | null; secondaryRole: string | null }> {
+  if (user.activeRiotAccountId) {
+    const activeAccount = await db.query.riotAccounts.findFirst({
+      where: eq(riotAccounts.id, user.activeRiotAccountId),
+      columns: { primaryRole: true, secondaryRole: true },
+    });
+    if (activeAccount) {
+      return {
+        primaryRole: activeAccount.primaryRole ?? null,
+        secondaryRole: activeAccount.secondaryRole ?? null,
+      };
+    }
+  }
+  // Fallback to user-level roles for backwards compatibility
+  return {
+    primaryRole: user.primaryRole,
+    secondaryRole: user.secondaryRole,
+  };
+}
 
 // ─── Real user (ignores impersonation) ──────────────────────────────────────
 // Always returns the JWT session user. Used by admin routes and
@@ -33,6 +61,9 @@ export const getRealUser = cache(async () => {
 // ─── Current user (impersonation-aware) ─────────────────────────────────────
 // cache() deduplicates this call within a single request,
 // so layout + page calling requireUser() only hits the DB once.
+// Role preferences (primaryRole/secondaryRole) are resolved from the active
+// Riot account to stay consistent with what the session callback sends to
+// client components via useAuth().
 export const getCurrentUser = cache(async () => {
   const realUser = await getRealUser();
   if (!realUser) return null;
@@ -41,21 +72,30 @@ export const getCurrentUser = cache(async () => {
   const cookieStore = await cookies();
   const targetUserId = cookieStore.get(IMPERSONATE_COOKIE)?.value;
 
+  let effectiveUser = realUser;
+
   if (targetUserId) {
     // Only admins may impersonate
-    if (realUser.role !== "admin") return realUser;
+    if (realUser.role === "admin") {
+      const targetUser = await db.query.users.findFirst({
+        where: eq(users.id, targetUserId),
+      });
 
-    const targetUser = await db.query.users.findFirst({
-      where: eq(users.id, targetUserId),
-    });
-
-    // Fall back to real user if target doesn't exist or is deactivated
-    if (!targetUser || targetUser.deactivatedAt) return realUser;
-
-    return targetUser;
+      // Use target if valid and not deactivated, otherwise fall back to real user
+      if (targetUser && !targetUser.deactivatedAt) {
+        effectiveUser = targetUser;
+      }
+    }
   }
 
-  return realUser;
+  // Resolve role preferences from the active Riot account (authoritative source)
+  const roles = await resolveRolePreferences(effectiveUser);
+
+  return {
+    ...effectiveUser,
+    primaryRole: roles.primaryRole,
+    secondaryRole: roles.secondaryRole,
+  };
 });
 
 // ─── Impersonation helpers ──────────────────────────────────────────────────

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { cache } from "react";
 
@@ -6,9 +7,13 @@ import { db } from "@/db";
 import { type User, users } from "@/db/schema";
 import { auth } from "@/lib/auth";
 
-// cache() deduplicates this call within a single request,
-// so layout + page calling requireUser() only hits the DB once.
-export const getCurrentUser = cache(async () => {
+// ─── Impersonation cookie name ──────────────────────────────────────────────
+export const IMPERSONATE_COOKIE = "admin-impersonate";
+
+// ─── Real user (ignores impersonation) ──────────────────────────────────────
+// Always returns the JWT session user. Used by admin routes and
+// impersonation guards so the real admin identity is never masked.
+export const getRealUser = cache(async () => {
   const session = await auth();
 
   if (!session?.user?.id) {
@@ -20,12 +25,60 @@ export const getCurrentUser = cache(async () => {
   });
 
   if (!user) return null;
-
-  // Deactivated users are treated as logged out — invalidates active JWT sessions
   if (user.deactivatedAt) return null;
 
   return user;
 });
+
+// ─── Current user (impersonation-aware) ─────────────────────────────────────
+// cache() deduplicates this call within a single request,
+// so layout + page calling requireUser() only hits the DB once.
+export const getCurrentUser = cache(async () => {
+  const realUser = await getRealUser();
+  if (!realUser) return null;
+
+  // Check for impersonation cookie
+  const cookieStore = await cookies();
+  const targetUserId = cookieStore.get(IMPERSONATE_COOKIE)?.value;
+
+  if (targetUserId) {
+    // Only admins may impersonate
+    if (realUser.role !== "admin") return realUser;
+
+    const targetUser = await db.query.users.findFirst({
+      where: eq(users.id, targetUserId),
+    });
+
+    // Fall back to real user if target doesn't exist or is deactivated
+    if (!targetUser || targetUser.deactivatedAt) return realUser;
+
+    return targetUser;
+  }
+
+  return realUser;
+});
+
+// ─── Impersonation helpers ──────────────────────────────────────────────────
+
+/** Returns true if the current request is under admin impersonation. */
+export async function isImpersonating(): Promise<boolean> {
+  const cookieStore = await cookies();
+  const targetUserId = cookieStore.get(IMPERSONATE_COOKIE)?.value;
+  if (!targetUserId) return false;
+
+  // Verify the real user is actually an admin
+  const realUser = await getRealUser();
+  return !!realUser && realUser.role === "admin" && realUser.id !== targetUserId;
+}
+
+/** Throws if currently impersonating. Use as a guard in mutative server actions. */
+export async function blockIfImpersonating(): Promise<void> {
+  if (await isImpersonating()) {
+    throw new Error("Action blocked: you are viewing as another user (read-only mode)");
+  }
+}
+
+// ─── Auth requirement helpers ───────────────────────────────────────────────
 
 export async function requireUser() {
   const user = await getCurrentUser();
@@ -36,7 +89,12 @@ export async function requireUser() {
 }
 
 export async function requireAdmin() {
-  const user = await requireUser();
+  // Always check the REAL user for admin routes — impersonation must not
+  // grant admin access to a non-admin target user.
+  const user = await getRealUser();
+  if (!user) {
+    redirect("/login");
+  }
   if (user.role !== "admin") {
     throw new Error("Unauthorized: admin access required");
   }

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -19,6 +19,10 @@ declare module "next-auth" {
       primaryRole?: string | null;
       secondaryRole?: string | null;
       coachingCadenceDays?: number | null;
+      /** True when an admin is impersonating this user */
+      isImpersonating?: boolean;
+      /** The real admin's display name during impersonation */
+      realAdminName?: string | null;
     };
   }
 }


### PR DESCRIPTION
## Summary

- Add admin impersonation feature allowing admins to temporarily view the app as any non-admin user for debugging production issues
- Impersonation is **read-only** — all 34 mutative server actions + sync route are guarded with `blockIfImpersonating()`
- Persistent amber banner with "Stop" button visible during impersonation
- No database changes — purely cookie + code logic

Relates to #191

## How it works

1. **Cookie-based approach**: `admin-impersonate` httpOnly cookie stores the target user ID (1h auto-expiry safety net)
2. **`getCurrentUser()`** checks the cookie and returns the target user if the real user is admin
3. **`getRealUser()`** always returns the JWT session user (used by admin routes and impersonation guards)
4. **Session callback** in `auth.ts` reflects the impersonated user to client-side `useAuth()`, including `isImpersonating` and `realAdminName` flags
5. **Admin layout** uses `getRealUser()` so the admin panel stays accessible during impersonation

## Security boundaries

- Cannot impersonate yourself
- Cannot impersonate another admin
- Cannot impersonate deactivated users
- All writes blocked during impersonation (`blockIfImpersonating()` guard)
- Admin actions (`deactivateUser`, `updateUserRole`, etc.) use `requireAdmin()` → `getRealUser()`, so they work with the real admin identity

## Files changed (21 files)

**Core auth:**
- `src/lib/session.ts` — `getCurrentUser()`, `getRealUser()`, `isImpersonating()`, `blockIfImpersonating()`
- `src/lib/auth.ts` — Session callback impersonation awareness
- `src/lib/auth-client.ts` — `AuthUser` type additions
- `src/types/next-auth.d.ts` — Session type extensions

**Admin:**
- `src/app/actions/admin.ts` — `startImpersonation()`, `stopImpersonation()` actions
- `src/app/(app)/admin/page.tsx` — "View as" button on user rows
- `src/app/(app)/admin/layout.tsx` — Uses `getRealUser()` for admin access check

**UI:**
- `src/components/impersonation-banner.tsx` — New client component (amber banner)
- `src/app/(app)/layout.tsx` — Mounts the banner

**Write protection (10 action files + 1 API route):**
- `matches.ts`, `settings.ts`, `goals.ts`, `duo.ts`, `ai-insights.ts`, `riot-accounts.ts`, `coaching.ts`, `matchup-notes.ts`, `onboarding.ts`, `live.ts` (no writes), `sync/route.ts`

**i18n:**
- `messages/en.json`, `messages/es.json` — Admin + Impersonation keys