### PR TITLE
chore: add migration safety check to block destructive schema changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,12 +92,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version-file: ".tool-versions"
           cache: npm
       - run: npm ci
-      - run: npm run test:migration
+      - name: Check migration safety (destructive patterns)
+        run: npm run test:migration-safety
+      - name: Run migration integrity tests
+        run: npm run test:migration
 
   build:
     name: Build

--- a/.opencode/skills/drizzle-schema/SKILL.md
+++ b/.opencode/skills/drizzle-schema/SKILL.md
@@ -131,6 +131,69 @@ Always add indexes when:
 5. **Write a `.validate.sql` companion file.**
    For any migration that creates tables or moves data, write `drizzle/XXXX_name.validate.sql` with assertions that verify data integrity. The migration runner executes these after applying the migration. See `scripts/migrate.ts` for the validation mechanism.
 
+## Destructive migrations — MANDATORY expand-contract pattern
+
+**CI blocks all destructive migrations.** The `migration-safety` CI check (`scripts/check-migration-safety.ts`) scans new migration SQL for `DROP TABLE`, `DROP COLUMN`, and `RENAME COLUMN` patterns. If found, CI fails and the PR cannot merge. There is no override mechanism — this is a hard blocker.
+
+**Why**: Migrations run before `next build` on Vercel. The old deployment still serves traffic while the build runs. Destructive schema changes break the old code immediately, causing downtime until the new deployment goes live (minutes later).
+
+**Incident reference**: PR #243 dropped columns from the `matches` table during deploy, causing a brief production outage (issue #246).
+
+### The expand-contract pattern
+
+All destructive schema changes MUST be split across multiple PRs:
+
+**Phase 1 (PR 1) — Expand:**
+
+- Add new columns/tables
+- Deploy code that works with BOTH old and new schema
+- No drops, no renames
+
+**Phase 2 (PR 2, optional) — Migrate:**
+
+- Backfill data from old columns to new columns
+- Can be a data migration script or a SQL migration
+
+**Phase 3 (PR 3, AFTER Phase 1 is live and verified) — Contract:**
+
+- Drop old columns/tables in a separate migration
+- Only safe because no running code references them anymore
+
+### Example: renaming a column
+
+```
+-- BAD: Single migration (CI will block this)
+ALTER TABLE matches RENAME COLUMN review_notes TO notes;
+
+-- GOOD: Three-phase approach
+-- Phase 1 migration: Add new column
+ALTER TABLE matches ADD COLUMN notes text;
+-- Phase 1 code: Write to BOTH columns, read from new (fallback to old)
+
+-- Phase 2 migration: Backfill
+UPDATE matches SET notes = review_notes WHERE notes IS NULL AND review_notes IS NOT NULL;
+
+-- Phase 3 migration (separate PR): Drop old column
+ALTER TABLE matches DROP COLUMN review_notes;
+```
+
+### Example: recreating a table to change column constraints
+
+```
+-- BAD: Single migration with table recreation (CI will block this)
+CREATE TABLE match_highlights_new (...);
+INSERT INTO match_highlights_new SELECT * FROM match_highlights;
+DROP TABLE match_highlights;
+ALTER TABLE match_highlights_new RENAME TO match_highlights;
+
+-- GOOD: Use ALTER TABLE to add/modify columns where possible
+-- If SQLite doesn't support the needed ALTER, split across phases:
+-- Phase 1: Create new table + copy data + deploy code that reads from new table
+-- Phase 3: Drop old table (separate PR)
+```
+
+**NEVER generate a single migration that adds new columns AND drops old ones.** Always split into separate PRs.
+
 ## Data sync (db-push / db-pull)
 
 ### Safety rules

