### PR TITLE
fix: add branded 404 page with i18n support

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1474,5 +1474,10 @@
       "next": "Next achievement",
       "newTier": "Reached {tier}"
     }
+  },
+  "NotFound": {
+    "title": "Page not found",
+    "description": "The page you're looking for doesn't exist or has been moved.",
+    "backToDashboard": "Back to dashboard"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1474,5 +1474,10 @@
       "next": "Siguiente logro",
       "newTier": "Alcanzaste {tier}"
     }
+  },
+  "NotFound": {
+    "title": "Página no encontrada",
+    "description": "La página que buscas no existe o ha sido movida.",
+    "backToDashboard": "Volver al inicio"
   }
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Home } from "lucide-react";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+
+export default function NotFound() {
+  let title = "Page not found";
+  let description = "The page you're looking for doesn't exist or has been moved.";
+  let backLabel = "Back to dashboard";
+
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- safe: always called, try/catch only guards missing provider
+    const t = useTranslations("NotFound");
+    title = t("title");
+    description = t("description");
+    backLabel = t("backToDashboard");
+  } catch {
+    // NextIntlClientProvider not available (root-level 404) — use English defaults
+  }
+
+  return (
+    <div className="bg-mesh flex min-h-screen items-center justify-center">
+      <div className="mx-auto max-w-md space-y-6 px-6 text-center">
+        <p className="text-gradient-gold text-8xl font-bold tracking-tighter">404</p>
+        <h1 className="text-2xl font-semibold text-foreground">{title}</h1>
+        <p className="text-muted-foreground">{description}</p>
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          <Home className="size-4" />
+          {backLabel}
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a custom `not-found.tsx` that replaces the default Next.js plain English 404 page
- Uses the app's branded design (dark mesh background, gold 404 text, navigation link)
- Supports English and Spanish via `useTranslations` when the `NextIntlClientProvider` is available (in-app 404s), with English fallback for root-level 404s
- Added `NotFound` namespace to both `messages/en.json` and `messages/es.json`

Fixes #287

## Changelog

skip-changelog — the default Next.js 404 page was a rare edge case that most players wouldn't encounter during normal use.