### PR TITLE
fix: add timeout and error state to feedback widget

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1162,7 +1162,9 @@
   "Feedback": {
     "pageTitle": "Feedback & suggestions",
     "pageSubtitle": "Share your ideas, report bugs, or vote on what we should build next.",
-    "loading": "Loading feedback widget…"
+    "loading": "Loading feedback widget…",
+    "loadError": "Unable to load the feedback widget. This can happen if an ad-blocker is active or the service is temporarily unavailable.",
+    "retry": "Try again"
   },
   "Premium": {
     "gateTitle": "Premium feature",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1162,7 +1162,9 @@
   "Feedback": {
     "pageTitle": "Sugerencias y comentarios",
     "pageSubtitle": "Comparte tus ideas, reporta errores o vota por lo que deberíamos construir.",
-    "loading": "Cargando widget de sugerencias…"
+    "loading": "Cargando widget de sugerencias…",
+    "loadError": "No se pudo cargar el widget de sugerencias. Esto puede pasar si tienes un bloqueador de anuncios activo o el servicio no está disponible temporalmente.",
+    "retry": "Reintentar"
   },
   "Premium": {
     "gateTitle": "Función premium",

--- a/src/app/(app)/feedback/feedback-client.tsx
+++ b/src/app/(app)/feedback/feedback-client.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { Loader2 } from "lucide-react";
+import { AlertTriangle, Loader2, RefreshCw } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
 
 // Extend Window to include the Canny SDK
 declare global {
@@ -12,9 +14,10 @@ declare global {
 }
 
 const BOARD_TOKEN = process.env.NEXT_PUBLIC_CANNY_BOARD_TOKEN;
+const LOAD_TIMEOUT_MS = 10_000;
 
 function loadCannySDK(): Promise<void> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     if (typeof window.Canny === "function") {
       resolve();
       return;
@@ -44,6 +47,7 @@ function loadCannySDK(): Promise<void> {
     e.id = i;
     e.src = "https://sdk.canny.io/sdk.js";
     e.onload = () => resolve();
+    e.onerror = () => reject(new Error("Failed to load Canny SDK"));
     f?.parentNode?.insertBefore(e, f);
   });
 }
@@ -51,11 +55,22 @@ function loadCannySDK(): Promise<void> {
 export function FeedbackClient() {
   const t = useTranslations("Feedback");
   const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
   const [sdkLoaded, setSdkLoaded] = useState(false);
   const cannyContainerRef = useRef<HTMLDivElement>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const renderCannyWidget = useCallback(async () => {
     if (!BOARD_TOKEN) return;
+
+    setIsLoading(true);
+    setHasError(false);
+
+    // Start a timeout — if the widget hasn't loaded after LOAD_TIMEOUT_MS, show error
+    timeoutRef.current = setTimeout(() => {
+      setIsLoading(false);
+      setHasError(true);
+    }, LOAD_TIMEOUT_MS);
 
     try {
       // Load SDK if not already loaded
@@ -84,14 +99,30 @@ export function FeedbackClient() {
           ssoToken,
           theme: "dark",
           onLoadCallback: () => {
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
             setIsLoading(false);
+            setHasError(false);
           },
         });
+      } else {
+        // Container not available or SDK not ready — clear loading
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        setIsLoading(false);
+        setHasError(true);
       }
     } catch {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
       setIsLoading(false);
+      setHasError(true);
     }
   }, [sdkLoaded]);
+
+  // Clean up timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
 
   // Render Canny widget on mount
   useEffect(() => {
@@ -108,6 +139,24 @@ export function FeedbackClient() {
         <div className="absolute inset-0 flex items-center justify-center">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
           <span className="sr-only">{t("loading")}</span>
+        </div>
+      )}
+      {hasError && !isLoading && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="flex max-w-sm flex-col items-center gap-4 text-center">
+            <AlertTriangle className="h-10 w-10 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">{t("loadError")}</p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                void renderCannyWidget();
+              }}
+            >
+              <RefreshCw className="mr-2 h-4 w-4" />
+              {t("retry")}
+            </Button>
+          </div>
         </div>
       )}
       <div ref={cannyContainerRef} data-canny className="-mx-[20px]" />


### PR DESCRIPTION
## Summary

- Add `onerror` handler to the Canny SDK script loader so the promise rejects instead of hanging forever when the script is blocked (ad-blocker) or fails to load
- Add a 10-second timeout that transitions from loading spinner to an error state
- Show a user-friendly error message with a retry button when the widget fails to load
- Ensure all code paths in `renderCannyWidget` clear the loading state (fixes the container-ref-null and SDK-loads-but-widget-doesn't-render scenarios)
- Add i18n keys for the error message and retry button (English + Spanish)

Fixes #281

## Changelog

skip-changelog — the feedback widget loading failure is an edge case (ad-blockers or Canny outages) that most players wouldn't encounter.