### PR TITLE
fix: disable eager prefetch on sidebar links

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -162,7 +162,7 @@ function NavLink({ item, onClick }: { item: NavItem; onClick?: () => void }) {
   }
 
   return (
-    <Link href={item.href} onClick={onClick} className={className}>
+    <Link href={item.href} prefetch={false} onClick={onClick} className={className}>
       {content}
     </Link>
   );


### PR DESCRIPTION
## Summary

- Adds `prefetch={false}` to the sidebar `<Link>` component, disabling eager viewport-based prefetching for all 14 sidebar links
- Next.js still prefetches on hover, so navigation remains fast — users just don't pay for 14+ prefetches on every page load

Fixes #268

## Details

Every sidebar page was triggering ~80-100 duplicate RSC prefetch requests because all 14 links eagerly prefetched when entering the viewport. Combined with re-renders, this caused ~720 duplicate requests across a full-app session.

The fix is a single prop on the `NavLink` component in `app-sidebar.tsx:165`. Hover-based prefetching still works automatically.