--- a/.opencode/skills/pr-workflow/SKILL.md
+++ b/.opencode/skills/pr-workflow/SKILL.md
@@ -54,6 +54,7 @@ Branch naming conventions:
   npm run test:e2e
   ```
 - **MANDATORY: Verify the lockfile before every push** (when `package-lock.json` is staged). Run `npm ci` to confirm the lockfile is consistent. If it fails, regenerate with `npm install`. The canonical Node version is defined in `.tool-versions` — both local dev and CI use the same version.
+- **MANDATORY: Destructive migrations are blocked by CI.** If the PR adds migration SQL containing `DROP TABLE`, `DROP COLUMN`, or `RENAME COLUMN`, the `migration-safety` CI check will fail and the PR cannot merge. Use the expand-contract pattern (split across multiple PRs). See the `drizzle-schema` skill for the full pattern and examples.
 
 ### 3. Write a changelog entry
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,22 @@ Steps after any schema change:
 
 Full workflow details are in the `vercel-turso-deploy` OpenCode skill.
 
+## Destructive migrations — MANDATORY expand-contract pattern
+
+**CI blocks all destructive migrations.** The `migration-safety` check (`scripts/check-migration-safety.ts`) scans new migration SQL for `DROP TABLE`, `DROP COLUMN`, and `RENAME COLUMN` patterns. If found, CI fails and the PR cannot merge.
+
+**Why**: Migrations run before `next build` on Vercel. The old deployment still serves traffic while the build runs. Destructive schema changes break the old code immediately, causing downtime until the new deployment goes live (minutes later).
+
+**Incident reference**: PR #243 dropped columns from the `matches` table during deploy, causing a production outage (issue #246).
+
+**The expand-contract pattern is mandatory for all destructive changes:**
+
+- **Phase 1** (PR 1): Add new columns/tables. Deploy code that works with BOTH old and new schema. No drops.
+- **Phase 2** (PR 2, optional): Backfill/migrate data if needed.
+- **Phase 3** (PR 3, AFTER Phase 1 is live and verified): Drop old columns/tables in a separate migration. This is safe because no running code references them.
+
+**NEVER generate a single migration that adds new columns AND drops old ones.** Split into separate PRs. See the `drizzle-schema` skill for detailed examples.
+
 <!-- END:turso-migration-rules -->
 
 <!-- BEGIN:env-safety-rules -->

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "db:seed": "tsx scripts/seed.ts",
     "db:seed-demo": "tsx scripts/seed-demo.ts",
     "test:migration": "tsx scripts/test-migration.ts",
+    "test:migration-safety": "tsx scripts/check-migration-safety.ts",
     "test:smoke": "playwright test --project=smoke",
     "test:e2e": "playwright test --project=e2e",
     "prepare": "lefthook install",

--- a/scripts/check-migration-safety.ts
+++ b/scripts/check-migration-safety.ts
@@ -1,0 +1,161 @@
+// scripts/check-migration-safety.ts
+// Scans new/pending migration SQL files for destructive patterns that would
+// cause downtime if applied while the old deployment is still serving traffic.
+//
+// Detected patterns:
+//   - DROP TABLE
+//   - DROP COLUMN (via ALTER TABLE ... DROP COLUMN)
+//   - ALTER TABLE ... RENAME COLUMN
+//   - Table recreation (CREATE TABLE + INSERT INTO ... SELECT + DROP TABLE)
+//
+// This is a HARD BLOCKER in CI. Destructive migrations must use the
+// expand-contract pattern across multiple deploys:
+//   Phase 1: Add new columns/tables, deploy code that works with both schemas
+//   Phase 2: Backfill/migrate data
+//   Phase 3: Drop old columns/tables (separate PR, after Phase 1 is live)
+//
+// Usage:
+//   npx tsx scripts/check-migration-safety.ts
+//
+// The script compares migrations in drizzle/meta/_journal.json against those
+// already committed on the main branch. Only NEW migrations (not on main) are
+// checked, so historical destructive migrations don't trigger false positives.
+
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+interface Violation {
+  file: string;
+  line: number;
+  pattern: string;
+  statement: string;
+}
+
+const DANGEROUS_PATTERNS: Array<{ name: string; regex: RegExp }> = [
+  { name: "DROP TABLE", regex: /\bDROP\s+TABLE\b/i },
+  { name: "DROP COLUMN", regex: /\bALTER\s+TABLE\b[^;]*\bDROP\s+COLUMN\b/i },
+  {
+    name: "RENAME COLUMN",
+    regex: /\bALTER\s+TABLE\b[^;]*\bRENAME\s+COLUMN\b/i,
+  },
+];
+
+function getBaselineTags(): Set<string> {
+  // Get the journal from origin/main to know which migrations already exist.
+  // If we can't read it (e.g., new repo, no remote), treat all as new.
+  try {
+    const mainJournalContent = execSync(
+      "git show origin/main:drizzle/meta/_journal.json 2>/dev/null",
+      {
+        encoding: "utf-8",
+      },
+    );
+    const mainJournal: Journal = JSON.parse(mainJournalContent);
+    return new Set(mainJournal.entries.map((e) => e.tag));
+  } catch {
+    // If origin/main doesn't exist or doesn't have the journal, all migrations are "new"
+    // But we don't want to flag historical migrations in that case, so return all current tags
+    // (this effectively means: no new migrations to check)
+    console.log("⚠ Could not read journal from origin/main — checking all migrations in journal.");
+    return new Set<string>();
+  }
+}
+
+function main() {
+  const journalPath = path.resolve(__dirname, "../drizzle/meta/_journal.json");
+  if (!fs.existsSync(journalPath)) {
+    console.log("No drizzle journal found — nothing to check.");
+    process.exit(0);
+  }
+
+  const journal: Journal = JSON.parse(fs.readFileSync(journalPath, "utf-8"));
+  const baselineTags = getBaselineTags();
+
+  // Only check migrations that are NOT on main (i.e., new in this PR)
+  const newEntries = journal.entries.filter((e) => !baselineTags.has(e.tag));
+
+  if (newEntries.length === 0) {
+    console.log("✓ No new migrations to check.");
+    process.exit(0);
+  }
+
+  console.log(`Checking ${newEntries.length} new migration(s) for destructive patterns...\n`);
+
+  const violations: Violation[] = [];
+
+  for (const entry of newEntries) {
+    const sqlPath = path.resolve(__dirname, `../drizzle/${entry.tag}.sql`);
+    if (!fs.existsSync(sqlPath)) {
+      console.warn(`⚠ SQL file not found: ${entry.tag}.sql — skipping.`);
+      continue;
+    }
+
+    const content = fs.readFileSync(sqlPath, "utf-8");
+    const lines = content.split("\n");
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      for (const pattern of DANGEROUS_PATTERNS) {
+        if (pattern.regex.test(line)) {
+          violations.push({
+            file: `drizzle/${entry.tag}.sql`,
+            line: i + 1,
+            pattern: pattern.name,
+            statement: line.trim().slice(0, 120),
+          });
+        }
+      }
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log("✓ All new migrations are safe — no destructive patterns found.");
+    process.exit(0);
+  }
+
+  // Report violations
+  console.error("✗ DESTRUCTIVE MIGRATION DETECTED\n");
+  console.error("The following migration(s) contain patterns that would cause downtime");
+  console.error("if applied while the old deployment is still serving traffic:\n");
+
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}`);
+    console.error(`    Pattern: ${v.pattern}`);
+    console.error(`    SQL:     ${v.statement}`);
+    console.error("");
+  }
+
+  console.error("─".repeat(70));
+  console.error("");
+  console.error("These changes MUST use the expand-contract pattern:");
+  console.error("");
+  console.error("  Phase 1 (this PR): Add new columns/tables. Deploy code that");
+  console.error("    works with BOTH old and new schema.");
+  console.error("");
+  console.error("  Phase 2 (separate PR): Backfill/migrate data if needed.");
+  console.error("");
+  console.error("  Phase 3 (separate PR, AFTER Phase 1 is live): Drop old");
+  console.error("    columns/tables. Only safe once no running code references them.");
+  console.error("");
+  console.error("See the drizzle-schema skill for detailed examples.");
+  console.error("");
+
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds `scripts/check-migration-safety.ts` — a CI-enforced lint that scans new migration SQL for `DROP TABLE`, `DROP COLUMN`, and `RENAME COLUMN` patterns
- Hard blocker in CI (no override) — destructive migrations must use the expand-contract pattern across multiple PRs
- Updated the `migration` CI job to run the safety check before the existing integrity tests
- Updated `AGENTS.md`, `drizzle-schema` skill, and `pr-workflow` skill so the AI knows these rules and follows them

Fixes #245
Fixes #246