### PR TITLE
fix: three a11y issues — avatar alt text, heading hierarchy, tab stops

### DIFF
--- a/src/app/(app)/achievements/achievements-client.tsx
+++ b/src/app/(app)/achievements/achievements-client.tsx
@@ -87,9 +87,9 @@ function AchievementCard({
       />
       <div className="min-w-0 flex-1 space-y-1">
         <div className="flex items-center gap-2">
-          <h3 className={cn("text-sm font-semibold", !unlocked && "text-muted-foreground")}>
+          <h2 className={cn("text-sm font-semibold", !unlocked && "text-muted-foreground")}>
             {title}
-          </h3>
+          </h2>
           {tierLabel && (
             <span
               className={cn(

--- a/src/components/champion-link.tsx
+++ b/src/components/champion-link.tsx
@@ -27,6 +27,8 @@ interface ChampionLinkProps {
   textClassName?: string;
   /** Stop event propagation (useful when inside clickable parents) */
   stopPropagation?: boolean;
+  /** Override tabIndex (use -1 to remove from tab order) */
+  tabIndex?: number;
 }
 
 function buildHref({
@@ -63,6 +65,7 @@ export function ChampionLink({
   className = "",
   textClassName = "",
   stopPropagation = false,
+  tabIndex,
 }: ChampionLinkProps) {
   const href = buildHref({ champion, linkTo, yourChampion, enemyChampion });
 
@@ -72,6 +75,7 @@ export function ChampionLink({
       onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}
       className={`-mx-0.5 inline-flex items-center gap-1 rounded px-0.5 transition-colors hover:bg-accent/50 ${className}`}
       title={`${linkTo === "matches" ? "View games as" : "Scout"} ${champion}`}
+      tabIndex={tabIndex}
     >
       {showIcon && <ChampionIcon championName={champion} size={iconSize} />}
       {showName && <span className={textClassName}>{champion}</span>}

--- a/src/components/match-card.tsx
+++ b/src/components/match-card.tsx
@@ -130,6 +130,7 @@ export function MatchCard({
               <TooltipTrigger
                 className="cursor-default"
                 aria-label={positionTooltipText ?? undefined}
+                tabIndex={-1}
               >
                 <PositionIcon
                   position={match.position}
@@ -163,6 +164,7 @@ export function MatchCard({
                       iconSize={isCompact ? 16 : 20}
                       textClassName={`text-muted-foreground ${isCompact ? "text-xs" : "text-sm"}`}
                       stopPropagation
+                      tabIndex={-1}
                     />
                   ) : (
                     <span className="inline-flex items-center gap-1 text-sm">

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -128,7 +128,7 @@ export function UserMenu({ user, accounts, activeAccountId }: UserMenuProps) {
         aria-label={t("accountSwitcherLabel")}
       >
         <Avatar className="h-8 w-8 shrink-0 ring-2 ring-gold/20">
-          <AvatarImage src={user.image || undefined} />
+          <AvatarImage src={user.image || undefined} alt={user.name ?? ""} />
           <AvatarFallback className="bg-gold/10 text-gold">
             {(user.name || "U").charAt(0).toUpperCase()}
           </AvatarFallback>


### PR DESCRIPTION
## Summary

- **Avatar alt text (#265)**: Add descriptive `alt={user.name}` to the Discord avatar image in the sidebar user menu — was previously empty
- **Heading hierarchy (#266)**: Change `h3`→`h2` on achievements page so it no longer skips from h1 directly to h3 (WCAG 1.3.1)
- **Excessive tab stops (#267)**: Add `tabIndex={-1}` to the position tooltip trigger and scout champion link inside match rows — reduces tab stops from 3 per row to 1, cutting ~20 unnecessary tab stops on dashboard/matches pages

Fixes #265
Fixes #266
Fixes #267