### PR TITLE
fix: defer sync rate limit recording until after lock acquisition

### DIFF
--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -6,7 +6,7 @@ import { db } from "@/db";
 import { matches, rankSnapshots, riotAccounts } from "@/db/schema";
 import { checkByDateChallenges, evaluateByGamesChallenges } from "@/lib/challenges";
 import { checkGoalAchievement } from "@/lib/goals";
-import { checkRateLimit, hasRecentEvent } from "@/lib/rate-limit";
+import { hasRecentEvent, peekRateLimit, recordRateLimitEvent } from "@/lib/rate-limit";
 import { calculateAdaptiveDelay } from "@/lib/rate-limiter";
 import {
   getMatchIds,
@@ -105,8 +105,9 @@ export async function GET(request: Request) {
           return;
         }
       } else {
-        const rateCheck = await checkRateLimit(user.id, "sync");
+        const rateCheck = await peekRateLimit(user.id, "sync");
         if (!rateCheck.allowed) {
+          console.warn(`[sync] Rate-limited user ${user.id} — retryAfter=${rateCheck.retryAfter}s`);
           send({
             type: "error",
             message: `You can only sync once every 5 minutes. Try again in ${rateCheck.retryAfter} seconds.`,
@@ -123,6 +124,7 @@ export async function GET(request: Request) {
         const lockResult = await acquireSyncLock(user.id);
 
         if (lockResult.status === "already_locked") {
+          console.warn(`[sync] Lock already held for user ${user.id} — skipping`);
           send({
             type: "locked",
             message: "A sync is already in progress. Please wait for it to finish.",
@@ -166,6 +168,9 @@ export async function GET(request: Request) {
           }
 
           if (!acquired) {
+            console.warn(
+              `[sync] Queue timeout for user ${user.id} — waited ${MAX_QUEUE_WAIT_MS}ms, no slot`,
+            );
             send({
               type: "error",
               message: "Timed out waiting for a sync slot. Please try again in a minute.",
@@ -176,6 +181,13 @@ export async function GET(request: Request) {
         }
 
         lockAcquired = true;
+
+        // Record the rate limit event NOW — after the lock is acquired.
+        // This ensures failed lock acquisitions (queue timeout, already locked)
+        // don't consume the user's rate limit allowance.
+        if (!isContinuation) {
+          await recordRateLimitEvent(user.id, "sync");
+        }
 
         // ── Sync logic (same as before, with adaptive delays) ────────────
         send({ type: "status", message: "Checking existing matches..." });

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -52,11 +52,32 @@ export interface RateLimitResult {
  * Check whether a user is allowed to perform an action, and record the event
  * if allowed.
  *
- * This is the only function consumers need — it checks + records atomically.
+ * This is the simplest API — it checks + records atomically. Use this for
+ * actions where recording should happen immediately (e.g., export, ai_insight).
+ *
+ * For actions where recording should be deferred (e.g., sync — where a lock
+ * must be acquired first), use `peekRateLimit` + `recordRateLimitEvent` instead.
  *
  * @throws if `action` has no configured tier (programming error).
  */
 export async function checkRateLimit(userId: string, action: string): Promise<RateLimitResult> {
+  const result = await peekRateLimit(userId, action);
+  if (result.allowed) {
+    await recordRateLimitEvent(userId, action);
+  }
+  return result;
+}
+
+/**
+ * Check whether a user is allowed to perform an action WITHOUT recording it.
+ *
+ * Use this when you need to verify rate limits before acquiring other resources
+ * (e.g., sync locks). Call `recordRateLimitEvent` separately after the resource
+ * is successfully acquired.
+ *
+ * @throws if `action` has no configured tier (programming error).
+ */
+export async function peekRateLimit(userId: string, action: string): Promise<RateLimitResult> {
   const tier = RATE_LIMIT_TIERS[action];
   if (!tier) {
     throw new Error(`No rate limit tier configured for action "${action}"`);
@@ -103,14 +124,19 @@ export async function checkRateLimit(userId: string, action: string): Promise<Ra
     return { allowed: false, retryAfter };
   }
 
-  // Record the event
+  return { allowed: true };
+}
+
+/**
+ * Record a rate limit event for a user+action. Call this AFTER you've confirmed
+ * the action will actually proceed (e.g., after acquiring a sync lock).
+ */
+export async function recordRateLimitEvent(userId: string, action: string): Promise<void> {
   await db.insert(rateLimitEvents).values({
     userId,
     action,
-    createdAt: now,
+    createdAt: new Date(),
   });
-
-  return { allowed: true };
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Bug**: `checkRateLimit()` was called before acquiring the sync lock. If the lock failed (queue timeout after 30s, or already locked from another tab), the user's 1-per-5-min rate limit slot was consumed without any sync work done. This forced users to wait 5 minutes before retrying, making it appear as if match syncing was broken ("no new matches").
- **Fix**: Split `checkRateLimit` into `peekRateLimit` (check-only) + `recordRateLimitEvent` (record-only). The sync route now checks first, acquires the lock, and only records the rate limit event after the lock succeeds. Failed lock attempts no longer burn the rate limit window.
- **Observability**: Added `console.warn` logging for rate-limited, queue-timeout, and already-locked sync attempts so these failures are visible in server logs.

## Changelog

- skip-changelog (invisible sync infrastructure fix — players just see "syncing")