### PR TITLE
feat: GDPR delete account with cascade and cross-reference cleanup

### DIFF
--- a/changelog/en/2026-04-12-delete-account.mdx
+++ b/changelog/en/2026-04-12-delete-account.mdx
@@ -1,0 +1,12 @@
+---
+version: "2026.04.15"
+date: "2026-04-12"
+title: "Delete your account"
+tags: ["feature"]
+---
+
+You can now permanently delete your account and all associated data from **Settings > Account**.
+
+- **Full data removal**: Deleting your account removes everything — linked Riot accounts, match history, coaching sessions, goals, highlights, matchup notes, and all other personal data.
+- **Privacy-conscious**: When you delete your account, your PUUID is also removed from other players' duo partner data, so your identity won't linger in anyone else's match history.
+- **Safety guards**: A confirmation dialog requires typing "DELETE" before proceeding. Admins who are the last remaining admin cannot delete their account until they promote someone else.

--- a/changelog/es/2026-04-12-delete-account.mdx
+++ b/changelog/es/2026-04-12-delete-account.mdx
@@ -1,0 +1,12 @@
+---
+version: "2026.04.15"
+date: "2026-04-12"
+title: "Elimina tu cuenta"
+tags: ["feature"]
+---
+
+Ahora puedes eliminar permanentemente tu cuenta y todos los datos asociados desde **Ajustes > Cuenta**.
+
+- **Eliminación completa de datos**: Al eliminar tu cuenta se borra todo — cuentas de Riot vinculadas, historial de partidas, sesiones de coaching, objetivos, aciertos, notas de matchup y todos los demás datos personales.
+- **Respetuoso con la privacidad**: Cuando eliminas tu cuenta, tu PUUID también se elimina de los datos de compañero de dúo de otros jugadores, para que tu identidad no permanezca en el historial de partidas de nadie.
+- **Protecciones de seguridad**: Un diálogo de confirmación requiere escribir "DELETE" antes de proceder. Los administradores que son el último admin no pueden eliminar su cuenta hasta que promuevan a otra persona.

--- a/messages/en.json
+++ b/messages/en.json
@@ -736,6 +736,19 @@
       "copyCode": "Copy invite code",
       "deleteInvite": "Delete invite"
     },
+    "deleteAccount": {
+      "title": "Delete account",
+      "description": "Permanently delete your account and all associated data. This action cannot be undone.",
+      "deleteButton": "Delete my account",
+      "dialogTitle": "Are you sure?",
+      "dialogDescription": "This will permanently delete your account, all linked Riot accounts, match history, coaching sessions, goals, and every other piece of data. This action cannot be undone.",
+      "confirmationLabel": "Type DELETE to confirm",
+      "confirmationPlaceholder": "DELETE",
+      "cancelButton": "Cancel",
+      "confirmButton": "Delete my account permanently",
+      "lastAdminError": "You are the only admin. Promote another user to admin before deleting your account.",
+      "genericError": "Failed to delete account. Please try again."
+    },
     "toasts": {
       "loadInvitesError": "Couldn't load invite codes.",
       "loadDuoPartnerError": "Couldn't load duo partner details.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -736,6 +736,19 @@
       "copyCode": "Copiar código de invitación",
       "deleteInvite": "Eliminar invitación"
     },
