### PR TITLE
fix: use qualified table.column in admin scalar subqueries

### DIFF
--- a/src/app/actions/admin.ts
+++ b/src/app/actions/admin.ts
@@ -41,16 +41,16 @@ export async function getUsers(): Promise<AdminUser[]> {
       deactivatedAt: users.deactivatedAt,
       createdAt: users.createdAt,
       matchCount:
-        sql<number>`(SELECT count(*) FROM matches WHERE matches.user_id = ${users.id})`.as(
+        sql<number>`(SELECT count(*) FROM matches WHERE matches.user_id = "users"."id")`.as(
           "match_count",
         ),
       scopedMatchCount:
-        sql<number>`(SELECT count(*) FROM matches WHERE matches.user_id = ${users.id} AND matches.riot_account_id = ${users.activeRiotAccountId})`.as(
+        sql<number>`(SELECT count(*) FROM matches WHERE matches.user_id = "users"."id" AND matches.riot_account_id = "users"."active_riot_account_id")`.as(
           "scoped_match_count",
         ),
       lastSync: sql<
         string | null
-      >`(SELECT max(matches.synced_at) FROM matches WHERE matches.user_id = ${users.id})`.as(
+      >`(SELECT max(matches.synced_at) FROM matches WHERE matches.user_id = "users"."id")`.as(
         "last_sync",
       ),
     })


### PR DESCRIPTION
## Summary

- Fix admin page showing 0 matches for all users after #228

Drizzle's `sql`\`${users.id}\`` renders an **unqualified** `"id"` column reference. Inside the correlated subquery against `matches`, SQLite resolves `"id"` to `matches.id` instead of `users.id`, so `matches.user_id = matches.id` is always false.

Fixed by using literal `"users"."id"` and `"users"."active_riot_account_id"` in the SQL template.

Fixes the regression introduced in #228.