### PR TITLE
fix: resolve topic names in highlights on all pages

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -8,6 +8,7 @@ import {
   coachingActionItems,
   coachingSessions,
   challenges,
+  topics,
 } from "@/db/schema";
 import { accountScope } from "@/lib/match-queries";
 import { toCumulativeLP } from "@/lib/rank";
@@ -174,19 +175,22 @@ export default async function DashboardPage() {
   const recentMatchIds = recentMatches.map((m) => m.id);
   const recentHighlights =
     recentMatchIds.length > 0
-      ? await db.query.matchHighlights.findMany({
-          where: and(
-            eq(matchHighlights.userId, user.id),
-            accountScope(matchHighlights.riotAccountId, accountId),
-            inArray(matchHighlights.matchId, recentMatchIds),
-          ),
-          columns: {
-            matchId: true,
-            type: true,
-            text: true,
-            topicId: true,
-          },
-        })
+      ? await db
+          .select({
+            matchId: matchHighlights.matchId,
+            type: matchHighlights.type,
+            text: matchHighlights.text,
+            topicName: topics.name,
+          })
+          .from(matchHighlights)
+          .leftJoin(topics, eq(matchHighlights.topicId, topics.id))
+          .where(
+            and(
+              eq(matchHighlights.userId, user.id),
+              accountScope(matchHighlights.riotAccountId, accountId),
+              inArray(matchHighlights.matchId, recentMatchIds),
+            ),
+          )
       : [];
 
   const highlightsPerMatch: Record<
@@ -200,7 +204,7 @@ export default async function DashboardPage() {
     highlightsPerMatch[h.matchId].push({
       type: h.type,
       text: h.text,
-      topicName: null, // Topic name resolution not needed for dashboard highlights display
+      topicName: h.topicName,
     });
   }
 

--- a/src/app/(app)/matches/[id]/page.tsx
+++ b/src/app/(app)/matches/[id]/page.tsx
@@ -6,7 +6,13 @@ import type { RiotMatch } from "@/lib/riot-api";
 import { checkAiConfigured, getCachedInsight } from "@/app/actions/ai-insights";
 import { getMatchupNotesForMatch } from "@/app/actions/matchup-notes";
 import { db } from "@/db";
-import { matches, matchHighlights, coachingSessionMatches, coachingSessions } from "@/db/schema";
+import {
+  matches,
+  matchHighlights,
+  coachingSessionMatches,
+  coachingSessions,
+  topics,
+} from "@/db/schema";
 import { getLatestVersion } from "@/lib/riot-api";
 import { requireUser } from "@/lib/session";
 
@@ -114,8 +120,14 @@ export default async function MatchDetailPage({ params }: { params: Promise<{ id
         ),
       ),
     db
-      .select()
+      .select({
+        type: matchHighlights.type,
+        text: matchHighlights.text,
+        topicId: matchHighlights.topicId,
+        topicName: topics.name,
+      })
       .from(matchHighlights)
+      .leftJoin(topics, eq(matchHighlights.topicId, topics.id))
       .where(
         and(
           eq(matchHighlights.matchId, match.id),
@@ -136,7 +148,7 @@ export default async function MatchDetailPage({ params }: { params: Promise<{ id
     type: h.type,
     text: h.text,
     topicId: h.topicId ?? undefined,
-    topicName: undefined as string | undefined, // TODO: resolve from topics table
+    topicName: h.topicName ?? undefined,
   }));
 
   return (

--- a/src/app/(app)/matches/page.tsx
+++ b/src/app/(app)/matches/page.tsx
@@ -1,7 +1,7 @@
 import { eq, and, desc, sql, inArray, count } from "drizzle-orm";
 
 import { db } from "@/db";
-import { matches, matchHighlights, type Match } from "@/db/schema";
+import { matches, matchHighlights, topics, type Match } from "@/db/schema";
 import { winLossRemakeSelect } from "@/lib/match-queries";
 import { getLatestVersion } from "@/lib/riot-api";
 import { requireUser } from "@/lib/session";
@@ -124,21 +124,24 @@ export default async function MatchesPage({
   const matchIds = pageMatches.map((m) => m.id);
   const pageHighlights =
     matchIds.length > 0
-      ? await db.query.matchHighlights.findMany({
-          where: and(
-            eq(matchHighlights.userId, user.id),
-            user.activeRiotAccountId
-              ? eq(matchHighlights.riotAccountId, user.activeRiotAccountId)
-              : sql`0`,
-            inArray(matchHighlights.matchId, matchIds),
-          ),
-          columns: {
-            matchId: true,
-            type: true,
-            text: true,
-            topicId: true,
-          },
-        })
+      ? await db
+          .select({
+            matchId: matchHighlights.matchId,
+            type: matchHighlights.type,
+            text: matchHighlights.text,
+            topicName: topics.name,
+          })
+          .from(matchHighlights)
+          .leftJoin(topics, eq(matchHighlights.topicId, topics.id))
+          .where(
+            and(
+              eq(matchHighlights.userId, user.id),
+              user.activeRiotAccountId
+                ? eq(matchHighlights.riotAccountId, user.activeRiotAccountId)
+                : sql`0`,
+              inArray(matchHighlights.matchId, matchIds),
+            ),
+          )
       : [];
 
   // Build highlight data per match
@@ -153,7 +156,7 @@ export default async function MatchesPage({
     highlightsPerMatch[h.matchId].push({
       type: h.type,
       text: h.text,
-      topicName: null,
+      topicName: h.topicName,
     });
   }
 

--- a/src/app/(app)/review/page.tsx
+++ b/src/app/(app)/review/page.tsx
@@ -3,7 +3,7 @@ import { eq, ne, and, asc, desc, inArray, count, or, isNull } from "drizzle-orm"
 import type { Match } from "@/db/schema";
 
 import { db } from "@/db";
-import { matches, matchHighlights } from "@/db/schema";
+import { matches, matchHighlights, topics } from "@/db/schema";
 import { accountScope } from "@/lib/match-queries";
 import { getLatestVersion } from "@/lib/riot-api";
 import { requireUser } from "@/lib/session";
@@ -107,8 +107,16 @@ export default async function ReviewPage({
   const allHighlights =
     allMatchIds.length > 0
       ? await db
-          .select()
+          .select({
+            id: matchHighlights.id,
+            matchId: matchHighlights.matchId,
+            type: matchHighlights.type,
+            text: matchHighlights.text,
+            topicId: matchHighlights.topicId,
+            topicName: topics.name,
+          })
           .from(matchHighlights)
+          .leftJoin(topics, eq(matchHighlights.topicId, topics.id))
           .where(
             and(
               eq(matchHighlights.userId, user.id),
@@ -138,7 +146,7 @@ export default async function ReviewPage({
       type: h.type,
       text: h.text,
       topicId: h.topicId ?? undefined,
-      topicName: undefined,
+      topicName: h.topicName ?? undefined,
     });
   }
 


### PR DESCRIPTION
## Summary

- After migration 0029 normalized topics into a separate table, 4 pages were hardcoding `topicName: null`/`undefined` instead of joining the `topics` table
- Added `leftJoin(topics, eq(matchHighlights.topicId, topics.id))` to highlight queries in dashboard, review, matches list, and match detail pages
- Follows the same pattern already used in `src/app/actions/live.ts` and `src/lib/ai/context.ts`

**Pages fixed:** `dashboard/page.tsx`, `review/page.tsx`, `matches/page.tsx`, `matches/[id]/page.tsx`