### PR TITLE
chore: add AdminUser demo user and make DemoPlayer non-admin

### DIFF
--- a/.opencode/skills/e2e-testing/SKILL.md
+++ b/.opencode/skills/e2e-testing/SKILL.md
@@ -182,15 +182,15 @@ Without this, `redirect()` is caught and the user sees a false error toast. This
 
 After `npm run db:seed`, the database contains:
 
-| Entity            | Count | Key details                                                  |
-| ----------------- | ----- | ------------------------------------------------------------ |
-| Users             | 2     | DemoPlayer (admin, Riot-linked, has duo partner), DuoPartner |
-| Matches           | 50    | ~60% unreviewed, ~30% reviewed, ~10% skipped                 |
-| Rank snapshots    | 14    | Various ranks over time                                      |
-| Coaching sessions | 3     | 2 completed + 1 scheduled, all with "CoachKim"               |
-| Action items      | 6     | Linked to completed sessions                                 |
-| Match highlights  | 12    | On specific match IDs                                        |
-| Invites           | 1     | For DemoPlayer                                               |
+| Entity            | Count | Key details                                                                                                                                       |
+| ----------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Users             | 4     | AdminUser (admin, no Riot), DemoPlayer (premium, Riot-linked, has duo partner), DuoPartner (premium), NewPlayer (free, no Riot, needs onboarding) |
+| Matches           | 50    | ~60% unreviewed, ~30% reviewed, ~10% skipped                                                                                                      |
+| Rank snapshots    | 14    | Various ranks over time                                                                                                                           |
+| Coaching sessions | 3     | 2 completed + 1 scheduled, all with "CoachKim"                                                                                                    |
+| Action items      | 6     | Linked to completed sessions                                                                                                                      |
+| Match highlights  | 12    | On specific match IDs                                                                                                                             |
+| Invites           | 1     | For DemoPlayer                                                                                                                                    |
 
 - The logged-in user is always **DemoPlayer** (demo mode auto-login).
 - Coach name in seed data is **"CoachKim"**.

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -131,6 +131,7 @@ const TOPIC_SLUG_MAP: Record<string, string> = {
 
 // ─── Fixed IDs ───────────────────────────────────────────────────────────────
 
+const ADMIN_USER_ID = "demo-user-0004-0004-000000000004";
 const MAIN_USER_ID = "demo-user-0001-0001-000000000001";
 const DUO_USER_ID = "demo-user-0002-0002-000000000002";
 const NEW_PLAYER_ID = "demo-user-0003-0003-000000000003";
@@ -154,7 +155,7 @@ const MAIN_USER = {
   onboardingCompleted: true,
   locale: "en-GB",
   language: "en",
-  role: "admin" as const,
+  role: "premium" as const,
   primaryRole: "MIDDLE",
   secondaryRole: "BOTTOM",
   activeRiotAccountId: MAIN_RIOT_ACCOUNT_ID,
@@ -197,6 +198,27 @@ const NEW_PLAYER = {
   locale: "en-GB",
   language: "en",
   role: "free" as const,
+  primaryRole: null,
+  secondaryRole: null,
+  activeRiotAccountId: null,
+};
+
+const ADMIN_USER = {
+  id: ADMIN_USER_ID,
+  discordId: "demo_discord_004",
+  name: "AdminUser",
+  image: null,
+  email: "admin@example.com",
+  riotGameName: null,
+  riotTagLine: null,
+  puuid: null,
+  summonerId: null,
+  duoPartnerUserId: null,
+  region: null,
+  onboardingCompleted: true,
+  locale: "en-GB",
+  language: "en",
+  role: "admin" as const,
   primaryRole: null,
   secondaryRole: null,
   activeRiotAccountId: null,
@@ -286,7 +308,7 @@ async function seed() {
   console.log("Creating users...");
   const now = new Date("2026-03-25T10:00:00Z");
 
-  for (const u of [MAIN_USER, DUO_USER, NEW_PLAYER]) {
+  for (const u of [ADMIN_USER, MAIN_USER, DUO_USER, NEW_PLAYER]) {
     await client.execute({
       sql: `INSERT INTO users (id, discord_id, name, image, email, riot_game_name, riot_tag_line, puuid, summoner_id, duo_partner_user_id, region, onboarding_completed, locale, language, role, primary_role, secondary_role, active_riot_account_id, created_at, updated_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1192,7 +1214,7 @@ async function seed() {
 
   // ─── Summary ─────────────────────────────────────────────────────────────
   console.log("\nSeed complete!");
-  console.log(`  Users:            3`);
+  console.log(`  Users:            4`);
   console.log(
     `  Matches:          ${totalMatches + totalDuoMatches} (${totalMatches} main + ${totalDuoMatches} duo)`,
   );
@@ -1203,7 +1225,8 @@ async function seed() {
   console.log(`  Challenges:       4`);
   console.log(`  Invites:          1`);
   console.log(`\nDemo user logins:`);
-  console.log(`  ${MAIN_USER.name} (admin, Riot linked, onboarding done)`);
+  console.log(`  ${ADMIN_USER.name} (admin, no Riot account, onboarding done)`);
+  console.log(`  ${MAIN_USER.name} (premium, Riot linked, onboarding done)`);
   console.log(`  ${DUO_USER.name} (premium, Riot linked, onboarding done)`);
   console.log(`  ${NEW_PLAYER.name} (free, no Riot account, needs onboarding)`);
 }

--- a/src/app/actions/demo-login.ts
+++ b/src/app/actions/demo-login.ts
@@ -16,6 +16,7 @@ export async function demoLogin(userId: string) {
 
 /** Demo user IDs (must match seed.ts) */
 const DEMO_USER_IDS = [
+  "demo-user-0004-0004-000000000004",
   "demo-user-0001-0001-000000000001",
   "demo-user-0002-0002-000000000002",
   "demo-user-0003-0003-000000000003",

--- a/tests/smoke/a11y.spec.ts
+++ b/tests/smoke/a11y.spec.ts
@@ -22,7 +22,6 @@ const authenticatedPages = [
   { name: "Goals", path: "/goals" },
   { name: "Feedback", path: "/feedback" },
   { name: "Settings", path: "/settings" },
-  { name: "Admin", path: "/admin" },
 ];
 
 const publicPages = [{ name: "Login", path: "/login" }];
@@ -60,6 +59,28 @@ test.describe("Accessibility — public pages", () => {
       expect(results.violations, formatViolations(results.violations)).toEqual([]);
     });
   }
+});
+
+test.describe("Accessibility — admin pages", () => {
+  // Admin pages require admin role — log in as AdminUser (no shared auth state)
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("Admin (/admin) has no WCAG 2.1 AA violations", async ({ page }) => {
+    // Log in as AdminUser
+    await page.goto("/login");
+    await page.getByText("AdminUser").first().click();
+    await page.waitForURL("**/dashboard", { timeout: 15_000 });
+
+    await page.goto("/admin");
+    await page.getByRole("main").waitFor({ state: "visible" });
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .exclude("[data-sonner-toaster]")
+      .analyze();
+
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
 });
 
 /**

--- a/tests/smoke/auth-routes.spec.ts
+++ b/tests/smoke/auth-routes.spec.ts
@@ -37,7 +37,6 @@ const AUTHENTICATED_ROUTES = [
   { path: "/review", name: "Post-game review" },
   { path: "/changelog", name: "Changelog" },
   { path: "/settings", name: "Settings" },
-  { path: "/admin", name: "Admin panel" },
 ];
 
 for (const route of AUTHENTICATED_ROUTES) {
@@ -52,3 +51,19 @@ for (const route of AUTHENTICATED_ROUTES) {
     await expect(page.getByRole("heading", { name: /something went wrong/i })).not.toBeVisible();
   });
 }
+
+// Admin page requires admin role — log in as AdminUser separately
+test.describe("Admin routes", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("/admin — Admin panel loads", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByText("AdminUser").first().click();
+    await page.waitForURL("**/dashboard", { timeout: 15_000 });
+
+    const response = await page.goto("/admin");
+    expect(response?.status()).toBe(200);
+    expect(page.url()).not.toContain("/login");
+    await expect(page.getByRole("heading", { name: /something went wrong/i })).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Add a 4th demo user **AdminUser** (admin role, no Riot account, onboarding complete) for testing admin functionality separately
- Change **DemoPlayer** role from `admin` to `premium` so it better reflects a real player
- AdminUser appears first in the demo login picker
- Update e2e-testing skill docs with the new user table

Fixes #215

## No changelog

Demo/admin infrastructure only — not visible to players. Using `skip-changelog` label.