+    "deleteAccount": {
+      "title": "Eliminar cuenta",
+      "description": "Elimina permanentemente tu cuenta y todos los datos asociados. Esta acción no se puede deshacer.",
+      "deleteButton": "Eliminar mi cuenta",
+      "dialogTitle": "¿Estás seguro?",
+      "dialogDescription": "Esto eliminará permanentemente tu cuenta, todas las cuentas de Riot vinculadas, historial de partidas, sesiones de coaching, objetivos y todos los demás datos. Esta acción no se puede deshacer.",
+      "confirmationLabel": "Escribe DELETE para confirmar",
+      "confirmationPlaceholder": "DELETE",
+      "cancelButton": "Cancelar",
+      "confirmButton": "Eliminar mi cuenta permanentemente",
+      "lastAdminError": "Eres el único administrador. Promueve a otro usuario a administrador antes de eliminar tu cuenta.",
+      "genericError": "Error al eliminar la cuenta. Inténtalo de nuevo."
+    },
     "toasts": {
       "loadInvitesError": "No se pudieron cargar los códigos de invitación.",
       "loadDuoPartnerError": "No se pudieron cargar los detalles del compañero de dúo.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lol-tracker",
-  "version": "2026.04.14",
+  "version": "2026.04.15",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -17,12 +17,14 @@ import {
   Eye,
   EyeOff,
   Crown,
+  AlertTriangle,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useState, useTransition, useEffect, useRef, useCallback } from "react";
 import { toast } from "sonner";
 
+import { deleteAccount } from "@/app/actions/account";
 import {
   addRiotAccount,
   removeRiotAccount,
@@ -43,6 +45,16 @@ import {
 } from "@/app/actions/settings";
 import { POSITIONS, PositionIcon } from "@/components/position-icon";
 import { PremiumGate } from "@/components/premium-gate";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -58,7 +70,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE, type SupportedLanguage } from "@/i18n/languages";
-import { useAuth } from "@/lib/auth-client";
+import { logout, useAuth } from "@/lib/auth-client";
 import { SUPPORTED_LOCALES, DEFAULT_LOCALE, formatDate, type SupportedLocale } from "@/lib/format";
 import { PLATFORM_IDS, PLATFORM_LABELS } from "@/lib/riot-api";
 
@@ -149,6 +161,10 @@ export default function SettingsPage() {
   const [editingLabelId, setEditingLabelId] = useState<string | null>(null);
   const [editingLabelValue, setEditingLabelValue] = useState("");
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
+
+  // ─── Delete account state ─────────────────────────────────────────────────
+  const [deleteConfirmation, setDeleteConfirmation] = useState("");
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   // Load riot accounts on mount and when tab changes to account
   useEffect(() => {
@@ -382,6 +398,24 @@ export default function SettingsPage() {
         await refreshAccounts();
         await updateSession();
       }
+    });
+  }
+
+  // ─── Delete account handler ───────────────────────────────────────────────
+
+  function handleDeleteAccount() {
+    startTransition(async () => {
+      const result = await deleteAccount(deleteConfirmation);
+      if ("error" in result) {
+        if (result.error === "LAST_ADMIN") {
+          toast.error(t("deleteAccount.lastAdminError"));
+        } else {
+          toast.error(t("deleteAccount.genericError"));
+        }
+        return;
+      }
+      // Success — clear cookie and redirect to home
+      await logout({ callbackUrl: "/" });
     });
   }
 
@@ -856,10 +890,72 @@ export default function SettingsPage() {
                 </CardContent>
               </Card>
             )}
+
+            {/* ─── Danger Zone ───────────────────────────────────────────── */}
+            <Card className="surface-glow border-destructive/50">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-destructive">
+                  <AlertTriangle className="h-5 w-5" />
+                  {t("deleteAccount.title")}
+                </CardTitle>
+                <CardDescription>{t("deleteAccount.description")}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <AlertDialog
+                  open={deleteDialogOpen}
+                  onOpenChange={(open) => {
+                    setDeleteDialogOpen(open);
+                    if (!open) setDeleteConfirmation("");
+                  }}
+                >
+                  <AlertDialogTrigger
+                    render={
+                      <Button variant="destructive" size="sm">
+                        <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+                        {t("deleteAccount.deleteButton")}
+                      </Button>
+                    }
+                  />
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>{t("deleteAccount.dialogTitle")}</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        {t("deleteAccount.dialogDescription")}
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <div className="space-y-2">
+                      <Label htmlFor="delete-confirmation">
+                        {t("deleteAccount.confirmationLabel")}
+                      </Label>
+                      <Input
+                        id="delete-confirmation"
+                        value={deleteConfirmation}
+                        onChange={(e) => setDeleteConfirmation(e.target.value)}
+                        placeholder={t("deleteAccount.confirmationPlaceholder")}
+                        autoComplete="off"
+                      />
+                    </div>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>{t("deleteAccount.cancelButton")}</AlertDialogCancel>
+                      <Button
+                        variant="destructive"
+                        onClick={handleDeleteAccount}
+                        disabled={deleteConfirmation !== "DELETE" || isPending}
+                      >
+                        {isPending ? (
+                          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+                        )}
+                        {t("deleteAccount.confirmButton")}
+                      </Button>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </CardContent>
+            </Card>
           </div>
         </TabsContent>
-
-        {/* ─── Preferences Tab ──────────────────────────────────────── */}
         <TabsContent value="preferences" className="mt-4">
           <div className="space-y-6">
             {/* Language & Region Card */}

