### PR TITLE
chore: remove 'Source code' menu item from sidebar

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -18,7 +18,6 @@
     "navAdmin": "Admin",
     "navFeedback": "Feedback",
     "navLegal": "Legal",
-    "navSourceCode": "Source code",
     "sectionTracker": "Tracker",
     "sectionInsights": "Insights",
     "sectionCoaching": "Coaching",

--- a/messages/es.json
+++ b/messages/es.json
@@ -18,7 +18,6 @@
     "navAdmin": "Admin",
     "navFeedback": "Sugerencias",
     "navLegal": "Legal",
-    "navSourceCode": "Código fuente",
     "sectionTracker": "Seguimiento",
     "sectionInsights": "Análisis",
     "sectionCoaching": "Coaching",

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -18,7 +18,6 @@ import {
   MessageSquarePlus,
   Scale,
   Lock,
-  Code,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
@@ -65,12 +64,6 @@ const navDefs = {
     { key: "navWhatsNew" as const, href: "/changelog", icon: Sparkles },
     { key: "navFeedback" as const, href: "/feedback", icon: MessageSquarePlus },
     { key: "navLegal" as const, href: "/legal", icon: Scale },
-    {
-      key: "navSourceCode" as const,
-      href: "https://github.com/beagleknight/lol-tracker",
-      icon: Code,
-      external: true,
-    },
   ],
 } as const;
 


### PR DESCRIPTION
## Summary

- Remove the 'Source code' GitHub link from the sidebar navigation
- Clean up unused `Code` icon import and `navSourceCode` i18n keys

Fixes #213