### PR TITLE
fix: sync reports false match failures due to updateTag in route handler

### DIFF
--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -292,6 +292,9 @@ export async function GET(request: Request) {
             const playerData = extractPlayerData(matchData, user.puuid!);
 
             if (!playerData) {
+              console.warn(
+                `[sync] extractPlayerData returned null for match ${matchId} (puuid: ${user.puuid}, queueId: ${matchData.info?.queueId}, participants: ${matchData.info?.participants?.length})`,
+              );
               failedCount++;
               continue;
             }
@@ -382,7 +385,11 @@ export async function GET(request: Request) {
             // Evaluate by-games challenges against this match
             await evaluateByGamesChallenges(user.id, matchId);
           } catch (matchError) {
-            console.error(`Failed to sync match ${matchId}:`, matchError);
+            const errMsg = matchError instanceof Error ? matchError.message : String(matchError);
+            console.error(
+              `[sync] Failed to sync match ${matchId} for user ${user.id}: ${errMsg}`,
+              matchError,
+            );
             failedCount++;
           }
 

--- a/src/lib/challenges.ts
+++ b/src/lib/challenges.ts
@@ -7,7 +7,6 @@ import { eq, and, desc, isNull } from "drizzle-orm";
 
 import { db } from "@/db";
 import { challenges, rankSnapshots, matches } from "@/db/schema";
-import { invalidateChallengesCaches } from "@/lib/cache";
 import { hasReachedTarget } from "@/lib/rank";
 
 /**
@@ -65,10 +64,6 @@ export async function checkByDateChallenges(
         .where(eq(challenges.id, challenge.id));
       completedCount++;
     }
-  }
-
-  if (completedCount > 0) {
-    invalidateChallengesCaches(userId);
   }
 
   return completedCount;
@@ -129,8 +124,6 @@ export async function evaluateByGamesChallenges(userId: string, matchId: string)
 
   if (!match) return;
 
-  let invalidate = false;
-
   for (const challenge of activeChallenges) {
     if (
       !challenge.metric ||
@@ -164,7 +157,6 @@ export async function evaluateByGamesChallenges(userId: string, matchId: string)
           ...(allSucceeded ? { completedAt: new Date() } : { failedAt: new Date() }),
         })
         .where(eq(challenges.id, challenge.id));
-      invalidate = true;
     } else {
       // Early failure: if we've already failed more games than allowed,
       // the challenge is mathematically impossible (ALL games must pass)
@@ -179,11 +171,6 @@ export async function evaluateByGamesChallenges(userId: string, matchId: string)
           ...(isImpossible ? { status: "failed" as const, failedAt: new Date() } : {}),
         })
         .where(eq(challenges.id, challenge.id));
-      invalidate = true;
     }
-  }
-
-  if (invalidate) {
-    invalidateChallengesCaches(userId);
   }
 }

--- a/src/lib/goals.ts
+++ b/src/lib/goals.ts
@@ -7,7 +7,6 @@ import { eq, and, desc, isNull } from "drizzle-orm";
 
 import { db } from "@/db";
 import { goals, rankSnapshots } from "@/db/schema";
-import { invalidateGoalsCaches } from "@/lib/cache";
 import { hasReachedTarget } from "@/lib/rank";
 
 /**
@@ -57,7 +56,6 @@ export async function checkGoalAchievement(
       })
       .where(eq(goals.id, activeGoal.id));
 
-    invalidateGoalsCaches(userId);
     return true;
   }
 


### PR DESCRIPTION
## Summary

- `evaluateByGamesChallenges` and `checkGoalAchievement` (called from the sync route handler) were invoking `invalidateChallengesCaches`/`invalidateGoalsCaches`, which use `updateTag` — only allowed in Server Actions, not Route Handlers
- This caused every synced match to throw `updateTag can only be called from within a Server Action`, incrementing `failedCount` and showing a misleading "(1 failed)" toast even though the match synced successfully
- Removed the `updateTag` calls from these lib functions — cache invalidation is already handled client-side via `invalidateSyncCaches` (a proper Server Action) after the SSE stream completes
- Also improved error logging in the sync route catch block

## Error

```
Failed to sync match EUW1_7827617327: Error: updateTag can only be called from within a Server Action.
```