### PR TITLE
fix: add lazy loading to changelog images

### DIFF
--- a/src/app/(app)/changelog/changelog-image.tsx
+++ b/src/app/(app)/changelog/changelog-image.tsx
@@ -36,7 +36,7 @@ export function ChangelogImage(props: React.ImgHTMLAttributes<HTMLImageElement>)
           onClick={() => setOpen(true)}
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img {...props} alt={props.alt ?? ""} />
+          <img {...props} alt={props.alt ?? ""} loading="lazy" />
           <span className="changelog-zoom-icon" aria-hidden="true">
             <svg
               width="20"


### PR DESCRIPTION
## Summary

- Add `loading="lazy"` to the `<img>` tag in `ChangelogImage` component, which all 153 changelog images route through
- This defers loading of offscreen images, improving initial page load performance on the changelog page

Fixes #271