### PR TITLE
feat: add GDPR PUUID scrubbing for Riot deletion requests

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1141,8 +1141,17 @@
       "deleteError": "Failed to delete invite.",
       "codeCopied": "Invite code copied to clipboard.",
       "linkCopied": "Invite link copied to clipboard.",
-      "impersonateError": "Failed to start impersonation."
-    }
+      "impersonateError": "Failed to start impersonation.",
+      "scrubSuccess": "PUUID scrubbed from {count} match records. {duoCount} duo references cleared.",
+      "scrubError": "Failed to scrub PUUID.",
+      "scrubBelongsToUser": "This PUUID belongs to a registered user. Use account deletion instead."
+    },
+    "gdprHeading": "Data deletion requests",
+    "gdprDescription": "Process GDPR deletion requests from Riot Games by scrubbing a player's PUUID from stored match data.",
+    "gdprPuuidLabel": "PUUID to scrub",
+    "gdprPuuidPlaceholder": "Enter the PUUID to remove from all match data",
+    "gdprScrubButton": "Scrub PUUID",
+    "gdprWarning": "This permanently redacts the player's identifiable data from all stored match records. This action cannot be undone."
   },
   "Impersonation": {
     "banner": "Viewing as {name} — logged in as {admin} (read-only)",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1141,8 +1141,17 @@
       "deleteError": "Error al eliminar invitación.",
       "codeCopied": "Código de invitación copiado al portapapeles.",
       "linkCopied": "Enlace de invitación copiado al portapapeles.",
-      "impersonateError": "Error al iniciar la suplantación."
-    }
+      "impersonateError": "Error al iniciar la suplantación.",
+      "scrubSuccess": "PUUID eliminado de {count} registros de partida. {duoCount} referencias de dúo limpiadas.",
+      "scrubError": "Error al eliminar el PUUID.",
+      "scrubBelongsToUser": "Este PUUID pertenece a un usuario registrado. Usa la eliminación de cuenta en su lugar."
+    },
+    "gdprHeading": "Solicitudes de eliminación de datos",
+    "gdprDescription": "Procesa solicitudes de eliminación RGPD de Riot Games eliminando el PUUID de un jugador de los datos de partidas almacenados.",
+    "gdprPuuidLabel": "PUUID a eliminar",
+    "gdprPuuidPlaceholder": "Ingresa el PUUID a eliminar de todos los datos de partidas",
+    "gdprScrubButton": "Eliminar PUUID",
+    "gdprWarning": "Esto elimina permanentemente los datos identificables del jugador de todos los registros de partidas almacenados. Esta acción no se puede deshacer."
   },
   "Impersonation": {
     "banner": "Viendo como {name} — sesión de {admin} (solo lectura)",

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -7,6 +7,7 @@ import {
   Loader2,
   Plus,
   Shield,
+  ShieldAlert,
   Trash2,
   Ticket,
   UserCheck,
@@ -24,6 +25,7 @@ import {
   reactivateUser,
   updateUserRole,
   startImpersonation,
+  scrubPuuidFromAllData,
   type AdminUser,
 } from "@/app/actions/admin";
 import { createInvite, getInvites, deleteInvite } from "@/app/actions/invites";
@@ -497,6 +499,80 @@ function InvitesSection() {
   );
 }
 
+// ─── GDPR Deletion Section ──────────────────────────────────────────────────
+
+function GdprSection() {
+  const t = useTranslations("Admin");
+  const [puuid, setPuuid] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  function handleScrub() {
+    if (!puuid.trim()) return;
+
+    startTransition(async () => {
+      try {
+        const result = await scrubPuuidFromAllData(puuid.trim());
+        if (!result.success && result.error === "PUUID_BELONGS_TO_USER") {
+          toast.error(t("toasts.scrubBelongsToUser"));
+          return;
+        }
+        if (result.success) {
+          toast.success(
+            t("toasts.scrubSuccess", {
+              count: result.matchJsonsScrubbed ?? 0,
+              duoCount: result.duoReferencesCleared ?? 0,
+            }),
+          );
+          setPuuid("");
+        }
+      } catch {
+        toast.error(t("toasts.scrubError"));
+      }
+    });
+  }
+
+  return (
+    <Card className="surface-glow">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <ShieldAlert className="h-5 w-5 text-gold" />
+          {t("gdprHeading")}
+        </CardTitle>
+        <CardDescription>{t("gdprDescription")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-destructive">{t("gdprWarning")}</p>
+        <div className="flex gap-2">
+          <label className="sr-only" htmlFor="gdpr-puuid-input">
+            {t("gdprPuuidLabel")}
+          </label>
+          <input
+            id="gdpr-puuid-input"
+            type="text"
+            value={puuid}
+            onChange={(e) => setPuuid(e.target.value)}
+            placeholder={t("gdprPuuidPlaceholder")}
+            className="flex-1 rounded-md border border-border/50 bg-surface-elevated px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:border-gold/50 focus:ring-1 focus:ring-gold/30 focus:outline-none"
+          />
+          <Button
+            onClick={handleScrub}
+            disabled={isPending || !puuid.trim()}
+            variant="destructive"
+            size="sm"
+          >
+            {isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <ShieldAlert className="mr-2 h-4 w-4" />
+            )}
+            {t("gdprScrubButton")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 // ─── Page ───────────────────────────────────────────────────────────────────
 
 export default function AdminPage() {
@@ -519,6 +595,7 @@ export default function AdminPage() {
       </div>
       <UsersSection />
       <InvitesSection />
+      <GdprSection />
     </div>
   );
 }

--- a/src/app/actions/admin.ts
+++ b/src/app/actions/admin.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import { eq, sql } from "drizzle-orm";
+import { eq, like, sql } from "drizzle-orm";
 import { cookies } from "next/headers";
 
 import { db } from "@/db";
-import { users } from "@/db/schema";
+import { users, matches, riotAccounts } from "@/db/schema";
 import { isDemoUserId } from "@/lib/fake-auth";
 import { IMPERSONATE_COOKIE, requireAdmin } from "@/lib/session";
 
@@ -183,4 +183,128 @@ export async function stopImpersonation() {
 
   // Same as above — client handles navigation after session refresh.
   return { success: true };
+}
+
+// ─── GDPR PUUID Scrubbing ───────────────────────────────────────────────────
+
+/**
+ * Scrub a PUUID from all stored data. Used to process GDPR deletion requests
+ * received from Riot Games for non-registered players whose data appears in
+ * stored match records (rawMatchJson blobs).
+ *
+ * What this does:
+ * 1. If any registered user has this PUUID → deletes their account (full cascade)
+ * 2. Nulls out duoPartnerPuuid references on any matches
+ * 3. Scrubs the PUUID, summoner name, and game name from all rawMatchJson blobs
+ *
+ * Returns the count of affected matches for confirmation.
+ */
+export async function scrubPuuidFromAllData(puuid: string) {
+  await requireAdmin();
+
+  // Validate PUUID format (Riot PUUIDs are 78-char hex strings with hyphens)
+  if (!puuid || !/^[\da-f-]{40,80}$/i.test(puuid.trim())) {
+    throw new Error("Invalid PUUID format");
+  }
+
+  const normalizedPuuid = puuid.trim();
+
+  // ── 1. Check if any registered user owns this PUUID ────────────────────
+  const linkedAccount = await db.query.riotAccounts.findFirst({
+    where: eq(riotAccounts.puuid, normalizedPuuid),
+  });
+
+  if (linkedAccount) {
+    // This PUUID belongs to a registered user — their deleteAccount flow handles it.
+    // We don't cascade-delete from admin to avoid accidentally nuking a real user.
+    return {
+      success: false,
+      error: "PUUID_BELONGS_TO_USER" as const,
+      userId: linkedAccount.userId,
+    };
+  }
+
+  // ── 2. Null out duoPartnerPuuid on matches ─────────────────────────────
+  const duoResult = await db
+    .update(matches)
+    .set({
+      duoPartnerPuuid: null,
+      duoPartnerChampionName: null,
+      duoPartnerKills: null,
+      duoPartnerDeaths: null,
+      duoPartnerAssists: null,
+    })
+    .where(eq(matches.duoPartnerPuuid, normalizedPuuid));
+
+  // ── 3. Scrub PUUID from rawMatchJson blobs ─────────────────────────────
+  // Find all matches whose rawMatchJson contains this PUUID
+  const affectedMatches = await db
+    .select({ id: matches.id, userId: matches.userId, rawMatchJson: matches.rawMatchJson })
+    .from(matches)
+    .where(like(matches.rawMatchJson, `%${normalizedPuuid}%`));
+
+  let scrubbedCount = 0;
+
+  for (const match of affectedMatches) {
+    if (!match.rawMatchJson) continue;
+
+    try {
+      const json = JSON.parse(match.rawMatchJson);
+      const scrubbed = scrubPuuidFromMatchJson(json, normalizedPuuid);
+
+      await db
+        .update(matches)
+        .set({ rawMatchJson: JSON.stringify(scrubbed) })
+        .where(sql`${matches.id} = ${match.id} AND ${matches.userId} = ${match.userId}`);
+
+      scrubbedCount++;
+    } catch {
+      // If JSON is malformed, do a simple string replacement as fallback
+      const replaced = match.rawMatchJson.replaceAll(normalizedPuuid, "[REDACTED]");
+      await db
+        .update(matches)
+        .set({ rawMatchJson: replaced })
+        .where(sql`${matches.id} = ${match.id} AND ${matches.userId} = ${match.userId}`);
+      scrubbedCount++;
+    }
+  }
+
+  return {
+    success: true,
+    duoReferencesCleared: duoResult.rowsAffected ?? 0,
+    matchJsonsScrubbed: scrubbedCount,
+  };
+}
+
+/**
+ * Scrub a specific PUUID's identifiable data from a parsed Riot match JSON.
+ * Replaces the PUUID, summonerName, riotIdGameName, and riotIdTagline
+ * with "[REDACTED]" in the participant entry matching the given PUUID.
+ */
+function scrubPuuidFromMatchJson(json: Record<string, unknown>, puuid: string) {
+  // The Riot match JSON structure: { info: { participants: [...] }, metadata: { participants: [...] } }
+  const info = json.info as Record<string, unknown> | undefined;
+  const metadata = json.metadata as Record<string, unknown> | undefined;
+
+  // Scrub from metadata.participants (array of PUUID strings)
+  if (metadata?.participants && Array.isArray(metadata.participants)) {
+    metadata.participants = (metadata.participants as string[]).map((p) =>
+      p === puuid ? "[REDACTED]" : p,
+    );
+  }
+
+  // Scrub from info.participants (array of participant objects)
+  if (info?.participants && Array.isArray(info.participants)) {
+    for (const participant of info.participants as Record<string, unknown>[]) {
+      if (participant.puuid === puuid) {
+        participant.puuid = "[REDACTED]";
+        participant.summonerName = "[REDACTED]";
+        participant.riotIdGameName = "[REDACTED]";
+        participant.riotIdTagline = "[REDACTED]";
+        break;
+      }
+    }
+  }
+
+  return json;
 }


### PR DESCRIPTION
## Summary

- Adds `scrubPuuidFromAllData()` admin server action to process Riot Games GDPR deletion requests
- Scrubs PUUID, summoner name, game name, and tag line from `rawMatchJson` blobs, replacing with `"[REDACTED]"`
- Clears `duoPartnerPuuid` and denormalized duo stats on affected matches
- Safely blocks scrubbing if the PUUID belongs to a registered user (directs to account deletion instead)
- Adds admin UI section with PUUID input field and destructive action button
- Full EN/ES i18n support

Fixes #298

## Notes

- Admin-only feature — fails the changelog litmus test (players would never see this)
- The scrubbing is irreversible by design (GDPR compliance)
- Works alongside the existing `deleteAccount()` flow: that handles registered users, this handles non-user PUUIDs in match data