### PR TITLE
fix: reset challenge wizard state after successful creation

### DIFF
--- a/src/app/(app)/challenges/new/new-challenge-client.tsx
+++ b/src/app/(app)/challenges/new/new-challenge-client.tsx
@@ -175,6 +175,19 @@ export function NewChallengeClient({
     );
   }
 
+  function resetWizard() {
+    setStep("type");
+    setChallengeType(null);
+    setSelectedTopicIds([]);
+    setSelectedTier("");
+    setSelectedDivision("");
+    setDeadline("");
+    setMetric("");
+    setCondition("");
+    setThreshold("");
+    setTargetGames("10");
+  }
+
   function handleSubmit() {
     if (challengeType === "by-date") {
       if (!canSubmitByDate) return;
@@ -190,6 +203,7 @@ export function NewChallengeClient({
             toast.error(result.error);
           } else {
             toast.success(t("toasts.challengeCreated"));
+            resetWizard();
             router.push("/challenges");
           }
         } catch {
@@ -212,6 +226,7 @@ export function NewChallengeClient({
             toast.error(String(result.error));
           } else {
             toast.success(t("toasts.challengeCreated"));
+            resetWizard();
             router.push("/challenges");
           }
         } catch {


### PR DESCRIPTION
## Summary

- Fix bug where the challenge creation wizard would stay on step 3 (topics) when navigating back to create a new challenge after successfully creating one
- Root cause: `router.push("/challenges")` uses client-side navigation, so the `NewChallengeClient` component isn't remounted when revisiting `/challenges/new` — all `useState` hooks (including `step`) retain their previous values
- Fix: reset all wizard state (step, challenge type, form fields) before navigating away after successful creation