### PR TITLE
fix: retry failed challenges instantly without form

### DIFF
--- a/changelog/en/2026-04-21-challenge-retry-instant.mdx
+++ b/changelog/en/2026-04-21-challenge-retry-instant.mdx
@@ -1,0 +1,8 @@
+---
+version: "2026.04.4"
+date: "2026-04-21"
+title: "Retry failed challenges instantly"
+tags: ["fix"]
+---
+
+The **try again** button on failed challenges now instantly re-creates the same challenge with the same settings — no need to fill out the form again. For rank challenges, the deadline is recalculated from today with the same duration as the original.

--- a/changelog/es/2026-04-21-challenge-retry-instant.mdx
+++ b/changelog/es/2026-04-21-challenge-retry-instant.mdx
@@ -1,0 +1,8 @@
+---
+version: "2026.04.4"
+date: "2026-04-21"
+title: "Reintentar desafíos fallidos al instante"
+tags: ["fix"]
+---
+
+El botón **intentar de nuevo** en los desafíos fallidos ahora recrea el mismo desafío con la misma configuración al instante, sin necesidad de rellenar el formulario de nuevo. Para desafíos de rango, el plazo se recalcula desde hoy con la misma duración que el original.

--- a/messages/en.json
+++ b/messages/en.json
@@ -973,7 +973,9 @@
       "retireError": "Failed to retire challenge.",
       "challengeDeleted": "Challenge deleted.",
       "deleteError": "Failed to delete challenge.",
-      "challengeCompleted": "Challenge completed! Congratulations!"
+      "challengeCompleted": "Challenge completed! Congratulations!",
+      "challengeRetried": "Challenge re-created! Good luck!",
+      "retryError": "Failed to retry challenge."
     }
   },
   "Onboarding": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -973,7 +973,9 @@
       "retireError": "Error al retirar el desafío.",
       "challengeDeleted": "Desafío eliminado.",
       "deleteError": "Error al eliminar el desafío.",
-      "challengeCompleted": "¡Desafío completado! ¡Felicidades!"
+      "challengeCompleted": "¡Desafío completado! ¡Felicidades!",
+      "challengeRetried": "¡Desafío recreado! ¡Buena suerte!",
+      "retryError": "Error al reintentar el desafío."
     }
   },
   "Onboarding": {

--- a/src/app/(app)/challenges/challenges-client.tsx
+++ b/src/app/(app)/challenges/challenges-client.tsx
@@ -20,18 +20,17 @@ import { toast } from "sonner";
 
 import type { Challenge } from "@/db/schema";
 
-import { retireChallenge, deleteChallenge } from "@/app/actions/challenges";
+import { retireChallenge, deleteChallenge, retryChallenge } from "@/app/actions/challenges";
 import { EmptyState } from "@/components/empty-state";
 import { Pagination, paginate } from "@/components/pagination";
 import { Badge } from "@/components/ui/badge";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Progress, ProgressLabel } from "@/components/ui/progress";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { formatTierDivision, calculateProgress } from "@/lib/rank";
