### PR TITLE
fix: only evaluate matches played after challenge creation

### DIFF
--- a/src/lib/challenges.ts
+++ b/src/lib/challenges.ts
@@ -155,6 +155,7 @@ export async function evaluateByGamesChallenges(
       csPerMin: true,
       deaths: true,
       visionScore: true,
+      gameDate: true,
     },
   });
 
@@ -163,6 +164,13 @@ export async function evaluateByGamesChallenges(
   const transitions: ChallengeTransition[] = [];
 
   for (const challenge of activeChallenges) {
+    // Only count matches played AFTER the challenge was created.
+    // Without this check, a batch sync of older matches would count
+    // pre-challenge games against the challenge counters.
+    if (match.gameDate && challenge.createdAt && match.gameDate < challenge.createdAt) {
+      continue;
+    }
+
     if (
       !challenge.metric ||
       !challenge.metricCondition ||


### PR DESCRIPTION
## Summary

- `evaluateByGamesChallenges` now skips matches where `gameDate < challenge.createdAt`
- Prevents old matches (played before a challenge was created) from counting against it during batch syncs

Without this fix, if a user creates a challenge and then syncs, any older matches in the sync batch would incorrectly count toward (or against) the challenge.

This was a pre-existing bug independent of the dedup regression in #228 — it just became more visible because of it.