### PR TITLE
fix: database audit — indexes, caching, query optimization, and JWT session

### DIFF
--- a/drizzle/0031_optimize_match_indexes.sql
+++ b/drizzle/0031_optimize_match_indexes.sql
@@ -1,13 +1,5 @@
--- Migration: Optimize match indexes for common query patterns
--- Adds composite indexes covering (userId, riotAccountId, ...) for review counts,
--- dashboard stats, matches page, and duo queries.
--- Drops 3 redundant/unused indexes (net: 7 → 6 indexes on matches).
-
--- Drop subsumed indexes
-DROP INDEX IF EXISTS `matches_user_reviewed_idx`;
-DROP INDEX IF EXISTS `matches_user_duo_partner_idx`;
-DROP INDEX IF EXISTS `matches_user_position_idx`;
-
--- Add composite indexes for hot query patterns
-CREATE INDEX `matches_user_riot_reviewed_result_idx` ON `matches` (`user_id`, `riot_account_id`, `reviewed`, `result`);
-CREATE INDEX `matches_user_riot_duo_idx` ON `matches` (`user_id`, `riot_account_id`, `duo_partner_puuid`);
+DROP INDEX IF EXISTS `matches_user_reviewed_idx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `matches_user_duo_partner_idx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `matches_user_position_idx`;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `matches_user_riot_reviewed_result_idx` ON `matches` (`user_id`, `riot_account_id`, `reviewed`, `result`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `matches_user_riot_duo_idx` ON `matches` (`user_id`, `riot_account_id`, `duo_partner_puuid`);

--- a/drizzle/0031_optimize_match_indexes.sql
+++ b/drizzle/0031_optimize_match_indexes.sql
@@ -1,0 +1,13 @@
+-- Migration: Optimize match indexes for common query patterns
+-- Adds composite indexes covering (userId, riotAccountId, ...) for review counts,
+-- dashboard stats, matches page, and duo queries.
+-- Drops 3 redundant/unused indexes (net: 7 → 6 indexes on matches).
+
+-- Drop subsumed indexes
+DROP INDEX IF EXISTS `matches_user_reviewed_idx`;
+DROP INDEX IF EXISTS `matches_user_duo_partner_idx`;
+DROP INDEX IF EXISTS `matches_user_position_idx`;
+
+-- Add composite indexes for hot query patterns
+CREATE INDEX `matches_user_riot_reviewed_result_idx` ON `matches` (`user_id`, `riot_account_id`, `reviewed`, `result`);
+CREATE INDEX `matches_user_riot_duo_idx` ON `matches` (`user_id`, `riot_account_id`, `duo_partner_puuid`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1776211200000,
       "tag": "0030_challenges_system",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1776297600000,
+      "tag": "0031_optimize_match_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
+import { cacheLife, cacheTag } from "next/cache";
 import { redirect } from "next/navigation";
 import { connection } from "next/server";
 import { Suspense } from "react";
@@ -11,9 +12,28 @@ import { Toaster } from "@/components/ui/sonner";
 import { db } from "@/db";
 import { matches, riotAccounts } from "@/db/schema";
 import { AuthProvider } from "@/lib/auth-client";
+import { sidebarTag } from "@/lib/cache";
 import { getLatestChangelogVersion } from "@/lib/changelog";
 import { accountScope, sidebarReviewCountsSelect } from "@/lib/match-queries";
 import { requireUser } from "@/lib/session";
+
+async function getCachedSidebarCounts(
+  userId: string,
+  primaryRole: string | null,
+  activeRiotAccountId: string | null,
+) {
+  "use cache: remote";
+  cacheLife("hours");
+  cacheTag(sidebarTag(userId));
+
+  return db
+    .select(sidebarReviewCountsSelect(primaryRole))
+    .from(matches)
+    .where(
+      and(eq(matches.userId, userId), accountScope(matches.riotAccountId, activeRiotAccountId)),
+    )
+    .then((rows) => rows[0]);
+}
 
 async function SidebarWithUser() {
   await connection();
@@ -26,16 +46,7 @@ async function SidebarWithUser() {
 
   // Lightweight count for sidebar review badges (excludes remakes + off-role)
   const [reviewCounts, latestVersion, userRiotAccounts] = await Promise.all([
-    db
-      .select(sidebarReviewCountsSelect(user.primaryRole))
-      .from(matches)
-      .where(
-        and(
-          eq(matches.userId, user.id),
-          accountScope(matches.riotAccountId, user.activeRiotAccountId),
-        ),
-      )
-      .then((rows) => rows[0]),
+    getCachedSidebarCounts(user.id, user.primaryRole, user.activeRiotAccountId),
     getLatestChangelogVersion(),
     db
       .select({

--- a/src/app/actions/admin.ts
+++ b/src/app/actions/admin.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import { eq, count, max, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { cookies } from "next/headers";
 
 import { db } from "@/db";
-import { users, matches } from "@/db/schema";
+import { users } from "@/db/schema";
 import { IMPERSONATE_COOKIE, requireAdmin } from "@/lib/session";
 
 export interface AdminUser {
@@ -26,7 +26,8 @@ export interface AdminUser {
 export async function getUsers(): Promise<AdminUser[]> {
   await requireAdmin();
 
-  // Single query: join users with aggregated match stats
+  // Use scalar subqueries instead of LEFT JOIN to avoid row explosion
+  // (users × matches GROUP BY). Each subquery is a simple indexed lookup.
   const rows = await db
     .select({
       id: users.id,
@@ -39,13 +40,21 @@ export async function getUsers(): Promise<AdminUser[]> {
       role: users.role,
       deactivatedAt: users.deactivatedAt,
       createdAt: users.createdAt,
-      matchCount: count(matches.id),
-      scopedMatchCount: sql<number>`SUM(CASE WHEN ${matches.riotAccountId} = ${users.activeRiotAccountId} THEN 1 ELSE 0 END)`,
-      lastSync: max(matches.syncedAt),
+      matchCount:
+        sql<number>`(SELECT count(*) FROM matches WHERE matches.user_id = ${users.id})`.as(
+          "match_count",
+        ),
+      scopedMatchCount:
+        sql<number>`(SELECT count(*) FROM matches WHERE matches.user_id = ${users.id} AND matches.riot_account_id = ${users.activeRiotAccountId})`.as(
+          "scoped_match_count",
+        ),
+      lastSync: sql<
+        string | null
+      >`(SELECT max(matches.synced_at) FROM matches WHERE matches.user_id = ${users.id})`.as(
+        "last_sync",
+      ),
     })
     .from(users)
-    .leftJoin(matches, eq(users.id, matches.userId))
-    .groupBy(users.id)
     .orderBy(users.createdAt);
 
   return rows.map((r) => ({

--- a/src/app/actions/duo.ts
+++ b/src/app/actions/duo.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import type { BatchItem } from "drizzle-orm/batch";
+
 import { eq, and, isNotNull, desc, sql, count } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { cacheLife, cacheTag } from "next/cache";
@@ -345,6 +347,10 @@ export async function backfillDuoGames(): Promise<{
 
   let duoFound = 0;
 
+  // Collect all updates in memory (CPU-only JSON parsing, no I/O)
+  // then execute as a single batched round-trip to Turso
+  const pendingUpdates: BatchItem<"sqlite">[] = [];
+
   for (const m of allMatches) {
     if (!m.rawMatchJson) continue;
     try {
@@ -359,21 +365,28 @@ export async function backfillDuoGames(): Promise<{
       );
 
       if (partnerOnTeam) {
-        await db
-          .update(matches)
-          .set({
-            duoPartnerPuuid: partnerOnTeam.puuid,
-            duoPartnerChampionName: partnerOnTeam.championName,
-            duoPartnerKills: partnerOnTeam.kills,
-            duoPartnerDeaths: partnerOnTeam.deaths,
-            duoPartnerAssists: partnerOnTeam.assists,
-          })
-          .where(and(eq(matches.id, m.id), eq(matches.userId, user.id)));
+        pendingUpdates.push(
+          db
+            .update(matches)
+            .set({
+              duoPartnerPuuid: partnerOnTeam.puuid,
+              duoPartnerChampionName: partnerOnTeam.championName,
+              duoPartnerKills: partnerOnTeam.kills,
+              duoPartnerDeaths: partnerOnTeam.deaths,
+              duoPartnerAssists: partnerOnTeam.assists,
+            })
+            .where(and(eq(matches.id, m.id), eq(matches.userId, user.id))),
+        );
         duoFound++;
       }
     } catch {
       // Skip unparseable matches
     }
+  }
+
+  // Execute all updates in a single batch round-trip
+  if (pendingUpdates.length > 0) {
+    await db.batch(pendingUpdates as [BatchItem<"sqlite">, ...BatchItem<"sqlite">[]]);
   }
 
   revalidatePath("/duo");

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,4 +1,4 @@
-import { eq, desc } from "drizzle-orm";
+import { and, eq, desc, gte } from "drizzle-orm";
 
 import type { ChallengeTransition } from "@/lib/challenges";
 
@@ -180,11 +180,25 @@ export async function GET(request: Request) {
         // ── Sync logic (same as before, with adaptive delays) ────────────
         send({ type: "status", message: "Checking existing matches..." });
 
-        // Check which matches we already have
-        const existingMatches = await db.query.matches.findMany({
+        // Check which matches we already have.
+        // Optimization: only load IDs newer than (mostRecent - 24h) to avoid
+        // scanning all historic matches. The 24h buffer covers Riot's delayed
+        // match processing. On first sync (no matches), falls back to empty set.
+        const DEDUP_BUFFER_MS = 24 * 60 * 60 * 1000;
+        const mostRecentMatch = await db.query.matches.findFirst({
           where: eq(matches.userId, user.id),
-          columns: { id: true },
+          orderBy: desc(matches.gameDate),
+          columns: { gameDate: true },
         });
+        const dedupCutoff = mostRecentMatch?.gameDate
+          ? new Date(mostRecentMatch.gameDate.getTime() - DEDUP_BUFFER_MS)
+          : null;
+        const existingMatches = dedupCutoff
+          ? await db.query.matches.findMany({
+              where: and(eq(matches.userId, user.id), gte(matches.gameDate, dedupCutoff)),
+              columns: { id: true },
+            })
+          : [];
         const existingIds = new Set(existingMatches.map((m: { id: string }) => m.id));
 
         send({ type: "status", message: "Fetching match history from Riot..." });
@@ -192,10 +206,13 @@ export async function GET(request: Request) {
         // Season 2026 start: January 8, 2026 (epoch seconds)
         const SEASON_START = Math.floor(new Date("2026-01-05T00:00:00Z").getTime() / 1000);
 
-        // Fetch all ranked match IDs via pagination
+        // Fetch ranked match IDs via pagination (Riot returns newest-first).
+        // Early termination: if 2 consecutive pages are fully known, stop —
+        // all older matches are guaranteed to be stored already.
         const allMatchIds: string[] = [];
         let start = 0;
         const PAGE_SIZE = 100;
+        let consecutiveAllKnownPages = 0;
 
         while (true) {
           const batch = await getMatchIds(
@@ -213,6 +230,22 @@ export async function GET(request: Request) {
 
           allMatchIds.push(...batch);
           start += batch.length;
+
+          // Early termination: if every match in this page is already stored,
+          // increment counter. After 2 consecutive all-known pages, stop.
+          const allKnown = batch.every((id) => existingIds.has(id));
+          if (allKnown) {
+            consecutiveAllKnownPages++;
+            if (consecutiveAllKnownPages >= 2) {
+              send({
+                type: "status",
+                message: `Found ${allMatchIds.length} matches in history (caught up).`,
+              });
+              break;
+            }
+          } else {
+            consecutiveAllKnownPages = 0;
+          }
 
           send({
             type: "status",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -128,9 +128,13 @@ export const matches = sqliteTable(
     primaryKey({ columns: [table.id, table.userId] }),
     unique("matches_user_odometer_unq").on(table.userId, table.odometer),
     index("matches_user_game_date_idx").on(table.userId, table.gameDate),
-    index("matches_user_reviewed_idx").on(table.userId, table.reviewed),
-    index("matches_user_duo_partner_idx").on(table.userId, table.duoPartnerPuuid),
-    index("matches_user_position_idx").on(table.userId, table.position),
+    index("matches_user_riot_reviewed_result_idx").on(
+      table.userId,
+      table.riotAccountId,
+      table.reviewed,
+      table.result,
+    ),
+    index("matches_user_riot_duo_idx").on(table.userId, table.riotAccountId, table.duoPartnerPuuid),
     index("matches_riot_account_idx").on(table.riotAccountId),
   ],
 );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -170,66 +170,116 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       return true;
     },
     async session({ session, token }) {
-      if (token.sub) {
-        // Look up our internal user by discord ID (the real JWT user)
-        const dbUser = await db.query.users.findFirst({
-          where: eq(users.discordId, token.discordId as string),
-        });
-        if (!dbUser) return session;
-
-        // Check for impersonation — only admins may impersonate
-        let effectiveUser = dbUser;
+      if (token.sub && token.userId) {
+        // Read user data from the JWT token (populated by jwt callback)
+        // instead of querying the DB on every request.
+        let effectiveUserId = token.userId as string;
         let impersonating = false;
+        let realAdminName: string | null = null;
+
+        // Check for impersonation — only admins may impersonate.
+        // This is the only path that still hits the DB per-request,
+        // and only when the admin-impersonate cookie is set.
         const cookieStore = await cookies();
         const targetUserId = cookieStore.get(IMPERSONATE_COOKIE)?.value;
 
-        if (targetUserId && dbUser.role === "admin" && dbUser.id !== targetUserId) {
+        if (targetUserId && token.role === "admin" && token.userId !== targetUserId) {
           const targetUser = await db.query.users.findFirst({
             where: eq(users.id, targetUserId),
           });
           if (targetUser && !targetUser.deactivatedAt) {
-            effectiveUser = targetUser;
+            effectiveUserId = targetUser.id;
             impersonating = true;
+            realAdminName = (token.name as string) ?? null;
+
+            // For impersonated user, populate session from DB
+            session.user.id = targetUser.id;
+            session.user.riotGameName = targetUser.riotGameName;
+            session.user.riotTagLine = targetUser.riotTagLine;
+            session.user.isRiotLinked = !!targetUser.puuid;
+            session.user.region = targetUser.region;
+            session.user.activeRiotAccountId = targetUser.activeRiotAccountId;
+            session.user.onboardingCompleted = targetUser.onboardingCompleted;
+            session.user.role = targetUser.role;
+            session.user.locale = targetUser.locale;
+            session.user.language = targetUser.language;
+            session.user.coachingCadenceDays = targetUser.coachingCadenceDays;
+
+            // Resolve role preferences for impersonated user
+            if (targetUser.activeRiotAccountId) {
+              const activeAccount = await db.query.riotAccounts.findFirst({
+                where: eq(riotAccounts.id, targetUser.activeRiotAccountId),
+                columns: { primaryRole: true, secondaryRole: true },
+              });
+              session.user.primaryRole = activeAccount?.primaryRole ?? null;
+              session.user.secondaryRole = activeAccount?.secondaryRole ?? null;
+            } else {
+              session.user.primaryRole = targetUser.primaryRole;
+              session.user.secondaryRole = targetUser.secondaryRole;
+            }
+
+            session.user.isImpersonating = true;
+            session.user.realAdminName = realAdminName;
+            return session;
           }
         }
 
-        session.user.id = effectiveUser.id;
-        session.user.riotGameName = effectiveUser.riotGameName;
-        session.user.riotTagLine = effectiveUser.riotTagLine;
-        session.user.isRiotLinked = !!effectiveUser.puuid;
-        session.user.region = effectiveUser.region;
-        session.user.activeRiotAccountId = effectiveUser.activeRiotAccountId;
-        session.user.onboardingCompleted = effectiveUser.onboardingCompleted;
-        session.user.role = impersonating ? effectiveUser.role : dbUser.role;
-        session.user.locale = effectiveUser.locale;
-        session.user.language = effectiveUser.language;
-        session.user.coachingCadenceDays = effectiveUser.coachingCadenceDays;
-
-        // Read role preferences from the active riot account (per-account)
-        if (effectiveUser.activeRiotAccountId) {
-          const activeAccount = await db.query.riotAccounts.findFirst({
-            where: eq(riotAccounts.id, effectiveUser.activeRiotAccountId),
-          });
-          session.user.primaryRole = activeAccount?.primaryRole ?? null;
-          session.user.secondaryRole = activeAccount?.secondaryRole ?? null;
-        } else {
-          // Fallback to user-level roles for backwards compatibility
-          session.user.primaryRole = effectiveUser.primaryRole;
-          session.user.secondaryRole = effectiveUser.secondaryRole;
-        }
-
-        // Signal impersonation state to the client
-        if (impersonating) {
-          session.user.isImpersonating = true;
-          session.user.realAdminName = dbUser.name;
-        }
+        // Normal path: read everything from the JWT token (zero DB queries)
+        session.user.id = effectiveUserId;
+        session.user.riotGameName = (token.riotGameName as string) ?? null;
+        session.user.riotTagLine = (token.riotTagLine as string) ?? null;
+        session.user.isRiotLinked = (token.isRiotLinked as boolean) ?? false;
+        session.user.region = (token.region as string) ?? null;
+        session.user.activeRiotAccountId = (token.activeRiotAccountId as string) ?? null;
+        session.user.onboardingCompleted = (token.onboardingCompleted as boolean) ?? false;
+        session.user.role = (token.role as "admin" | "premium" | "free") ?? "free";
+        session.user.locale = (token.locale as string) ?? null;
+        session.user.language = (token.language as string) ?? null;
+        session.user.coachingCadenceDays = (token.coachingCadenceDays as number) ?? null;
+        session.user.primaryRole = (token.primaryRole as string) ?? null;
+        session.user.secondaryRole = (token.secondaryRole as string) ?? null;
       }
       return session;
     },
-    async jwt({ token, account }) {
+    async jwt({ token, account, trigger }) {
       if (account?.provider === "discord" || account?.provider === "demo") {
         token.discordId = account.providerAccountId;
       }
+
+      // On sign-in or explicit session.update(), load user data into the JWT
+      // so the session callback doesn't need to hit the DB on every request.
+      if (trigger === "signIn" || trigger === "update" || (token.discordId && !token.userId)) {
+        const dbUser = await db.query.users.findFirst({
+          where: eq(users.discordId, token.discordId as string),
+        });
+        if (dbUser) {
+          token.userId = dbUser.id;
+          token.riotGameName = dbUser.riotGameName;
+          token.riotTagLine = dbUser.riotTagLine;
+          token.isRiotLinked = !!dbUser.puuid;
+          token.region = dbUser.region;
+          token.activeRiotAccountId = dbUser.activeRiotAccountId;
+          token.onboardingCompleted = dbUser.onboardingCompleted;
+          token.role = dbUser.role;
+          token.locale = dbUser.locale;
+          token.language = dbUser.language;
+          token.coachingCadenceDays = dbUser.coachingCadenceDays;
+
+          // Resolve role preferences from active riot account
+          if (dbUser.activeRiotAccountId) {
+            const activeAccount = await db.query.riotAccounts.findFirst({
+              where: eq(riotAccounts.id, dbUser.activeRiotAccountId),
+              columns: { primaryRole: true, secondaryRole: true },
+            });
+            token.primaryRole = activeAccount?.primaryRole ?? null;
+            token.secondaryRole = activeAccount?.secondaryRole ?? null;
+          } else {
+            token.primaryRole = dbUser.primaryRole;
+            token.secondaryRole = dbUser.secondaryRole;
+          }
+        }
+      }
+
       return token;
     },
   },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -174,7 +174,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         // Read user data from the JWT token (populated by jwt callback)
         // instead of querying the DB on every request.
         let effectiveUserId = token.userId as string;
-        let impersonating = false;
         let realAdminName: string | null = null;
 
         // Check for impersonation — only admins may impersonate.
@@ -189,7 +188,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           });
           if (targetUser && !targetUser.deactivatedAt) {
             effectiveUserId = targetUser.id;
-            impersonating = true;
             realAdminName = (token.name as string) ?? null;
 
             // For impersonated user, populate session from DB

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -11,6 +11,7 @@ export const coachingTag = (userId: string) => `coaching-${userId}`;
 export const scoutTag = (userId: string) => `scout-${userId}`;
 export const goalsTag = (userId: string) => `goals-${userId}`;
 export const challengesTag = (userId: string) => `challenges-${userId}`;
+export const sidebarTag = (userId: string) => `sidebar-${userId}`;
 
 // ─── Invalidation Helpers ───────────────────────────────────────────────────
 // Call these from Server Actions after writing to the DB.
@@ -24,6 +25,7 @@ export function invalidateAllCaches(userId: string) {
   updateTag(scoutTag(userId));
   updateTag(goalsTag(userId));
   updateTag(challengesTag(userId));
+  updateTag(sidebarTag(userId));
 }
 
 /** Invalidate caches affected by match review changes. */
@@ -31,6 +33,7 @@ export function invalidateReviewCaches(userId: string) {
   updateTag(analyticsTag(userId));
   updateTag(coachingTag(userId));
   updateTag(scoutTag(userId));
+  updateTag(sidebarTag(userId));
 }
 
 /** Invalidate caches affected by coaching mutations. */

--- a/src/lib/match-queries.ts
+++ b/src/lib/match-queries.ts
@@ -26,25 +26,6 @@ export const notRemake: SQL = sql`${matches.result} != 'Remake'`;
 // ─── Aggregate Helpers ───────────────────────────────────────────────────────
 
 /**
- * Build a SELECT that returns win/loss/remake/unreviewed/vodPending counts.
- * Use with `db.select(matchStatCountsSelect).from(matches).where(...)`.
- */
-export const matchStatCountsSelect = {
-  total: sql<number>`SUM(CASE WHEN ${matches.result} != 'Remake' THEN 1 ELSE 0 END)`.as("total"),
-  wins: sql<number>`SUM(CASE WHEN ${matches.result} = 'Victory' THEN 1 ELSE 0 END)`.as("wins"),
-  remakes: sql<number>`SUM(CASE WHEN ${matches.result} = 'Remake' THEN 1 ELSE 0 END)`.as("remakes"),
-  unreviewed:
-    sql<number>`SUM(CASE WHEN ${matches.reviewed} = 0 AND ${matches.result} != 'Remake' THEN 1 ELSE 0 END)`.as(
-      "unreviewed",
-    ),
-  vodPending:
-    sql<number>`SUM(CASE WHEN ${matches.reviewed} = 0 AND ${matches.result} != 'Remake' AND (
-    ${matches.comment} IS NOT NULL
-    OR EXISTS (SELECT 1 FROM ${matchHighlights} WHERE ${matchHighlights.matchId} = ${matches.id})
-  ) THEN 1 ELSE 0 END)`.as("vod_pending"),
-};
-
-/**
  * Returns win/loss/remake counts for a result-aware query.
  * Use: `db.select(winLossRemakeSelect).from(matches).where(...)`
  */


### PR DESCRIPTION
## Summary

- **Indexes**: Add 2 composite indexes on `matches`, drop 3 redundant single-column indexes (net 7→6)
- **Sidebar caching**: Cache review counts with `"use cache: remote"` + `cacheLife("hours")`
- **Sync dedup**: Date-bound query (24h buffer from most recent match) + early termination after 2 consecutive all-known pages
- **Duo backfill**: Replace N+1 UPDATE loop with single `db.batch()` round-trip
- **Admin getUsers (#225)**: Replace LEFT JOIN causing row explosion with scalar subqueries
- **JWT session**: Store user data in JWT token — session callback reads from token instead of querying DB on every `auth()` call (eliminates ~1,100 queries/day)
- **Dead code**: Remove unused `matchStatCountsSelect` export

## Context

Turso query logs showed the top DB costs were:
1. Auth session callback — 378s total, 1,100+ calls (now zero DB queries for non-impersonation)
2. Sync dedup — 609 calls loading ALL match IDs (now date-bounded, ~0-5 rows)
3. Review counts — 199s total, no caching (now cached for hours)
4. Admin getUsers — LEFT JOIN on matches caused row explosion (now scalar subqueries)

Fixes #226
Fixes #225