### PR TITLE
fix: changelog image grids for challenges entry

### DIFF
--- a/changelog/en/2026-04-20-challenges-system.mdx
+++ b/changelog/en/2026-04-20-challenges-system.mdx
@@ -12,19 +12,29 @@ You can still set rank targets with a deadline (like the old goals), but now you
 You can also link challenges to **topics** (like laning phase, vision control, or teamfighting) to stay focused on what you're working on.
 
 <div className="changelog-image-grid">
-  ![The old goals page showing a single rank target](/changelog/challenges-system/before-goals.png)
-  ![The new challenges list with by-games challenge cards, success rates, and active/past
-  tabs](/changelog/challenges-system/after-challenges-list-annotated.png)
+
+![The old goals page showing a single rank target](/changelog/challenges-system/before-goals.png)
+
+![The new challenges list with by-games challenge cards, success rates, and active/past tabs](/changelog/challenges-system/after-challenges-list-annotated.png)
+
 </div>
 
 The wizard helps you configure by-games challenges with real-time feedback: your average stats, a difficulty indicator, and an auto-generated title.
 
+<div className="changelog-image-grid">
+
+![Wizard step 1: choose between a rank target or a by-games challenge](/changelog/challenges-system/after-wizard-step1.png)
+
 ![By-games challenge wizard showing metric selection, difficulty indicator, and auto-generated title](/changelog/challenges-system/after-wizard-bygames-annotated.png)
+
+</div>
 
 The dashboard now shows up to three active challenges at a glance instead of a single goal.
 
 <div className="changelog-image-grid">
-  ![The old dashboard with a single goal widget](/changelog/challenges-system/before-dashboard.png)
-  ![The new dashboard showing multiple active challenges of different
-  types](/changelog/challenges-system/after-dashboard-annotated.png)
+
+![The old dashboard with a single goal widget](/changelog/challenges-system/before-dashboard.png)
+
+![The new dashboard showing multiple active challenges of different types](/changelog/challenges-system/after-dashboard-annotated.png)
+
 </div>

--- a/changelog/es/2026-04-20-challenges-system.mdx
+++ b/changelog/es/2026-04-20-challenges-system.mdx
@@ -12,20 +12,29 @@ Puedes seguir estableciendo metas de rango con fecha límite (como los antiguos 
 También puedes vincular desafíos a **temas** (como fase de línea, control de visión o teamfighting) para mantenerte enfocado en lo que estás trabajando.
 
 <div className="changelog-image-grid">
-  ![La antigua página de objetivos mostrando una única meta de
-  rango](/changelog/challenges-system/before-goals.png) ![La nueva lista de desafíos con tarjetas
-  por partidas, tasas de éxito y pestañas
-  activo/pasado](/changelog/challenges-system/after-challenges-list-annotated.png)
+
+![La antigua página de objetivos mostrando una única meta de rango](/changelog/challenges-system/before-goals.png)
+
+![La nueva lista de desafíos con tarjetas por partidas, tasas de éxito y pestañas activo/pasado](/changelog/challenges-system/after-challenges-list-annotated.png)
+
 </div>
 
 El asistente te ayuda a configurar desafíos por partidas con información en tiempo real: tus estadísticas promedio, un indicador de dificultad y un título generado automáticamente.
 
+<div className="changelog-image-grid">
+
+![Paso 1 del asistente: elige entre una meta de rango o un desafío por partidas](/changelog/challenges-system/after-wizard-step1.png)
+
 ![Asistente de desafío por partidas mostrando selección de métrica, indicador de dificultad y título auto-generado](/changelog/challenges-system/after-wizard-bygames-annotated.png)
+
+</div>
 
 El panel ahora muestra hasta tres desafíos activos de un vistazo en lugar de un solo objetivo.
 
 <div className="changelog-image-grid">
-  ![El antiguo panel con un solo widget de
-  objetivo](/changelog/challenges-system/before-dashboard.png) ![El nuevo panel mostrando múltiples
-  desafíos activos de diferentes tipos](/changelog/challenges-system/after-dashboard-annotated.png)
+
+![El antiguo panel con un solo widget de objetivo](/changelog/challenges-system/before-dashboard.png)
+
+![El nuevo panel mostrando múltiples desafíos activos de diferentes tipos](/changelog/challenges-system/after-dashboard-annotated.png)
+
 </div>


### PR DESCRIPTION
## Summary

- Replace standalone wizard screenshot with a two-column grid (step 1 + by-games config)
- Fix MDX formatting in all three image grids (EN + ES): add required blank lines between `<div>` tags and images, remove indentation, fix alt text broken across multiple lines

These formatting issues caused images to not render correctly in the changelog page.