### PR TITLE
fix: correct changelog version numbering

### DIFF
--- a/changelog/en/2026-04-21-challenge-retry-instant.mdx
+++ b/changelog/en/2026-04-21-challenge-retry-instant.mdx
@@ -1,5 +1,5 @@
 ---
-version: "2026.04.4"
+version: "2026.04.24"
 date: "2026-04-21"
 title: "Retry failed challenges instantly"
 tags: ["fix"]

--- a/changelog/en/2026-04-21-public-demo.mdx
+++ b/changelog/en/2026-04-21-public-demo.mdx
@@ -1,5 +1,5 @@
 ---
-version: "2026.04.3"
+version: "2026.04.23"
 date: "2026-04-21"
 title: "Public demo mode"
 tags: ["feature"]

--- a/changelog/es/2026-04-21-challenge-retry-instant.mdx
+++ b/changelog/es/2026-04-21-challenge-retry-instant.mdx
@@ -1,5 +1,5 @@
 ---
-version: "2026.04.4"
+version: "2026.04.24"
 date: "2026-04-21"
 title: "Reintentar desafíos fallidos al instante"
 tags: ["fix"]

--- a/changelog/es/2026-04-21-public-demo.mdx
+++ b/changelog/es/2026-04-21-public-demo.mdx
@@ -1,5 +1,5 @@
 ---
-version: "2026.04.3"
+version: "2026.04.23"
 date: "2026-04-21"
 title: "Modo demo público"
 tags: ["feature"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lol-tracker",
-  "version": "2026.04.22",
+  "version": "2026.04.24",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
## Summary

- Fix changelog version numbering: two recent entries (public-demo and challenge-retry-instant) were numbered `2026.04.3` and `2026.04.4` instead of `2026.04.23` and `2026.04.24`, creating duplicates of existing versions and breaking the display order
- Updated both EN and ES changelog files and bumped `package.json` version to `2026.04.24`

## Changelog

- Version 2026.04.24: Fixed changelog ordering — entries now display in the correct sequence