### PR TITLE
fix: navigate to correct page and scroll to match via matchId param

### DIFF
--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -695,28 +695,29 @@ export function ReviewClient({
   }, [pendingMatches, expandedId]);
 
   // Navigate to the correct page and scroll to the target match when initialMatchId is set
-  const hasNavigatedToMatch = useRef(false);
+  const prevMatchIdRef = useRef<string | undefined>(undefined);
   useEffect(() => {
-    if (hasNavigatedToMatch.current || !initialMatchId || pendingMatches.length === 0) return;
+    if (!initialMatchId || pendingMatches.length === 0) return;
+    // Only act when initialMatchId actually changes (handles client-side navigation)
+    if (prevMatchIdRef.current === initialMatchId) return;
+    prevMatchIdRef.current = initialMatchId;
+
+    // Sync expandedId to the new target match
+    setExpandedId(initialMatchId);
+
     const idx = pendingMatches.findIndex((m) => m.id === initialMatchId);
     if (idx === -1) return; // match not found (already reviewed or invalid)
     const targetPage = Math.ceil((idx + 1) / PAGE_SIZE);
-    if (targetPage !== pendingPage) {
-      setPendingPage(targetPage);
-    }
-    hasNavigatedToMatch.current = true;
-  }, [initialMatchId, pendingMatches, pendingPage]);
+    setPendingPage(targetPage);
 
-  // Scroll to target match card once it's rendered
-  useEffect(() => {
-    if (!initialMatchId || !hasNavigatedToMatch.current) return;
-    const el = document.querySelector(`[data-match-id="${initialMatchId}"]`);
-    if (!el) return;
-    // Wait one frame for layout to settle after page change
+    // Scroll to the card after React commits the page change
     requestAnimationFrame(() => {
-      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      requestAnimationFrame(() => {
+        const el = document.querySelector(`[data-match-id="${initialMatchId}"]`);
+        el?.scrollIntoView({ behavior: "smooth", block: "center" });
+      });
     });
-  }, [initialMatchId, pendingPage]);
+  }, [initialMatchId, pendingMatches]);
 
   const handleReviewed = useCallback(
     (matchId: string) => {

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -38,7 +38,7 @@ import {
   type TopicOption,
 } from "@/components/highlights-editor";
 import { MarkdownTextarea } from "@/components/markdown-textarea";
-import { Pagination, paginate } from "@/components/pagination";
+import { Pagination, paginate, PAGE_SIZE } from "@/components/pagination";
 import { PositionIcon, getRoleRelevance, getPositionLabel } from "@/components/position-icon";
 import { ResultBadge, ResultBar } from "@/components/result-badge";
 import { TopicClickGrid, type TopicToggle } from "@/components/topic-click-grid";
@@ -278,7 +278,7 @@ function PendingReviewCard({
   }, [match.id, selected, comment, vodUrl, outcomes, onReviewed, t]);
 
   return (
-    <Card className="surface-glow">
+    <Card className="surface-glow" data-match-id={match.id}>
       <CardHeader className="pb-3">
         <div className="flex w-full items-center gap-3">
           <button
@@ -693,6 +693,30 @@ export function ReviewClient({
       hasAutoExpanded.current = true;
     }
   }, [pendingMatches, expandedId]);
+
+  // Navigate to the correct page and scroll to the target match when initialMatchId is set
+  const hasNavigatedToMatch = useRef(false);
+  useEffect(() => {
+    if (hasNavigatedToMatch.current || !initialMatchId || pendingMatches.length === 0) return;
+    const idx = pendingMatches.findIndex((m) => m.id === initialMatchId);
+    if (idx === -1) return; // match not found (already reviewed or invalid)
+    const targetPage = Math.ceil((idx + 1) / PAGE_SIZE);
+    if (targetPage !== pendingPage) {
+      setPendingPage(targetPage);
+    }
+    hasNavigatedToMatch.current = true;
+  }, [initialMatchId, pendingMatches, pendingPage]);
+
+  // Scroll to target match card once it's rendered
+  useEffect(() => {
+    if (!initialMatchId || !hasNavigatedToMatch.current) return;
+    const el = document.querySelector(`[data-match-id="${initialMatchId}"]`);
+    if (!el) return;
+    // Wait one frame for layout to settle after page change
+    requestAnimationFrame(() => {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+  }, [initialMatchId, pendingPage]);
 
   const handleReviewed = useCallback(
     (matchId: string) => {


### PR DESCRIPTION
## Summary

- When visiting `/review?matchId=xxx`, the page now navigates to the correct pagination page and scrolls the target match card into view
- Previously `pendingPage` always started at 1, so matches on page 2+ were invisible even though `expandedId` was set correctly
- Adds `data-match-id` attribute to review cards for scroll targeting

Fixes #248