### PR TITLE
fix: filter action items by match date to prevent stale items on old matches

### DIFF
--- a/changelog/en/2026-04-22-action-items-date-filter.mdx
+++ b/changelog/en/2026-04-22-action-items-date-filter.mdx
@@ -1,0 +1,10 @@
+---
+version: "2026.04.26"
+date: "2026-04-22"
+title: "Action items now match the game they belong to"
+tags: ["fix"]
+---
+
+Action items from coaching sessions used to show up on every unreviewed match — even games played **before** the action item was created. Now, action items only appear on matches played after they were created, so your review check-ins stay relevant to each game.
+
+The same fix applies to AI-generated post-game insights, which no longer reference action items that didn't exist yet when the match was played.

--- a/changelog/es/2026-04-22-action-items-date-filter.mdx
+++ b/changelog/es/2026-04-22-action-items-date-filter.mdx
@@ -1,0 +1,10 @@
+---
+version: "2026.04.26"
+date: "2026-04-22"
+title: "Los elementos de acción ahora corresponden al juego correcto"
+tags: ["fix"]
+---
+
+Los elementos de acción de las sesiones de coaching aparecían en todas las partidas sin revisar, incluso en partidas jugadas **antes** de que se creara el elemento de acción. Ahora, los elementos de acción solo aparecen en partidas jugadas después de su creación, para que el repaso de cada partida sea más relevante.
+
+La misma corrección aplica a los análisis post-partida generados por IA, que ya no hacen referencia a elementos de acción que no existían cuando se jugó la partida.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lol-tracker",
-  "version": "2026.04.25",
+  "version": "2026.04.26",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -81,7 +81,12 @@ interface ReviewClientProps {
   reviewedTotal: number;
   initialTab: "pending" | "reviewed";
   topics: TopicOption[];
-  activeActionItems: Array<{ id: number; description: string; topicId: number | null }>;
+  activeActionItems: Array<{
+    id: number;
+    description: string;
+    topicId: number | null;
+    createdAt: Date;
+  }>;
   initialMatchId?: string;
   readOnly?: boolean;
 }
@@ -223,7 +228,12 @@ function PendingReviewCard({
   onToggleExpand: () => void;
   priorityScore: number;
   topics: TopicOption[];
-  activeActionItems: Array<{ id: number; description: string; topicId: number | null }>;
+  activeActionItems: Array<{
+    id: number;
+    description: string;
+    topicId: number | null;
+    createdAt: Date;
+  }>;
 }) {
   // Convert existing highlights to TopicToggle format
   const initialSelected: TopicToggle[] = existingHighlights
@@ -237,8 +247,12 @@ function PendingReviewCard({
   const [selected, setSelected] = useState<TopicToggle[]>(initialSelected);
   const [comment, setComment] = useState(match.comment || "");
   const [vodUrl, setVodUrl] = useState(match.vodUrl || "");
+  // Only show action items that existed before this match was played
+  const matchActionItems = activeActionItems.filter(
+    (ai) => ai.createdAt.getTime() <= match.gameDate.getTime(),
+  );
   const [outcomes, setOutcomes] = useState<ActionItemOutcome[]>(
-    activeActionItems.map((ai) => ({
+    matchActionItems.map((ai) => ({
       actionItemId: ai.id,
       description: ai.description,
       topicName: ai.topicId ? topics.find((t) => t.id === ai.topicId)?.name : undefined,

--- a/src/lib/ai/context.ts
+++ b/src/lib/ai/context.ts
@@ -301,6 +301,7 @@ export async function buildPostGameContext(
           and(
             eq(coachingActionItems.userId, userId),
             sql`${coachingActionItems.status} != 'completed'`,
+            sql`${coachingActionItems.createdAt} <= ${match.gameDate.getTime()}`,
           ),
         ),
       db

--- a/src/lib/queries/review.ts
+++ b/src/lib/queries/review.ts
@@ -102,7 +102,7 @@ export async function getReviewData(
     // Fetch active action items for the check-in during review
     db.query.coachingActionItems.findMany({
       where: and(eq(coachingActionItems.userId, userId), eq(coachingActionItems.status, "active")),
-      columns: { id: true, description: true, topicId: true },
+      columns: { id: true, description: true, topicId: true, createdAt: true },
     }),
   ]);
 


### PR DESCRIPTION
## Summary

- Action items from coaching sessions were appearing on matches played **before** the item was created
- Added `createdAt` to the review page action items query and filter per match in the client (`createdAt <= gameDate`)
- Added date filter to the AI post-game insight context query so coaching prompts only reference relevant action items

Fixes #252

## Changelog

- Version 2026.04.26: Action items now only appear on matches played after they were created, both in review check-ins and AI post-game insights