### PR TITLE
fix: detect early challenge failure and remove misleading success rate

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -889,7 +889,7 @@
     "startedFrom": "Started from {rank}",
     "progress": "Progress",
     "gamesProgress": "Games",
-    "successRate": "{rate}% success rate",
+
     "currentRank": "Currently at {rank}, {lp} LP",
     "overdue": "Deadline passed on {date}. Challenge is still active.",
     "deadline": "Target date: {date}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -889,7 +889,7 @@
     "startedFrom": "Empezó desde {rank}",
     "progress": "Progreso",
     "gamesProgress": "Partidas",
-    "successRate": "{rate}% de éxito",
+
     "currentRank": "Actualmente en {rank}, {lp} LP",
     "overdue": "La fecha límite pasó el {date}. El desafío sigue activo.",
     "deadline": "Fecha objetivo: {date}",

--- a/src/app/(app)/challenges/challenges-client.tsx
+++ b/src/app/(app)/challenges/challenges-client.tsx
@@ -206,11 +206,6 @@ function ActiveChallengeCard({
 
   const isOverdue = isByDate && challenge.deadline && new Date(challenge.deadline) < new Date();
 
-  const successRate =
-    !isByDate && (challenge.currentGames ?? 0) > 0
-      ? Math.round(((challenge.successfulGames ?? 0) / (challenge.currentGames ?? 1)) * 100)
-      : null;
-
   function handleRetire() {
     if (!confirm(t("retireConfirm"))) return;
     startRetire(async () => {
@@ -269,11 +264,6 @@ function ActiveChallengeCard({
                 rank: formatTierDivision(currentRank.tier, currentRank.division),
                 lp: currentRank.lp,
               })}
-            </p>
-          )}
-          {!isByDate && successRate !== null && (
-            <p className="mt-2 text-sm text-muted-foreground">
-              {t("successRate", { rate: successRate })}
             </p>
           )}
         </div>

--- a/src/lib/challenges.ts
+++ b/src/lib/challenges.ts
@@ -166,11 +166,17 @@ export async function evaluateByGamesChallenges(userId: string, matchId: string)
         .where(eq(challenges.id, challenge.id));
       invalidate = true;
     } else {
+      // Early failure: if we've already failed more games than allowed,
+      // the challenge is mathematically impossible (ALL games must pass)
+      const failedGames = newCurrent - newSuccessful;
+      const isImpossible = failedGames > 0;
+
       await db
         .update(challenges)
         .set({
           currentGames: newCurrent,
           successfulGames: newSuccessful,
+          ...(isImpossible ? { status: "failed" as const, failedAt: new Date() } : {}),
         })
         .where(eq(challenges.id, challenge.id));
       invalidate = true;


### PR DESCRIPTION
## Summary

- **Early failure detection**: By-games challenges require ALL games to meet the condition. Previously, failing game 1 of 10 still forced the user to play 9 more useless games. Now the challenge fails immediately on the first missed game since it's mathematically impossible.
- **Remove success rate**: The `X% success rate` display was confusing — since the pass condition is 100% of games, anything below 100% means failure. Removed the percentage and its i18n keys (`successRate` in en/es). The games progress bar (`3/10`) remains.