### PR TITLE
feat: add sort toggle to review pending tab

### DIFF
--- a/.opencode/skills/accessibility/SKILL.md
+++ b/.opencode/skills/accessibility/SKILL.md
@@ -127,17 +127,31 @@ Add `aria-label` when there's no visible label adjacent:
 </SelectTrigger>
 ```
 
-**CRITICAL: Base UI `SelectValue` displays the raw `value` string, NOT the `SelectItem` label.** The `placeholder` prop is used as the display text when the value matches the default. To ensure the correct label is shown, always provide a `placeholder` that matches the default option's display text:
+**CRITICAL: Base UI `SelectValue` displays the raw `value` string, NOT the `SelectItem` label.** This is the #1 recurring UI bug in this codebase. The `placeholder` prop only works when NO value is selected. When a value IS selected (including the default), `SelectValue` renders the raw value string (e.g. `"suggested"` instead of `"Suggested"`).
+
+**The ONLY reliable fix** is to use the `children` render function, which receives the current value and lets you map it to the correct label:
 
 ```tsx
-// WRONG — shows "suggested" instead of "Suggested"
-<SelectValue />
+// WRONG — shows raw value "suggested"
+<SelectValue placeholder="Suggested" />
 
-// CORRECT — shows "Suggested" as the placeholder text
+// WRONG — placeholder only shows when value is null/undefined
 <SelectValue placeholder={t("sort.suggested")} />
+
+// CORRECT — children function maps value to label
+<SelectValue placeholder={t("sort.suggested")}>
+  {(value: string) => {
+    const labels: Record<string, string> = {
+      suggested: t("sort.suggested"),
+      newest: t("sort.newestFirst"),
+      oldest: t("sort.oldestFirst"),
+    };
+    return labels[value] ?? value;
+  }}
+</SelectValue>
 ```
 
-This is a known Base UI quirk — `SelectValue` does not automatically resolve the label from the matching `SelectItem`.
+**MANDATORY: Every `<SelectValue>` in this codebase MUST use the children function pattern.** No exceptions. The `placeholder` prop alone is never sufficient when a default value is set.
 
 ### Tooltip triggers
 

--- a/.opencode/skills/accessibility/SKILL.md
+++ b/.opencode/skills/accessibility/SKILL.md
@@ -127,6 +127,42 @@ Add `aria-label` when there's no visible label adjacent:
 </SelectTrigger>
 ```
 
+**CRITICAL: Base UI `SelectValue` displays the raw `value` string, NOT the `SelectItem` label.** The `placeholder` prop is used as the display text when the value matches the default. To ensure the correct label is shown, always provide a `placeholder` that matches the default option's display text:
+
+```tsx
+// WRONG — shows "suggested" instead of "Suggested"
+<SelectValue />
+
+// CORRECT — shows "Suggested" as the placeholder text
+<SelectValue placeholder={t("sort.suggested")} />
+```
+
+This is a known Base UI quirk — `SelectValue` does not automatically resolve the label from the matching `SelectItem`.
+
+### Tooltip triggers
+
+`TooltipTrigger` renders a `<button>` element. If the content is an icon-only element, it **must** have an `aria-label` — otherwise axe-core reports a `button-name` violation:
+
+```tsx
+// WRONG — button has no accessible name
+<Tooltip>
+  <TooltipTrigger>
+    <Info className="h-3.5 w-3.5" />
+  </TooltipTrigger>
+  ...
+</Tooltip>
+
+// CORRECT — aria-label provides the accessible name
+<Tooltip>
+  <TooltipTrigger aria-label={t("tooltipLabel")}>
+    <Info className="h-3.5 w-3.5" />
+  </TooltipTrigger>
+  ...
+</Tooltip>
+```
+
+Remember: every `aria-label={t("key")}` requires keys in BOTH `messages/en.json` AND `messages/es.json`.
+
 ### Dialogs and drawers
 
 Focus trapping is handled automatically by `@base-ui/react/dialog`. No manual implementation needed for Dialog, AlertDialog, or drawer patterns using Dialog primitives.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,3 +165,27 @@ If you forgot to capture "before" screenshots, check out `main`, capture them, t
 Full workflow details are in the `ui-screenshots` OpenCode skill.
 
 <!-- END:ui-screenshots-rules -->
+
+<!-- BEGIN:base-ui-select-rules -->
+
+# Base UI Select — MANDATORY
+
+**`SelectValue` displays the raw `value` string, NOT the `SelectItem` label.** This is the #1 recurring UI bug in this codebase. The `placeholder` prop only works when no value is selected.
+
+**Every `<SelectValue>` MUST use the children render function:**
+
+```tsx
+<SelectValue placeholder={t("default.label")}>
+  {(value: string) => {
+    const labels: Record<string, string> = {
+      optionA: t("optionA.label"),
+      optionB: t("optionB.label"),
+    };
+    return labels[value] ?? value;
+  }}
+</SelectValue>
+```
+
+**Every `<SelectTrigger>` without a visible adjacent label MUST have `aria-label`.**
+
+<!-- END:base-ui-select-rules -->

