### PR TITLE
fix: use SelectValue children render function in all selects

### DIFF
--- a/src/app/(app)/coaching/action-items/action-items-client.tsx
+++ b/src/app/(app)/coaching/action-items/action-items-client.tsx
@@ -239,7 +239,12 @@ export function ActionItemsClient({ items, topicNames, outcomeStats }: ActionIte
           <div className="w-36">
             <Select value={newTopic} onValueChange={(v) => setNewTopic(v ?? "")}>
               <SelectTrigger aria-label={t("addTopicPlaceholder")}>
-                <SelectValue placeholder={t("addTopicPlaceholder")} />
+                <SelectValue placeholder={t("addTopicPlaceholder")}>
+                  {(value: string) => {
+                    const topic = topicNames.find((tn) => String(tn.id) === value);
+                    return topic?.name ?? t("addTopicPlaceholder");
+                  }}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {topicNames.map((tn) => (
@@ -266,7 +271,16 @@ export function ActionItemsClient({ items, topicNames, outcomeStats }: ActionIte
           }}
         >
           <SelectTrigger className="w-[150px]" aria-label="Filter by status">
-            <SelectValue placeholder={t("statusFilterPlaceholder")} />
+            <SelectValue placeholder={t("statusFilterPlaceholder")}>
+              {(value: string) => {
+                const labels: Record<string, string> = {
+                  all: t("allStatuses"),
+                  active: t("active"),
+                  completed: t("completed"),
+                };
+                return labels[value] ?? value;
+              }}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">{t("allStatuses")}</SelectItem>
@@ -283,7 +297,13 @@ export function ActionItemsClient({ items, topicNames, outcomeStats }: ActionIte
             }}
           >
             <SelectTrigger className="w-[180px]" aria-label="Filter by topic">
-              <SelectValue placeholder={t("topicFilterPlaceholder")} />
+              <SelectValue placeholder={t("topicFilterPlaceholder")}>
+                {(value: string) => {
+                  if (value === "all") return t("allTopics");
+                  const id = Number(value);
+                  return topicNames.find((tn) => tn.id === id)?.name ?? `Topic #${value}`;
+                }}
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">{t("allTopics")}</SelectItem>

--- a/src/app/(app)/goals/new/new-goal-client.tsx
+++ b/src/app/(app)/goals/new/new-goal-client.tsx
@@ -148,7 +148,9 @@ export function NewGoalClient({ currentRank }: NewGoalClientProps) {
                 }}
               >
                 <SelectTrigger aria-label="Select tier">
-                  <SelectValue placeholder={t("selectTier")} />
+                  <SelectValue placeholder={t("selectTier")}>
+                    {(value: string) => value.charAt(0) + value.slice(1).toLowerCase()}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {TIER_ORDER.map((tier) => (
@@ -166,7 +168,9 @@ export function NewGoalClient({ currentRank }: NewGoalClientProps) {
                 <Label>{t("division")}</Label>
                 <Select value={selectedDivision} onValueChange={(v) => v && setSelectedDivision(v)}>
                   <SelectTrigger aria-label="Select division">
-                    <SelectValue placeholder={t("selectDivision")} />
+                    <SelectValue placeholder={t("selectDivision")}>
+                      {(value: string) => value}
+                    </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
                     {DIVISION_ORDER.map((div) => (

--- a/src/app/(app)/matches/matches-client.tsx
+++ b/src/app/(app)/matches/matches-client.tsx
@@ -308,7 +308,17 @@ export function MatchesClient({
           onValueChange={(v) => navigateWithFilter("result", v ?? "all")}
         >
           <SelectTrigger className="w-full sm:w-[130px]" aria-label="Filter by result">
-            <SelectValue placeholder={t("resultFilterPlaceholder")} />
+            <SelectValue placeholder={t("resultFilterPlaceholder")}>
+              {(value: string) => {
+                const labels: Record<string, string> = {
+                  all: t("allResults"),
+                  Victory: t("victories"),
+                  Defeat: t("defeats"),
+                  Remake: t("remakes"),
+                };
+                return labels[value] ?? value;
+              }}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">{t("allResults")}</SelectItem>
@@ -322,7 +332,12 @@ export function MatchesClient({
           onValueChange={(v) => navigateWithFilter("champion", v ?? "all")}
         >
           <SelectTrigger className="w-full sm:w-[150px]" aria-label="Filter by champion">
-            <SelectValue placeholder={t("championFilterPlaceholder")} />
+            <SelectValue placeholder={t("championFilterPlaceholder")}>
+              {(value: string) => {
+                if (value === "all") return t("allChampions");
+                return value;
+              }}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">{t("allChampions")}</SelectItem>
@@ -348,7 +363,17 @@ export function MatchesClient({
           onValueChange={(v) => navigateWithFilter("review", v ?? "all")}
         >
           <SelectTrigger className="w-full sm:w-[160px]" aria-label="Filter by review status">
-            <SelectValue placeholder={t("reviewFilterPlaceholder")} />
+            <SelectValue placeholder={t("reviewFilterPlaceholder")}>
+              {(value: string) => {
+                const labels: Record<string, string> = {
+                  all: t("reviewAll"),
+                  reviewed: t("reviewed"),
+                  unreviewed: t("notReviewed"),
+                  "has-notes": t("hasNotes"),
+                };
+                return labels[value] ?? value;
+              }}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">{t("reviewAll")}</SelectItem>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -836,7 +836,11 @@ export default function SettingsPage() {
                           className="h-9 w-[160px]"
                           disabled={isPending}
                         >
-                          <SelectValue placeholder={t("riotAccounts.regionPlaceholder")} />
+                          <SelectValue placeholder={t("riotAccounts.regionPlaceholder")}>
+                            {(value: string) =>
+                              `${PLATFORM_LABELS[value as keyof typeof PLATFORM_LABELS]} (${value})`
+                            }
+                          </SelectValue>
                         </SelectTrigger>
                         <SelectContent>
                           {PLATFORM_IDS.map((id) => (
@@ -976,7 +980,12 @@ export default function SettingsPage() {
                       className="w-full max-w-xs"
                       disabled={isPending}
                     >
-                      <SelectValue />
+                      <SelectValue>
+                        {(value: string) => {
+                          const lang = SUPPORTED_LANGUAGES.find((l) => l.value === value);
+                          return lang?.label ?? value;
+                        }}
+                      </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       {SUPPORTED_LANGUAGES.map((lang) => (
@@ -995,7 +1004,12 @@ export default function SettingsPage() {
                       className="w-full max-w-xs"
                       disabled={isPending}
                     >
-                      <SelectValue placeholder={t("languageCard.selectPlaceholder")} />
+                      <SelectValue placeholder={t("languageCard.selectPlaceholder")}>
+                        {(value: string) => {
+                          const loc = SUPPORTED_LOCALES.find((l) => l.value === value);
+                          return loc ? `${loc.label} (${loc.description})` : value;
+                        }}
+                      </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       {SUPPORTED_LOCALES.map((loc) => (

--- a/src/app/onboarding/onboarding-client.tsx
+++ b/src/app/onboarding/onboarding-client.tsx
@@ -90,7 +90,11 @@ function RegionStep({
           }}
         >
           <SelectTrigger id="onboarding-region" className="w-full" aria-label={t("region.label")}>
-            <SelectValue placeholder={t("region.placeholder")} />
+            <SelectValue placeholder={t("region.placeholder")}>
+              {(value: string) =>
+                `${PLATFORM_LABELS[value as keyof typeof PLATFORM_LABELS]} (${value})`
+              }
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             {PLATFORM_IDS.map((id) => (


### PR DESCRIPTION
## Summary

- Fixes all `SelectValue` components that only used the `placeholder` prop, which causes Base UI to display raw value strings instead of human-readable labels
- Applies the children render function pattern (`{(value) => labels[value]}`) to 8 remaining broken selects across 5 files

**Files changed:**
- `action-items-client.tsx` — status filter, topic filter
- `settings/page.tsx` — region, language, locale selectors
- `new-goal-client.tsx` — tier, division selectors
- `onboarding-client.tsx` — region selector
- `matches-client.tsx` — result, champion, review status filters (fixed in prior commit on this branch)

Fixes #244