--- a/src/app/actions/account.ts
+++ b/src/app/actions/account.ts
@@ -1,0 +1,75 @@
+"use server";
+
+import { eq, count } from "drizzle-orm";
+
+import { db } from "@/db";
+import { users, riotAccounts, matches } from "@/db/schema";
+import { blockIfImpersonating, requireUser } from "@/lib/session";
+
+/**
+ * Permanently delete the current user's account and all associated data.
+ *
+ * Deletion strategy:
+ * 1. Collect the user's PUUIDs (from riot_accounts) before deletion
+ * 2. Null out duoPartnerUserId on other users who had this user as duo partner
+ * 3. Null out duoPartnerPuuid on other users' matches (privacy cleanup)
+ * 4. DELETE FROM users WHERE id = ? — FK cascades handle all 12 child tables
+ *
+ * Requires the confirmation string "DELETE" to prevent accidental invocation.
+ */
+export async function deleteAccount(confirmation: string) {
+  const user = await requireUser();
+  await blockIfImpersonating();
+
+  // ── Validate confirmation ──────────────────────────────────────────────
+  if (confirmation !== "DELETE") {
+    return { error: "INVALID_CONFIRMATION" };
+  }
+
+  // ── Prevent deletion if user is the only admin ─────────────────────────
+  if (user.role === "admin") {
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(users)
+      .where(eq(users.role, "admin"));
+
+    if (total <= 1) {
+      return { error: "LAST_ADMIN" };
+    }
+  }
+
+  // ── Collect user's PUUIDs before cascade deletes them ──────────────────
+  const userAccounts = await db
+    .select({ puuid: riotAccounts.puuid })
+    .from(riotAccounts)
+    .where(eq(riotAccounts.userId, user.id));
+
+  const puuids = userAccounts.map((a) => a.puuid);
+
+  // ── Cross-reference cleanup (other users' data) ────────────────────────
+
+  // 1. Null out duoPartnerUserId on other users who had this user as partner
+  await db
+    .update(users)
+    .set({ duoPartnerUserId: null, updatedAt: new Date() })
+    .where(eq(users.duoPartnerUserId, user.id));
+
+  // 2. Null out duoPartnerPuuid on other users' matches for privacy
+  for (const puuid of puuids) {
+    await db
+      .update(matches)
+      .set({
+        duoPartnerPuuid: null,
+        duoPartnerChampionName: null,
+        duoPartnerKills: null,
+        duoPartnerDeaths: null,
+        duoPartnerAssists: null,
+      })
+      .where(eq(matches.duoPartnerPuuid, puuid));
+  }
+
+  // ── Delete user row — FK cascades handle all child tables ──────────────
+  await db.delete(users).where(eq(users.id, user.id));
+
+  return { success: true };
+}

--- a/src/app/actions/demo-login.ts
+++ b/src/app/actions/demo-login.ts
@@ -49,25 +49,20 @@ export async function getDemoUsers(): Promise<DemoUserInfo[]> {
     },
   });
 
-  // Return in a stable order matching DEMO_USER_IDS
-  return DEMO_USER_IDS.map((id) => {
+  // Return in a stable order matching DEMO_USER_IDS, excluding deleted users
+  return DEMO_USER_IDS.flatMap((id) => {
     const row = rows.find((r) => r.id === id);
     return row
-      ? {
-          id: row.id,
-          name: row.name,
-          role: row.role,
-          riotGameName: row.riotGameName,
-          riotTagLine: row.riotTagLine,
-          onboardingCompleted: row.onboardingCompleted ?? false,
-        }
-      : {
-          id,
-          name: null,
-          role: "free",
-          riotGameName: null,
-          riotTagLine: null,
-          onboardingCompleted: false,
-        };
+      ? [
+          {
+            id: row.id,
+            name: row.name,
+            role: row.role,
+            riotGameName: row.riotGameName,
+            riotTagLine: row.riotTagLine,
+            onboardingCompleted: row.onboardingCompleted ?? false,
+          },
+        ]
+      : [];
   });
 }


### PR DESCRIPTION
## Summary

- Adds a "Delete my account" danger zone at the bottom of Settings > Account tab with a confirmation dialog requiring the user to type `DELETE`
- Server action performs cross-reference cleanup (nulls duo partner references and match duo data for other users), then deletes the user row — SQLite FK cascades handle all 12 child tables automatically
- Includes safety guards: blocks impersonating admins, prevents deletion if user is the only admin

Relates to #171

## Changelog

- Version 2026.04.15: Players can now permanently delete their account and all associated data from Settings > Account