--- a/messages/en.json
+++ b/messages/en.json
@@ -257,9 +257,11 @@
     "vodReviewHint": "These games have post-game notes but haven't been VOD-reviewed yet. Watch the VOD and add your takeaways.",
     "pendingHint": "Click topics to mark highlights and lowlights, add notes, and save to mark as reviewed.",
     "sort": {
+      "label": "Sort order",
       "suggested": "Suggested",
       "newestFirst": "Newest first",
       "oldestFirst": "Oldest first",
+      "suggestedInfoLabel": "What does suggested mean?",
       "suggestedTooltip": "Shows games where you likely have the most to learn first — losses, high deaths, low KDA, long games."
     },
     "reviewedGamesCount": "{count, plural, one {# reviewed game} other {# reviewed games}}.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -256,6 +256,12 @@
     "postGameHint": "These games haven't been reviewed yet. Add highlights, notes, and optionally a VOD link.",
     "vodReviewHint": "These games have post-game notes but haven't been VOD-reviewed yet. Watch the VOD and add your takeaways.",
     "pendingHint": "Click topics to mark highlights and lowlights, add notes, and save to mark as reviewed.",
+    "sort": {
+      "suggested": "Suggested",
+      "newestFirst": "Newest first",
+      "oldestFirst": "Oldest first",
+      "suggestedTooltip": "Shows games where you likely have the most to learn first — losses, high deaths, low KDA, long games."
+    },
     "reviewedGamesCount": "{count, plural, one {# reviewed game} other {# reviewed games}}.",
     "suggested": "Suggested",
     "disabledSaveTooltip": "Add at least one highlight, note, or VOD link to save.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -257,9 +257,11 @@
     "vodReviewHint": "Estas partidas tienen notas post-partida pero no han sido revisadas con VOD. Mira el VOD y añade tus conclusiones.",
     "pendingHint": "Haz clic en los temas para marcar aciertos y errores, añade notas y guarda para marcar como revisada.",
     "sort": {
+      "label": "Orden",
       "suggested": "Sugeridas",
       "newestFirst": "Más recientes",
       "oldestFirst": "Más antiguas",
+      "suggestedInfoLabel": "¿Qué significa sugeridas?",
       "suggestedTooltip": "Muestra primero las partidas de las que más puedes aprender — derrotas, muchas muertes, KDA bajo, partidas largas."
     },
     "reviewedGamesCount": "{count, plural, one {# partida revisada} other {# partidas revisadas}}.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -256,6 +256,12 @@
     "postGameHint": "Estas partidas no han sido revisadas. Añade aciertos, notas y opcionalmente un enlace de VOD.",
     "vodReviewHint": "Estas partidas tienen notas post-partida pero no han sido revisadas con VOD. Mira el VOD y añade tus conclusiones.",
     "pendingHint": "Haz clic en los temas para marcar aciertos y errores, añade notas y guarda para marcar como revisada.",