-import { cn } from "@/lib/utils";
 
 interface ChallengesClientProps {
   challenges: Challenge[];
@@ -344,6 +343,7 @@ function PastChallengeCard({
 }) {
   const t = useTranslations("Challenges");
   const [isDeleting, startDelete] = useTransition();
+  const [isRetrying, startRetry] = useTransition();
 
   function handleDelete() {
     if (!confirm(t("deleteConfirm"))) return;
@@ -414,16 +414,33 @@ function PastChallengeCard({
           {t(challenge.status as "completed" | "failed" | "retired")}
         </Badge>
         {!readOnly && challenge.status === "failed" && (
-          <Link
-            href="/challenges/new"
-            className={cn(
-              buttonVariants({ variant: "outline", size: "sm" }),
-              "h-7 gap-1.5 text-xs",
-            )}
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1.5 text-xs"
+            disabled={isRetrying}
+            onClick={() => {
+              startRetry(async () => {
+                try {
+                  const result = await retryChallenge(challenge.id);
+                  if ("error" in result) {
+                    toast.error(result.error);
+                  } else {
+                    toast.success(t("toasts.challengeRetried"));
+                  }
+                } catch {
+                  toast.error(t("toasts.retryError"));
+                }
+              });
+            }}
           >
-            <RotateCcw className="h-3 w-3" />
+            {isRetrying ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RotateCcw className="h-3 w-3" />
+            )}
             {t("tryAgain")}
-          </Link>
+          </Button>
         )}
         {!readOnly && (
           <Button

--- a/src/app/actions/challenges.ts
+++ b/src/app/actions/challenges.ts
@@ -120,6 +120,57 @@ export async function createByGamesChallenge(data: {
   return { success: true, challengeId: challenge.id };
 }
 
+// ─── Retry a failed challenge (re-create with same parameters) ─────────────
+
+export async function retryChallenge(challengeId: number) {
+  const user = await requireUser();
+  await blockIfImpersonating();
+
+  // Fetch the failed challenge + its topics
+  const original = await db.query.challenges.findFirst({
+    where: and(
+      eq(challenges.id, challengeId),
+      eq(challenges.userId, user.id),
+      eq(challenges.status, "failed"),
+    ),
+  });
+
+  if (!original) {
+    return { error: "Failed challenge not found." };
+  }
+
+  const originalTopics = await db.query.challengeTopics.findMany({
+    where: eq(challengeTopics.challengeId, challengeId),
+  });
+  const topicIds = originalTopics.map((ct) => ct.topicId);
+
+  if (original.type === "by-date") {
+    // Compute original duration and apply from now
+    const originalDuration =
+      original.deadline && original.createdAt
+        ? new Date(original.deadline).getTime() - new Date(original.createdAt).getTime()
+        : null;
+    const newDeadline = originalDuration ? new Date(Date.now() + originalDuration) : null;
+
+    return createByDateChallenge({
+      targetTier: original.targetTier!,
+      targetDivision: original.targetDivision,
+      deadline: newDeadline ? newDeadline.toISOString() : null,
+      topicIds,
+    });
+  }
+
+  // by-games challenge
+  return createByGamesChallenge({
+    title: original.title,
+    metric: original.metric as ChallengeMetric,
+    metricCondition: original.metricCondition as MetricCondition,
+    metricThreshold: original.metricThreshold!,
+    targetGames: original.targetGames!,
+    topicIds,
+  });
+}
+
 // ─── Retire a challenge ────────────────────────────────────────────────────
 
 export async function retireChallenge(challengeId: number) {

--- a/src/components/challenge-result-modal.tsx
+++ b/src/components/challenge-result-modal.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import confetti from "canvas-confetti";
-import { Trophy, XCircle, ChevronLeft, ChevronRight, RotateCcw } from "lucide-react";
+import { Trophy, XCircle, ChevronLeft, ChevronRight, RotateCcw, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState, useRef } from "react";
+import { useCallback, useEffect, useState, useRef, useTransition } from "react";
+import { toast } from "sonner";
 
 import type { ChallengeTransition } from "@/lib/challenges";
 
+import { retryChallenge } from "@/app/actions/challenges";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -107,10 +109,25 @@ export function ChallengeResultModal({ transitions, onDismiss }: ChallengeResult
     }
   }, [currentIndex]);
 
+  const tChallenges = useTranslations("Challenges");
+  const [isRetrying, startRetry] = useTransition();
+
   const handleTryAgain = useCallback(() => {
-    onDismiss();
-    router.push("/challenges/new");
-  }, [onDismiss, router]);
+    startRetry(async () => {
+      try {
+        const result = await retryChallenge(current.id);
+        if ("error" in result) {
+          toast.error(result.error);
+        } else {
+          toast.success(tChallenges("toasts.challengeRetried"));
+          onDismiss();
+          router.push("/challenges");
+        }
+      } catch {
+        toast.error(tChallenges("toasts.retryError"));
+      }
+    });
+  }, [current, onDismiss, router, tChallenges]);
 
   if (!current) return null;
 
@@ -215,8 +232,17 @@ export function ChallengeResultModal({ transitions, onDismiss }: ChallengeResult
 
         <DialogFooter className="sm:justify-center">
           {!isSuccess && (
-            <Button variant="outline" onClick={handleTryAgain} className="gap-2">
-              <RotateCcw className="h-4 w-4" />
+            <Button
+              variant="outline"
+              onClick={handleTryAgain}
+              disabled={isRetrying}
+              className="gap-2"
+            >
+              {isRetrying ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RotateCcw className="h-4 w-4" />
+              )}
               {t("tryAgain")}
             </Button>
           )}


### PR DESCRIPTION
## Summary

- **Try Again** on failed challenges now calls a `retryChallenge` server action that re-creates the same challenge with identical parameters, instead of redirecting to `/challenges/new`
- For by-date challenges, the deadline is recalculated from today with the same duration as the original
- For by-games challenges, the metric/condition/threshold/target are copied and counters reset to 0
- Both the result modal and the past challenges list use the new instant retry

## Changelog

- Version 2026.04.4: Retry failed challenges instantly without filling the form again