### PR TITLE
chore: overhaul README for public launch

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: beagleknight

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,63 @@
 
 1. Fork and clone the repository
 2. Install dependencies: `npm install`
-3. Copy `.env.example` to `.env.local` and fill in your values
-4. Set up Discord OAuth redirect: `http://localhost:3000/api/auth/callback/discord`
+3. Copy `.env.example` to `.env.local` and fill in your values (see [environment variables](#environment-variables) below)
+4. Set up Discord OAuth redirect (see [Discord OAuth setup](#discord-oauth-setup) below)
 5. Create the data directory and push the schema: `mkdir data && npx drizzle-kit push`
 6. Run the dev server: `npm run dev`
+7. Open [http://localhost:3000](http://localhost:3000)
+
+### Environment variables
+
+Copy `.env.example` to `.env.local` and fill in the required values:
+
+| Variable                       | Required | Where to get it                                                                   |
+| ------------------------------ | -------- | --------------------------------------------------------------------------------- |
+| `AUTH_SECRET`                  | Yes      | Generate with `npx auth secret`                                                   |
+| `AUTH_DISCORD_ID`              | Yes      | [Discord Developer Portal](https://discord.com/developers/applications)           |
+| `AUTH_DISCORD_SECRET`          | Yes      | Discord Developer Portal                                                          |
+| `RIOT_API_KEY`                 | Yes      | [developer.riotgames.com](https://developer.riotgames.com)                        |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | No       | [Google AI Studio](https://aistudio.google.com/apikey) (for AI coaching features) |
+| `TURSO_DATABASE_URL`           | No       | Defaults to local SQLite file (`file:./data/lol-tracker.db`)                      |
+| `TURSO_AUTH_TOKEN`             | No       | Only needed for remote Turso databases                                            |
+
+See `.env.example` for the full list with documentation.
+
+### Discord OAuth setup
+
+1. Create a new application at [discord.com/developers](https://discord.com/developers/applications)
+2. Go to **OAuth2 > Redirects** and add: `http://localhost:3000/api/auth/callback/discord`
+3. Copy the **Client ID** and **Client Secret** into your `.env.local` as `AUTH_DISCORD_ID` and `AUTH_DISCORD_SECRET`
+
+### Demo mode (no credentials needed)
+
+If you want to skip Discord and Riot API setup entirely, you can run in demo mode:
+
+1. Set `NEXT_PUBLIC_DEMO_MODE=true` in `.env.local`
+2. Seed the database: `npm run db:seed`
+3. Start the dev server: `npm run dev`
+
+Demo mode uses fake auth (no Discord OAuth) and mocked Riot API data. The login page shows a user picker instead of Discord sign-in.
+
+## Available scripts
+
+| Command                    | Description                                    |
+| -------------------------- | ---------------------------------------------- |
+| `npm run dev`              | Start dev server                               |
+| `npm run build`            | Production build                               |
+| `npm run start`            | Start production server                        |
+| `npm run fmt`              | Fix formatting issues                          |
+| `npm run test:smoke`       | Run Playwright smoke tests (a11y + pages)      |
+| `npm run test:e2e`         | Run Playwright end-to-end tests                |
+| `npm run test:migration`   | Test database migrations against existing data |
+| `npm run db:seed`          | Seed the database with demo data               |
+| `npx drizzle-kit push`     | Push schema changes to the database            |
+| `npx drizzle-kit generate` | Generate migration SQL from schema changes     |
+| `npx drizzle-kit studio`   | Open Drizzle Studio to browse the database     |
+
+### Build notes
+
+- The production build uses the `--webpack` flag (`next build --webpack`) because Turbopack has issues bundling `@libsql/client`.
 
 ## Development workflow
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![CI](https://github.com/beagleknight/lol-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/beagleknight/lol-tracker/actions/workflows/ci.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
-[![Live Demo](https://img.shields.io/badge/Live_Demo-lol--tracker.vercel.app-brightgreen)](https://lol-tracker.vercel.app)
+[![Try it](https://img.shields.io/badge/Try_it-lol--tracker.vercel.app-brightgreen)](https://lol-tracker.vercel.app)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-Support_this_project-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/beagleknight)
 
 An open-source League of Legends companion app that syncs your match history, tracks your performance over time, and gives you AI-powered coaching to help you improve. Built for players who want to take their game seriously.
 
-**[Try the live demo →](https://lol-tracker.vercel.app)**
+**[Try it at lol-tracker.vercel.app →](https://lol-tracker.vercel.app)**
 
 ![LoL Tracker Dashboard](public/landing/dashboard.png)
 

--- a/README.md
+++ b/README.md
@@ -2,119 +2,91 @@
 
 [![CI](https://github.com/beagleknight/lol-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/beagleknight/lol-tracker/actions/workflows/ci.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
+[![Live Demo](https://img.shields.io/badge/Live_Demo-lol--tracker.vercel.app-brightgreen)](https://lol-tracker.vercel.app)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-Support_this_project-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/beagleknight)
 
-A personal League of Legends match tracker built with Next.js 16, featuring automatic match syncing via the Riot Games API, coaching session logging, and performance analytics.
+An open-source League of Legends companion app that syncs your match history, tracks your performance over time, and gives you AI-powered coaching to help you improve. Built for players who want to take their game seriously.
+
+**[Try the live demo →](https://lol-tracker.vercel.app)**
+
+![LoL Tracker Dashboard](public/landing/dashboard.png)
 
 ## Features
 
-- **Automatic match syncing** — links your Riot account and keeps your match history up to date
+### Performance analytics
+
+Track your win rates, LP trends, champion stats, and role breakdowns. See how your performance changes over time with interactive charts and detailed match breakdowns.
+
+![Analytics](public/landing/analytics.png)
+
+### AI-powered coaching
+
+Log coaching sessions, get personalized feedback from AI, and track action items across sessions. The coaching system helps you identify patterns and turn insights into concrete improvements.
+
+![Coaching](public/landing/coaching.png)
+
+### Post-game review
+
+Review your recent matches with categorized highlights — things you did well and things to work on. Focus on one game at a time or look at patterns across your match history.
+
+![Review](public/landing/review.png)
+
+### And more
+
+- **Automatic match syncing** — link your Riot account and your match history stays up to date
 - **Multi-account support** — track multiple Riot accounts (smurfs) under one login
-- **Performance analytics** — win rates, champion stats, role breakdowns, and trends over time
-- **AI-powered coaching** — get personalized feedback and action items from match reviews
 - **Duo partner tracking** — find and analyze your performance with duo partners
+- **Goal setting** — set ranked goals and track your progress
+- **Matchup scout** — AI-powered advice for your next matchup
 - **Bilingual** — full English and Spanish support
 
-## Prerequisites
-
-- Node.js 24+ (recommended: use [fnm](https://github.com/Schniz/fnm) with the included `.tool-versions`)
-- A [Discord application](https://discord.com/developers/applications) for OAuth login
-- A [Riot Games API key](https://developer.riotgames.com)
-
-## Setup
-
-### 1. Install dependencies
+## Quick start
 
 ```bash
+git clone https://github.com/beagleknight/lol-tracker.git
+cd lol-tracker
 npm install
-```
-
-### 2. Configure environment variables
-
-Copy the example and fill in your values:
-
-```bash
-cp .env.example .env.local
-```
-
-Required variables in `.env.local`:
-
-```
-AUTH_SECRET=           # Generate with: npx auth secret
-AUTH_DISCORD_ID=       # From Discord Developer Portal
-AUTH_DISCORD_SECRET=   # From Discord Developer Portal
-RIOT_API_KEY=          # From developer.riotgames.com
-```
-
-### 3. Set up Discord OAuth
-
-In your Discord application settings under **OAuth2 > Redirects**, add:
-
-```
-http://localhost:3000/api/auth/callback/discord
-```
-
-### 4. Initialize the database
-
-The app uses SQLite via `@libsql/client` (Turso). Create the data directory and push the schema:
-
-```bash
-mkdir data
-npx drizzle-kit push
-```
-
-### 5. Run the development server
-
-```bash
+cp .env.example .env.local    # Fill in your API keys
+mkdir data && npx drizzle-kit push
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) in your browser.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed setup instructions, including Discord OAuth configuration, demo mode, and all available scripts.
 
 ## Self-hosting
 
 LoL Tracker is designed to run on [Vercel](https://vercel.com) with [Turso](https://turso.tech) as the production database, but you can adapt it to other platforms.
 
-**Each instance requires its own credentials:**
+Each instance requires its own credentials:
 
-- **Riot Games API key** — register at [developer.riotgames.com](https://developer.riotgames.com). Development keys expire every 24 hours; for a persistent deployment, apply for a production key and register your product on the Riot Developer Portal.
+- **Riot Games API key** — register at [developer.riotgames.com](https://developer.riotgames.com). Development keys expire every 24 hours; for a persistent deployment, apply for a production key.
 - **Discord OAuth app** — create one at [discord.com/developers](https://discord.com/developers/applications). Set the redirect URI to `https://your-domain.com/api/auth/callback/discord`.
 - **Turso database** — create a database at [turso.tech](https://turso.tech) and set `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` in your hosting environment.
 
-See `.env.example` for the full list of environment variables.
-
-Migrations are applied automatically on deploy via `scripts/migrate.ts`. No manual migration step is needed.
-
-## Important notes
-
-- The production build uses the `--webpack` flag because Turbopack has issues bundling `@libsql/client`.
-
-## Scripts
-
-| Command                  | Description                                |
-| ------------------------ | ------------------------------------------ |
-| `npm run dev`            | Start dev server (webpack)                 |
-| `npm run build`          | Production build (webpack)                 |
-| `npm run start`          | Start production server                    |
-| `npm run test:smoke`     | Run Playwright smoke tests (a11y + pages)  |
-| `npm run test:e2e`       | Run Playwright end-to-end tests            |
-| `npx drizzle-kit push`   | Push schema changes to the database        |
-| `npx drizzle-kit studio` | Open Drizzle Studio to browse the database |
+Migrations are applied automatically on deploy via `scripts/migrate.ts`. See `.env.example` for the full list of environment variables.
 
 ## Tech stack
 
-- **Framework:** Next.js 16 (React 19)
-- **Database:** SQLite/Turso via @libsql/client + Drizzle ORM
-- **Auth:** NextAuth v5 with Discord provider
-- **UI:** shadcn/ui v4, Tailwind CSS v4
-- **AI:** Google Gemini via Vercel AI SDK
-- **i18n:** next-intl (English + Spanish)
-- **Testing:** Playwright, axe-core
-- **Linting:** oxlint, oxfmt
-- **API:** Riot Games API for match data
+| Layer     | Technology                         |
+| --------- | ---------------------------------- |
+| Framework | Next.js 16 (React 19)              |
+| Database  | SQLite / Turso via Drizzle ORM     |
+| Auth      | Auth.js (NextAuth v5) with Discord |
+| UI        | shadcn/ui v4, Tailwind CSS v4      |
+| AI        | Google Gemini via Vercel AI SDK    |
+| i18n      | next-intl (English + Spanish)      |
+| Testing   | Playwright, axe-core               |
+| Linting   | oxlint, oxfmt                      |
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, coding guidelines, and the pull request workflow.
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, coding guidelines, and the pull request workflow.
+
+## Support the project
+
+If you find LoL Tracker useful, consider supporting its development:
+
+[![Ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/beagleknight)
 
 ## Security
 


### PR DESCRIPTION
## Summary

- Rewrote README with hero screenshot, feature gallery (analytics, coaching, review), live demo badge, and Ko-fi support button
- Condensed quick start to 5 lines, moved detailed setup (Discord OAuth, env vars, scripts table, build notes) to CONTRIBUTING.md
- Added `.github/FUNDING.yml` to enable GitHub's native Sponsor button linking to Ko-fi

This is docs/infrastructure only — no code changes, no user-facing impact. `skip-changelog` label applied.