+    "sort": {
+      "suggested": "Sugeridas",
+      "newestFirst": "Más recientes",
+      "oldestFirst": "Más antiguas",
+      "suggestedTooltip": "Muestra primero las partidas de las que más puedes aprender — derrotas, muchas muertes, KDA bajo, partidas largas."
+    },
     "reviewedGamesCount": "{count, plural, one {# partida revisada} other {# partidas revisadas}}.",
     "suggested": "Sugerida",
     "disabledSaveTooltip": "Añade al menos un acierto, nota o enlace VOD para guardar.",

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -826,8 +826,8 @@ export function ReviewClient({
                         setPendingSortMode(v as "suggested" | "newest" | "oldest")
                       }
                     >
-                      <SelectTrigger size="sm" className="w-[150px]">
-                        <SelectValue />
+                      <SelectTrigger size="sm" className="w-[150px]" aria-label={t("sort.label")}>
+                        <SelectValue placeholder={t("sort.suggested")} />
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="suggested">{t("sort.suggested")}</SelectItem>
@@ -837,7 +837,7 @@ export function ReviewClient({
                     </Select>
                     {pendingSortMode === "suggested" && (
                       <Tooltip>
-                        <TooltipTrigger>
+                        <TooltipTrigger aria-label={t("sort.suggestedInfoLabel")}>
                           <Info className="h-3.5 w-3.5 text-muted-foreground" />
                         </TooltipTrigger>
                         <TooltipContent>

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -833,7 +833,16 @@ export function ReviewClient({
                       }
                     >
                       <SelectTrigger size="sm" className="w-[150px]" aria-label={t("sort.label")}>
-                        <SelectValue placeholder={t("sort.suggested")} />
+                        <SelectValue placeholder={t("sort.suggested")}>
+                          {(value: string) => {
+                            const labels: Record<string, string> = {
+                              suggested: t("sort.suggested"),
+                              newest: t("sort.newestFirst"),
+                              oldest: t("sort.oldestFirst"),
+                            };
+                            return labels[value] ?? value;
+                          }}
+                        </SelectValue>
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="suggested">{t("sort.suggested")}</SelectItem>

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -15,7 +15,6 @@ import {
   Sparkles,
   Crosshair,
   Globe,
-  Info,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
@@ -295,10 +294,17 @@ function PendingReviewCard({
             </div>
           </button>
           {priorityScore >= PRIORITY_THRESHOLD && (
-            <Badge variant="secondary" className="gap-1 text-gold">
-              <Sparkles className="h-3 w-3" />
-              {t("suggested")}
-            </Badge>
+            <Tooltip>
+              <TooltipTrigger aria-label={t("sort.suggestedInfoLabel")}>
+                <Badge variant="secondary" className="gap-1 text-gold">
+                  <Sparkles className="h-3 w-3" />
+                  {t("suggested")}
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="max-w-[200px] text-xs">{t("sort.suggestedTooltip")}</p>
+              </TooltipContent>
+            </Tooltip>
           )}
           <Link href={`/matches/${match.id}`} aria-label={t("viewMatchDetails")}>
             <ChevronRight className="h-4 w-4 text-muted-foreground" />
@@ -835,16 +841,6 @@ export function ReviewClient({
                         <SelectItem value="oldest">{t("sort.oldestFirst")}</SelectItem>
                       </SelectContent>
                     </Select>
-                    {pendingSortMode === "suggested" && (
-                      <Tooltip>
-                        <TooltipTrigger aria-label={t("sort.suggestedInfoLabel")}>
-                          <Info className="h-3.5 w-3.5 text-muted-foreground" />
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p className="max-w-[200px] text-xs">{t("sort.suggestedTooltip")}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
                   </div>
                 </div>
                 {paginatedPending.map((match) => (

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -15,6 +15,7 @@ import {
   Sparkles,
   Crosshair,
   Globe,
+  Info,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
@@ -46,7 +47,15 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAuth } from "@/lib/auth-client";
 import { formatDate, formatDuration, DEFAULT_LOCALE } from "@/lib/format";
 import { getKeystoneIconUrlByName, getChampionIconUrl } from "@/lib/riot-api";
@@ -651,15 +660,24 @@ export function ReviewClient({
   );
 
   // Sort pending matches by priority
+  const [pendingSortMode, setPendingSortMode] = useState<"suggested" | "newest" | "oldest">(
+    "suggested",
+  );
   const { pendingMatches, priorityScores } = useMemo(() => {
     const remaining = unreviewedMatches.filter((m) => !actionedIds.has(m.id));
     const scores: Record<string, number> = {};
     for (const m of remaining) {
       scores[m.id] = computePriorityScore(m);
     }
-    remaining.sort((a, b) => (scores[b.id] ?? 0) - (scores[a.id] ?? 0));
+    if (pendingSortMode === "suggested") {
+      remaining.sort((a, b) => (scores[b.id] ?? 0) - (scores[a.id] ?? 0));
+    } else if (pendingSortMode === "newest") {
+      remaining.sort((a, b) => b.gameDate.getTime() - a.gameDate.getTime());
+    } else {
+      remaining.sort((a, b) => a.gameDate.getTime() - b.gameDate.getTime());
+    }
     return { pendingMatches: remaining, priorityScores: scores };
-  }, [unreviewedMatches, actionedIds]);
+  }, [unreviewedMatches, actionedIds, pendingSortMode]);
 
   // Auto-expand the first card
   const hasAutoExpanded = useRef(false);
@@ -799,7 +817,36 @@ export function ReviewClient({
               />
             ) : (
               <>
-                <p className="text-xs text-muted-foreground">{t("pendingHint")}</p>
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-xs text-muted-foreground">{t("pendingHint")}</p>
+                  <div className="flex items-center gap-1.5">
+                    <Select
+                      value={pendingSortMode}
+                      onValueChange={(v) =>
+                        setPendingSortMode(v as "suggested" | "newest" | "oldest")
+                      }
+                    >
+                      <SelectTrigger size="sm" className="w-[150px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="suggested">{t("sort.suggested")}</SelectItem>
+                        <SelectItem value="newest">{t("sort.newestFirst")}</SelectItem>
+                        <SelectItem value="oldest">{t("sort.oldestFirst")}</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {pendingSortMode === "suggested" && (
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p className="max-w-[200px] text-xs">{t("sort.suggestedTooltip")}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  </div>
+                </div>
                 {paginatedPending.map((match) => (
                   <PendingReviewCard
                     key={match.id}


### PR DESCRIPTION
## Summary

- Adds a sort dropdown to the Review pending tab with 3 options: Suggested (default priority heuristic), Newest first, Oldest first
- Shows an info tooltip on "Suggested" explaining the priority criteria (losses, high deaths, low KDA, long games)
- Uses the existing `Select` component for consistency with matches/action-items filter patterns

Relates to #243