### PR TITLE
feat: add sort toggle to action items page

### DIFF
--- a/changelog/en/2026-04-22-action-items-sort-toggle.mdx
+++ b/changelog/en/2026-04-22-action-items-sort-toggle.mdx
@@ -1,0 +1,8 @@
+---
+version: "2026.04.27"
+date: "2026-04-22"
+title: "Sort your action items by newest or oldest"
+tags: ["feature"]
+---
+
+The action items page now has a sort toggle next to the existing filters. You can sort by **newest first** (default) or **oldest first** to find the items you care about faster.

--- a/changelog/es/2026-04-22-action-items-sort-toggle.mdx
+++ b/changelog/es/2026-04-22-action-items-sort-toggle.mdx
@@ -1,0 +1,8 @@
+---
+version: "2026.04.27"
+date: "2026-04-22"
+title: "Ordena tus tareas por más recientes o más antiguas"
+tags: ["feature"]
+---
+
+La página de tareas ahora tiene un control de orden junto a los filtros existentes. Puedes ordenar por **más recientes** (por defecto) o **más antiguas** para encontrar las tareas que te importan más rápido.

--- a/messages/en.json
+++ b/messages/en.json
@@ -589,6 +589,11 @@
       "deleteError": "Failed to delete action item.",
       "itemCreated": "Action item created!",
       "createError": "Failed to create action item."
+    },
+    "sort": {
+      "label": "Sort order",
+      "newestFirst": "Newest first",
+      "oldestFirst": "Oldest first"
     }
   },
   "ScheduleSession": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -589,6 +589,11 @@
       "deleteError": "Error al eliminar la tarea.",
       "itemCreated": "¡Tarea creada!",
       "createError": "Error al crear la tarea."
+    },
+    "sort": {
+      "label": "Orden",
+      "newestFirst": "Más recientes",
+      "oldestFirst": "Más antiguas"
     }
   },
   "ScheduleSession": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lol-tracker",
-  "version": "2026.04.26",
+  "version": "2026.04.27",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/src/app/(app)/coaching/action-items/action-items-client.tsx
+++ b/src/app/(app)/coaching/action-items/action-items-client.tsx
@@ -3,7 +3,7 @@
 import { Loader2, Circle, Play, CheckCircle2, Trash2, ListChecks, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
-import { useState, useTransition } from "react";
+import { useState, useMemo, useTransition } from "react";
 import { toast } from "sonner";
 
 import { updateActionItemStatus, deleteActionItem, createActionItem } from "@/app/actions/coaching";
@@ -167,6 +167,7 @@ export function ActionItemsClient({ items, topicNames, outcomeStats }: ActionIte
   const t = useTranslations("ActionItems");
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [topicFilter, setTopicFilter] = useState<string>("all");
+  const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
   const [page, setPage] = useState(1);
   const [showAddForm, setShowAddForm] = useState(false);
   const [newDescription, setNewDescription] = useState("");
@@ -175,11 +176,19 @@ export function ActionItemsClient({ items, topicNames, outcomeStats }: ActionIte
 
   const topics = [...new Set(items.map((i) => i.topicId).filter(Boolean))] as number[];
 
-  const filtered = items.filter((item) => {
-    if (statusFilter !== "all" && item.status !== statusFilter) return false;
-    if (topicFilter !== "all" && item.topicId !== Number(topicFilter)) return false;
-    return true;
-  });
+  const filtered = useMemo(() => {
+    const result = items.filter((item) => {
+      if (statusFilter !== "all" && item.status !== statusFilter) return false;
+      if (topicFilter !== "all" && item.topicId !== Number(topicFilter)) return false;
+      return true;
+    });
+    if (sortOrder === "newest") {
+      result.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    } else {
+      result.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    }
+    return result;
+  }, [items, statusFilter, topicFilter, sortOrder]);
 
   // Clamp page if filters reduce result count
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
@@ -319,6 +328,29 @@ export function ActionItemsClient({ items, topicNames, outcomeStats }: ActionIte
             </SelectContent>
           </Select>
         )}
+        <Select
+          value={sortOrder}
+          onValueChange={(v) => {
+            setSortOrder(v as "newest" | "oldest");
+            setPage(1);
+          }}
+        >
+          <SelectTrigger className="w-[150px]" aria-label={t("sort.label")}>
+            <SelectValue placeholder={t("sort.newestFirst")}>
+              {(value: string) => {
+                const labels: Record<string, string> = {
+                  newest: t("sort.newestFirst"),
+                  oldest: t("sort.oldestFirst"),
+                };
+                return labels[value] ?? value;
+              }}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="newest">{t("sort.newestFirst")}</SelectItem>
+            <SelectItem value="oldest">{t("sort.oldestFirst")}</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
 
       {/* Items */}


### PR DESCRIPTION
## Summary

- Adds a newest/oldest sort dropdown to the action items page, letting users control display order
- Uses the same `Select` component pattern as the review page filters
- Default sort is newest first (most recently created action items on top)

Fixes #251

## Changes

- `action-items-client.tsx`: Added `sortOrder` state, `useMemo` for filtering+sorting, and `Select` dropdown
- `messages/en.json` / `messages/es.json`: Added `ActionItems.sort.*` i18n keys
- `package.json`: Version bump to 2026.04.27
- Changelog entries (en/es)