### PR TITLE
fix: show 404 instead of redirecting to login when demo data is missing

### DIFF
--- a/src/app/(demo)/demo/analytics/page.tsx
+++ b/src/app/(demo)/demo/analytics/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
 import { AnalyticsClient } from "@/app/(app)/analytics/analytics-client";
@@ -8,7 +8,7 @@ import { getAnalyticsData } from "@/lib/queries/analytics";
 export default async function DemoAnalyticsPage() {
   await connection();
   const user = await getDemoUser();
-  if (!user) redirect("/login");
+  if (!user) notFound();
 
   const { allMatches, sessions, ranks, ddragonVersion, activeGoal } = await getAnalyticsData(
     user.id,

--- a/src/app/(demo)/demo/challenges/page.tsx
+++ b/src/app/(demo)/demo/challenges/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
 import { ChallengesClient } from "@/app/(app)/challenges/challenges-client";
@@ -8,7 +8,7 @@ import { getChallengesData } from "@/lib/queries/challenges";
 export default async function DemoChallengesPage() {
   await connection();
   const user = await getDemoUser();
-  if (!user) redirect("/login");
+  if (!user) notFound();
 
   const data = await getChallengesData(user.id, user.activeRiotAccountId);
 

--- a/src/app/(demo)/demo/coaching/page.tsx
+++ b/src/app/(demo)/demo/coaching/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
 import { CoachingHubClient } from "@/app/(app)/coaching/coaching-hub-client";
@@ -8,7 +8,7 @@ import { getCoachingData } from "@/lib/queries/coaching";
 export default async function DemoCoachingPage() {
   await connection();
   const user = await getDemoUser();
-  if (!user) redirect("/login");
+  if (!user) notFound();
 
   const data = await getCoachingData(user.id, user.activeRiotAccountId);
 

--- a/src/app/(demo)/demo/matches/[id]/page.tsx
+++ b/src/app/(demo)/demo/matches/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
 import { MatchDetailClient } from "@/app/(app)/matches/[id]/match-detail-client";
@@ -9,7 +9,7 @@ export default async function DemoMatchDetailPage({ params }: { params: Promise<
   await connection();
   const { id } = await params;
   const user = await getDemoUser();
-  if (!user) redirect("/login");
+  if (!user) notFound();
 
   const data = await getMatchDetailData(id, user.id, user.activeRiotAccountId, user.puuid, {
     skipAuthDependentQueries: true,

--- a/src/app/(demo)/demo/matches/page.tsx
+++ b/src/app/(demo)/demo/matches/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
 import { MatchesClient } from "@/app/(app)/matches/matches-client";
@@ -12,7 +12,7 @@ export default async function DemoMatchesPage({
 }) {
   await connection();
   const user = await getDemoUser();
-  if (!user) redirect("/login");
+  if (!user) notFound();
 
   const params = await searchParams;
   const page = Math.max(1, parseInt(String(params.page ?? "1"), 10) || 1);

--- a/src/app/(demo)/demo/page.tsx
+++ b/src/app/(demo)/demo/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
 import { DashboardClient } from "@/app/(app)/dashboard/dashboard-client";
@@ -8,7 +8,7 @@ import { getDashboardData } from "@/lib/queries/dashboard";
 export default async function DemoDashboardPage() {
   await connection();
   const user = await getDemoUser();
-  if (!user) redirect("/login");
+  if (!user) notFound();
 
   const data = await getDashboardData(user.id, user.activeRiotAccountId);
 

--- a/src/app/(demo)/demo/review/page.tsx
+++ b/src/app/(demo)/demo/review/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
 import { ReviewClient } from "@/app/(app)/review/review-client";
@@ -12,7 +12,7 @@ export default async function DemoReviewPage({
 }) {
   await connection();
   const user = await getDemoUser();
-  if (!user) redirect("/login");
+  if (!user) notFound();
 
   const params = await searchParams;
 

--- a/src/app/(demo)/demo/scout/page.tsx
+++ b/src/app/(demo)/demo/scout/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
 import { ScoutClient } from "@/app/(app)/scout/scout-client";
@@ -12,7 +12,7 @@ export default async function DemoScoutPage({
 }) {
   await connection();
   const user = await getDemoUser();
-  if (!user) redirect("/login");
+  if (!user) notFound();
 
   const params = await searchParams;
   const data = await getScoutData(!!user.puuid, params, {


### PR DESCRIPTION
## Summary

- When demo seed data is missing from the production database, all `/demo` pages were calling `redirect("/login")` — confusing visitors into thinking they need to authenticate
- Replaced `redirect("/login")` with `notFound()` in all 8 demo page files so users see a proper 404 instead

Fixes #240

## Note

This fixes the symptom (confusing redirect). The root cause is that `seed-demo` needs to be run against the production Turso database to populate demo data. After seeding, the 404 path won't be hit.