### PR TITLE
perf: optimize analytics page — server-side aggregation, smooth charts, lazy recharts

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -402,7 +402,7 @@
     "peakLabel": "Peak: {rank}",
     "lpOverall": "{value} LP overall",
     "notEnoughRankData": "Not enough rank data yet. Play more ranked games to see your LP journey.",
-    "winRateOverTime": "Win rate over time (10-game rolling)",
+    "winRateOverTime": "Win rate over time (20-game rolling)",
     "coachingBandsDescription": "Shaded areas show the time between coaching sessions.",
     "noCoachingSessions": "No coaching sessions to show.",
     "matchupWinRates": "Matchup win rates",
@@ -433,7 +433,9 @@
       "champion": "Champion",
       "avgKda": "Avg KDA"
     },
-    "perfectKda": "Perfect"
+    "perfectKda": "Perfect",
+    "showAll": "Show all ({count})",
+    "showLess": "Show less"
   },
   "Coaching": {
     "title": "Coaching",

--- a/messages/es.json
+++ b/messages/es.json
@@ -402,7 +402,7 @@
     "peakLabel": "Máximo: {rank}",
     "lpOverall": "{value} LP en total",
     "notEnoughRankData": "No hay suficientes datos de rango aún. Juega más partidas ranked para ver tu progresión de LP.",
-    "winRateOverTime": "Win rate a lo largo del tiempo (media móvil de 10 partidas)",
+    "winRateOverTime": "Win rate a lo largo del tiempo (media móvil de 20 partidas)",
     "coachingBandsDescription": "Las áreas sombreadas muestran el tiempo entre sesiones de coaching.",
     "noCoachingSessions": "No hay sesiones de coaching para mostrar.",
     "matchupWinRates": "Win rate por matchup",
@@ -433,7 +433,9 @@
       "champion": "Campeón",
       "avgKda": "KDA prom."
     },
-    "perfectKda": "Perfecto"
+    "perfectKda": "Perfecto",
+    "showAll": "Mostrar todos ({count})",
+    "showLess": "Mostrar menos"
   },
   "Coaching": {
     "title": "Coaching",

--- a/src/app/(app)/analytics/analytics-charts.tsx
+++ b/src/app/(app)/analytics/analytics-charts.tsx
@@ -41,6 +41,8 @@ interface AnalyticsChartsProps {
   topMatchups: MatchupStat[];
   goalTargetLP: number | null;
   goalTargetLabel: string;
+  /** Slot for content rendered alongside the matchup chart in the 2-col grid */
+  children?: React.ReactNode;
 }
 
 export function AnalyticsCharts({
@@ -51,6 +53,7 @@ export function AnalyticsCharts({
   topMatchups,
   goalTargetLP,
   goalTargetLabel,
+  children,
 }: AnalyticsChartsProps) {
   const t = useTranslations("Analytics");
   const cc = useChartColors();
@@ -513,6 +516,7 @@ export function AnalyticsCharts({
             )}
           </CardContent>
         </Card>
+        {children}
       </div>
     </>
   );

--- a/src/app/(app)/analytics/analytics-charts.tsx
+++ b/src/app/(app)/analytics/analytics-charts.tsx
@@ -1,0 +1,519 @@
+"use client";
+
+import { TrendingUp, Trophy } from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+  ReferenceArea,
+  ReferenceDot,
+  Cell,
+} from "recharts";
+
+import type {
+  RankChartPoint,
+  LPChartMeta,
+  WinRatePoint,
+  CoachingBands,
+  MatchupStat,
+} from "@/lib/queries/analytics";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useChartColors } from "@/hooks/use-chart-colors";
+import { getLocalChampionIconUrl } from "@/lib/ddragon-assets";
+import { formatRank, formatTierDivision, getTierBoundaries } from "@/lib/rank";
+
+interface AnalyticsChartsProps {
+  rankChartData: RankChartPoint[];
+  lpChartMeta: LPChartMeta | null;
+  rollingWR: WinRatePoint[];
+  coachingBands: CoachingBands;
+  topMatchups: MatchupStat[];
+  goalTargetLP: number | null;
+  goalTargetLabel: string;
+}
+
+export function AnalyticsCharts({
+  rankChartData,
+  lpChartMeta,
+  rollingWR,
+  coachingBands,
+  topMatchups,
+  goalTargetLP,
+  goalTargetLabel,
+}: AnalyticsChartsProps) {
+  const t = useTranslations("Analytics");
+  const cc = useChartColors();
+
+  // Adjusted tier boundaries — extend range to include goal target if present
+  const adjustedTierBoundaries = (() => {
+    if (!lpChartMeta || goalTargetLP === null) return null;
+    const yMin = Math.min(lpChartMeta.yMin, Math.floor((goalTargetLP - 50) / 100) * 100);
+    const yMax = Math.max(lpChartMeta.yMax, Math.ceil((goalTargetLP + 50) / 100) * 100);
+    if (yMin < lpChartMeta.yMin || yMax > lpChartMeta.yMax) {
+      return getTierBoundaries(yMin, yMax);
+    }
+    return null;
+  })();
+
+  return (
+    <>
+      {/* Rank Journey + Win Rate side-by-side */}
+      <div className="animate-in-up-delay-1 grid gap-6 lg:grid-cols-2">
+        {rankChartData.length >= 2 && lpChartMeta ? (
+          <Card className="surface-glow">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Trophy className="h-4 w-4 text-gold" />
+                {t("rankJourney")}
+              </CardTitle>
+              <CardDescription>
+                <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                  <span className="font-medium text-foreground/80">
+                    {t("peakLabel", { rank: lpChartMeta.peakRank })}
+                  </span>
+                  {lpChartMeta.netChange !== 0 && (
+                    <span
+                      className={`font-mono font-semibold ${
+                        lpChartMeta.netChange >= 0 ? "text-win" : "text-loss"
+                      }`}
+                    >
+                      {lpChartMeta.netChange >= 0 ? "+" : ""}
+                      {t("lpOverall", { value: lpChartMeta.netChange })}
+                    </span>
+                  )}
+                </span>
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="h-[300px]">
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={rankChartData}>
+                    <defs>
+                      <linearGradient id="lpGradient" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor={cc.gold} stopOpacity={0.3} />
+                        <stop offset="95%" stopColor={cc.gold} stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke={cc.chartGrid} />
+                    <XAxis
+                      dataKey="date"
+                      stroke={cc.chartAxis}
+                      fontSize={12}
+                      interval="preserveStartEnd"
+                    />
+                    <YAxis
+                      stroke={cc.chartAxis}
+                      fontSize={12}
+                      domain={[
+                        goalTargetLP !== null
+                          ? Math.min(lpChartMeta.yMin, Math.floor((goalTargetLP - 50) / 100) * 100)
+                          : lpChartMeta.yMin,
+                        goalTargetLP !== null
+                          ? Math.max(lpChartMeta.yMax, Math.ceil((goalTargetLP + 50) / 100) * 100)
+                          : lpChartMeta.yMax,
+                      ]}
+                      tickFormatter={(v: number) => formatRank(v).split("—")[0].trim()}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: cc.chartTooltipBg,
+                        border: `1px solid ${cc.chartTooltipBorder}`,
+                        borderRadius: "8px",
+                      }}
+                      content={({ active, payload }) => {
+                        if (!active || !payload || !payload[0]) return null;
+                        const d = payload[0].payload as RankChartPoint;
+                        const idx = rankChartData.findIndex((r) => r.timestamp === d.timestamp);
+                        const isPeak = idx === lpChartMeta.peakIndex;
+                        const milestone = lpChartMeta.milestones.find((m) => m.index === idx);
+                        return (
+                          <div className="rounded-lg border border-border/50 bg-surface-elevated p-3 shadow-lg">
+                            {isPeak && (
+                              <p className="mb-1 text-xs font-semibold text-gold">
+                                {t("tooltips.peakRankAchieved")}
+                              </p>
+                            )}
+                            {milestone && (
+                              <p className="mb-1 text-xs font-semibold text-win">
+                                {t("tooltips.firstTimeInTier", { tier: milestone.tier })}
+                              </p>
+                            )}
+                            <p className="font-semibold text-gold">
+                              {formatTierDivision(d.tier, d.division)}
+                            </p>
+                            <p className="text-sm">
+                              <span className="text-gold/80">{d.lp} LP</span>
+                            </p>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {d.wins}W {d.losses}L &middot; {d.date}
+                            </p>
+                          </div>
+                        );
+                      }}
+                    />
+                    {/* Tier boundary reference lines */}
+                    {(adjustedTierBoundaries ?? lpChartMeta.tierBoundaries).map((b) => (
+                      <ReferenceLine
+                        key={b.label}
+                        y={b.lp}
+                        stroke={cc.electric}
+                        strokeDasharray="6 3"
+                        label={{
+                          value: b.label,
+                          fill: cc.electric,
+                          fontSize: 11,
+                          position: "right",
+                        }}
+                      />
+                    ))}
+                    {/* Goal target reference line */}
+                    {goalTargetLP !== null && (
+                      <ReferenceLine
+                        y={goalTargetLP}
+                        stroke={cc.gold}
+                        strokeDasharray="8 4"
+                        strokeWidth={2}
+                        label={({ viewBox }: { viewBox: { x: number; y: number } }) => {
+                          const label = t("chartLabels.goalTarget", { rank: goalTargetLabel });
+                          return (
+                            <g>
+                              <g transform={`translate(${viewBox.x + 4}, ${viewBox.y - 8})`}>
+                                <circle
+                                  cx="6"
+                                  cy="6"
+                                  r="5"
+                                  fill="none"
+                                  stroke={cc.gold}
+                                  strokeWidth="1.5"
+                                />
+                                <circle cx="6" cy="6" r="2" fill={cc.gold} />
+                                <line
+                                  x1="6"
+                                  y1="0"
+                                  x2="6"
+                                  y2="2.5"
+                                  stroke={cc.gold}
+                                  strokeWidth="1.5"
+                                />
+                                <line
+                                  x1="6"
+                                  y1="9.5"
+                                  x2="6"
+                                  y2="12"
+                                  stroke={cc.gold}
+                                  strokeWidth="1.5"
+                                />
+                                <line
+                                  x1="0"
+                                  y1="6"
+                                  x2="2.5"
+                                  y2="6"
+                                  stroke={cc.gold}
+                                  strokeWidth="1.5"
+                                />
+                                <line
+                                  x1="9.5"
+                                  y1="6"
+                                  x2="12"
+                                  y2="6"
+                                  stroke={cc.gold}
+                                  strokeWidth="1.5"
+                                />
+                              </g>
+                              <text
+                                x={viewBox.x + 20}
+                                y={viewBox.y - 3}
+                                fill={cc.gold}
+                                fontSize={11}
+                                fontWeight="bold"
+                              >
+                                {label}
+                              </text>
+                            </g>
+                          );
+                        }}
+                      />
+                    )}
+                    {/* Promotion/demotion markers */}
+                    {lpChartMeta.events.map((e, i) => (
+                      <ReferenceLine
+                        key={`event-${i}`}
+                        x={rankChartData[e.index]?.date}
+                        stroke={e.type === "promotion" ? cc.chartPromotion : cc.chartDemotion}
+                        strokeDasharray="4 4"
+                        label={{
+                          value:
+                            e.type === "promotion"
+                              ? t("chartLabels.reached", { tier: e.to.split(" ")[0] })
+                              : t("chartLabels.backTo", { tier: e.to.split(" ")[0] }),
+                          fill: e.type === "promotion" ? cc.chartPromotion : cc.chartDemotion,
+                          fontSize: 10,
+                          position: "top",
+                        }}
+                      />
+                    ))}
+                    <Area
+                      type="monotone"
+                      dataKey="cumulativeLP"
+                      stroke={cc.gold}
+                      strokeWidth={2}
+                      fill="url(#lpGradient)"
+                      dot={false}
+                      activeDot={{ r: 5, fill: cc.goldLight }}
+                    />
+                    {/* Peak rank dot */}
+                    <ReferenceDot
+                      x={rankChartData[lpChartMeta.peakIndex]?.date}
+                      y={rankChartData[lpChartMeta.peakIndex]?.cumulativeLP}
+                      r={6}
+                      fill={cc.gold}
+                      stroke={cc.goldLight}
+                      strokeWidth={2}
+                      label={{
+                        value: t("peak"),
+                        fill: cc.goldLight,
+                        fontSize: 9,
+                        fontWeight: "bold",
+                        position: "top",
+                        offset: 12,
+                      }}
+                    />
+                    {/* Event dots (promotions/demotions) */}
+                    {lpChartMeta.events.map((e, i) => (
+                      <ReferenceDot
+                        key={`event-dot-${i}`}
+                        x={rankChartData[e.index]?.date}
+                        y={rankChartData[e.index]?.cumulativeLP}
+                        r={5}
+                        fill={cc.gold}
+                        stroke={cc.background}
+                        strokeWidth={2}
+                      />
+                    ))}
+                  </AreaChart>
+                </ResponsiveContainer>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          <Card className="surface-glow">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Trophy className="h-4 w-4 text-gold" />
+                {t("rankJourney")}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">{t("notEnoughRankData")}</p>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Win Rate Over Time */}
+        <Card className="surface-glow">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <TrendingUp className="h-4 w-4 text-gold" />
+              {t("winRateOverTime")}
+            </CardTitle>
+            <CardDescription>
+              {coachingBands.bands.length > 0
+                ? t("coachingBandsDescription")
+                : t("noCoachingSessions")}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="h-[300px]">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={rollingWR}>
+                  <CartesianGrid strokeDasharray="3 3" stroke={cc.chartGrid} />
+                  <XAxis
+                    dataKey="date"
+                    stroke={cc.chartAxis}
+                    fontSize={12}
+                    interval="preserveStartEnd"
+                  />
+                  <YAxis
+                    stroke={cc.chartAxis}
+                    fontSize={12}
+                    domain={[0, 100]}
+                    tickFormatter={(v) => `${v}%`}
+                  />
+                  <Tooltip
+                    cursor={{ stroke: cc.chartReference }}
+                    content={({ active, payload }) => {
+                      if (!active || !payload || !payload[0]) return null;
+                      const d = payload[0].payload as WinRatePoint;
+                      return (
+                        <div className="rounded-lg border border-border/50 bg-surface-elevated p-3 shadow-lg">
+                          <p className="text-sm font-semibold text-foreground">{d.date}</p>
+                          <p className="text-sm">
+                            {t("tooltips.winRate")}{" "}
+                            <span className={d.winRate >= 50 ? "text-gold" : "text-loss"}>
+                              {d.winRate}%
+                            </span>
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {t("tooltips.gameNumber", { index: d.index })}
+                          </p>
+                        </div>
+                      );
+                    }}
+                  />
+                  <ReferenceLine
+                    y={50}
+                    stroke={cc.chartReference}
+                    strokeDasharray="3 3"
+                    label={{ value: "50%", fill: cc.chartAxis, fontSize: 11 }}
+                  />
+                  {/* Shaded bands between coaching sessions */}
+                  {coachingBands.bands.map((band, i) => (
+                    <ReferenceArea
+                      key={`band-${i}`}
+                      x1={band.x1}
+                      x2={band.x2}
+                      fill={cc.neonPurple}
+                      fillOpacity={band.isOngoing ? 0.08 : 0.12}
+                      strokeOpacity={0}
+                    />
+                  ))}
+                  {/* Coaching session markers */}
+                  {coachingBands.sessionIndices.map((s, i) => (
+                    <ReferenceLine
+                      key={`session-${i}`}
+                      x={s.index}
+                      stroke={cc.neonPurple}
+                      strokeOpacity={s.status === "scheduled" ? 0.6 : 1}
+                      strokeDasharray={s.status === "scheduled" ? "6 4" : "4 4"}
+                      label={{
+                        value: s.coachName,
+                        fill: cc.neonPurple,
+                        fontSize: 10,
+                        position: "top",
+                      }}
+                    />
+                  ))}
+                  <Line
+                    type="monotone"
+                    dataKey="winRate"
+                    stroke={cc.gold}
+                    strokeWidth={2}
+                    dot={false}
+                    activeDot={{ r: 4 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Matchup Win Rates */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card className="surface-glow">
+          <CardHeader>
+            <CardTitle>{t("matchupWinRates")}</CardTitle>
+            <CardDescription>{t("topMatchupsDescription")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {topMatchups.length === 0 ? (
+              <p className="text-sm text-muted-foreground">{t("noMatchupData")}</p>
+            ) : (
+              <div style={{ height: Math.max(200, topMatchups.length * 40 + 40) }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={topMatchups} layout="vertical">
+                    <CartesianGrid strokeDasharray="3 3" stroke={cc.chartGrid} />
+                    <XAxis
+                      type="number"
+                      domain={[0, 100]}
+                      tickFormatter={(v) => `${v}%`}
+                      stroke={cc.chartAxis}
+                      fontSize={12}
+                    />
+                    <YAxis
+                      type="category"
+                      dataKey="name"
+                      width={100}
+                      stroke={cc.chartAxis}
+                      fontSize={12}
+                      tick={({
+                        x,
+                        y,
+                        payload,
+                      }: {
+                        x: string | number;
+                        y: string | number;
+                        payload: { value: string };
+                      }) => (
+                        <a href={`/scout?enemy=${encodeURIComponent(payload.value)}`}>
+                          <g transform={`translate(${x},${y})`} style={{ cursor: "pointer" }}>
+                            <image
+                              href={getLocalChampionIconUrl(payload.value, 20)}
+                              x={-98}
+                              y={-10}
+                              width={20}
+                              height={20}
+                              clipPath="inset(0 round 2px)"
+                            />
+                            <text
+                              x={-74}
+                              y={0}
+                              dy={4}
+                              fill={cc.mutedForeground}
+                              fontSize={12}
+                              textAnchor="start"
+                            >
+                              {payload.value}
+                            </text>
+                          </g>
+                        </a>
+                      )}
+                    />
+                    <Tooltip
+                      cursor={{ fill: `color-mix(in oklch, ${cc.chartGrid}, transparent 70%)` }}
+                      content={({ active, payload }) => {
+                        if (!active || !payload || !payload[0]) return null;
+                        const d = payload[0].payload as MatchupStat;
+                        return (
+                          <div className="rounded-lg border border-border/50 bg-surface-elevated p-3 shadow-lg">
+                            <p className="font-semibold text-foreground">{d.name}</p>
+                            <p className="text-sm">
+                              Win Rate:{" "}
+                              <span className={d.winRate >= 50 ? "text-gold" : "text-loss"}>
+                                {d.winRate}%
+                              </span>{" "}
+                              <span className="text-muted-foreground">
+                                ({d.wins}W {d.losses}L / {d.games} games)
+                              </span>
+                            </p>
+                          </div>
+                        );
+                      }}
+                    />
+                    <ReferenceLine x={50} stroke={cc.chartReference} strokeDasharray="3 3" />
+                    <Bar dataKey="winRate" radius={[0, 4, 4, 0]}>
+                      {topMatchups.map((entry, index) => (
+                        <Cell key={index} fill={entry.winRate >= 50 ? cc.gold : cc.loss} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/src/app/(app)/analytics/analytics-client.tsx
+++ b/src/app/(app)/analytics/analytics-client.tsx
@@ -177,11 +177,8 @@ export function AnalyticsClient({ data }: AnalyticsClientProps) {
         topMatchups={topMatchups}
         goalTargetLP={goalTargetLP}
         goalTargetLabel={goalTargetLabel}
-      />
-
-      {/* Rune Keystones + Champion Stats (no recharts needed) */}
-      <div className="grid gap-6 lg:grid-cols-2">
-        {/* Rune Comparison — shares grid row with matchup chart above on lg */}
+      >
+        {/* Rune Comparison — rendered alongside matchup chart in 2-col grid */}
         <Card className="surface-glow">
           <CardHeader>
             <CardTitle>{t("runeKeystones")}</CardTitle>
@@ -265,7 +262,7 @@ export function AnalyticsClient({ data }: AnalyticsClientProps) {
             )}
           </CardContent>
         </Card>
-      </div>
+      </AnalyticsCharts>
 
       {/* Champion Stats */}
       <Card className="surface-glow">

--- a/src/app/(app)/analytics/analytics-client.tsx
+++ b/src/app/(app)/analytics/analytics-client.tsx
@@ -1,26 +1,11 @@
 "use client";
 
-import { BarChart3, TrendingUp, Trophy, ArrowUpDown } from "lucide-react";
+import { BarChart3, ArrowUpDown, ChevronDown } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useMemo, useState } from "react";
-import {
-  LineChart,
-  Line,
-  BarChart,
-  Bar,
-  AreaChart,
-  Area,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  ReferenceLine,
-  ReferenceArea,
-  Cell,
-} from "recharts";
+import dynamic from "next/dynamic";
+import { useState, useMemo } from "react";
 
-import type { RankSnapshot } from "@/db/schema";
+import type { AnalyticsData } from "@/lib/queries/analytics";
 
 import { ChampionLink } from "@/components/champion-link";
 import { EmptyState } from "@/components/empty-state";
@@ -28,6 +13,7 @@ import { RuneIcon } from "@/components/icons/rune-icon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Table,
   TableBody,
@@ -36,216 +22,76 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { useChartColors } from "@/hooks/use-chart-colors";
-import { useAuth } from "@/lib/auth-client";
-import { getLocalChampionIconUrl } from "@/lib/ddragon-assets";
-import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
-import { filterMeaningful } from "@/lib/match-result";
-import { toCumulativeLP, getTierBoundaries, formatRank, formatTierDivision } from "@/lib/rank";
 
-/** Prepare rank snapshot data for the LP chart */
-function prepareRankChartData(snapshots: RankSnapshot[], locale: string) {
-  const data: Array<{
-    date: string;
-    cumulativeLP: number;
-    tier: string;
-    division: string;
-    lp: number;
-    wins: number;
-    losses: number;
-    timestamp: number;
-  }> = [];
+const AnalyticsCharts = dynamic(() => import("./analytics-charts").then((m) => m.AnalyticsCharts), {
+  ssr: false,
+  loading: () => (
+    <div className="space-y-6">
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card className="surface-glow">
+          <CardHeader>
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="mt-1 h-3 w-56" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-[300px] w-full" />
+          </CardContent>
+        </Card>
+        <Card className="surface-glow">
+          <CardHeader>
+            <Skeleton className="h-5 w-64" />
+            <Skeleton className="mt-1 h-3 w-48" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-[300px] w-full" />
+          </CardContent>
+        </Card>
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card className="surface-glow">
+          <CardHeader>
+            <Skeleton className="h-5 w-36" />
+            <Skeleton className="mt-1 h-3 w-48" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-[300px] w-full" />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  ),
+});
 
-  for (const s of snapshots) {
-    const clp = toCumulativeLP(s.tier, s.division, s.lp);
-    if (clp === null) continue;
-
-    const dateStr = formatDate(s.capturedAt, locale, "short-compact");
-
-    const tierName = s.tier ? s.tier.charAt(0) + s.tier.slice(1).toLowerCase() : "";
-
-    data.push({
-      date: dateStr,
-      cumulativeLP: clp,
-      tier: tierName,
-      division: s.division || "",
-      lp: s.lp || 0,
-      wins: s.wins || 0,
-      losses: s.losses || 0,
-      timestamp: s.capturedAt.getTime(),
-    });
-  }
-
-  return data;
-}
-
-/** Slim match shape — only the 8 columns fetched by the analytics page */
-interface AnalyticsMatch {
-  gameDate: Date;
-  result: string;
-  championName: string;
-  matchupChampionName: string | null;
-  runeKeystoneName: string | null;
-  kills: number;
-  deaths: number;
-  assists: number;
-}
-
-interface CoachingSessionSummary {
-  id: number;
-  coachName: string;
-  date: Date;
-  status: "scheduled" | "completed";
-}
+const TABLE_INITIAL_ROWS = 10;
 
 interface AnalyticsClientProps {
-  matches: AnalyticsMatch[];
-  coachingSessions: CoachingSessionSummary[];
-  rankSnapshots: RankSnapshot[];
-  ddragonVersion: string;
-  activeGoal: { targetTier: string; targetDivision: string | null } | null;
+  data: AnalyticsData;
   readOnly?: boolean;
 }
 
-// Rolling win rate: for each match, calculate win rate of last N games
-function computeRollingWinRate(
-  matches: AnalyticsMatch[],
-  locale: string,
-  window = 10,
-): Array<{ index: number; date: string; winRate: number }> {
-  // Exclude remakes from rolling win rate
-  const meaningful = matches.filter((m) => m.result !== "Remake");
-  const data: Array<{ index: number; date: string; winRate: number }> = [];
-  for (let i = 0; i < meaningful.length; i++) {
-    const start = Math.max(0, i - window + 1);
-    const slice = meaningful.slice(start, i + 1);
-    const wins = slice.filter((m) => m.result === "Victory").length;
-    const wr = Math.round((wins / slice.length) * 100);
-    const dateStr = formatDate(meaningful[i].gameDate, locale, "short-compact");
-    data.push({ index: i + 1, date: dateStr, winRate: wr });
-  }
-  return data;
-}
-
-function computeMatchupStats(matches: AnalyticsMatch[]) {
-  const stats = new Map<string, { wins: number; losses: number; games: number }>();
-  for (const m of matches) {
-    if (m.result === "Remake") continue; // Skip remakes
-    const name = m.matchupChampionName || "Unknown";
-    const existing = stats.get(name) || { wins: 0, losses: 0, games: 0 };
-    existing.games++;
-    if (m.result === "Victory") existing.wins++;
-    else existing.losses++;
-    stats.set(name, existing);
-  }
-  return Array.from(stats.entries())
-    .map(([name, s]) => ({
-      name,
-      ...s,
-      winRate: Math.round((s.wins / s.games) * 100),
-    }))
-    .sort((a, b) => b.games - a.games);
-}
-
-function computeRuneStats(matches: AnalyticsMatch[]) {
-  const stats = new Map<string, { wins: number; losses: number; games: number }>();
-  for (const m of matches) {
-    if (m.result === "Remake") continue; // Skip remakes
-    const name = m.runeKeystoneName || "Unknown";
-    const existing = stats.get(name) || { wins: 0, losses: 0, games: 0 };
-    existing.games++;
-    if (m.result === "Victory") existing.wins++;
-    else existing.losses++;
-    stats.set(name, existing);
-  }
-  return Array.from(stats.entries())
-    .map(([name, s]) => ({
-      name,
-      ...s,
-      winRate: Math.round((s.wins / s.games) * 100),
-    }))
-    .sort((a, b) => b.games - a.games);
-}
-
-function computeChampionStats(matches: AnalyticsMatch[]) {
-  const stats = new Map<
-    string,
-    {
-      wins: number;
-      losses: number;
-      games: number;
-      kills: number;
-      deaths: number;
-      assists: number;
-    }
-  >();
-  for (const m of matches) {
-    if (m.result === "Remake") continue; // Skip remakes
-    const existing = stats.get(m.championName) || {
-      wins: 0,
-      losses: 0,
-      games: 0,
-      kills: 0,
-      deaths: 0,
-      assists: 0,
-    };
-    existing.games++;
-    if (m.result === "Victory") existing.wins++;
-    else existing.losses++;
-    existing.kills += m.kills;
-    existing.deaths += m.deaths;
-    existing.assists += m.assists;
-    stats.set(m.championName, existing);
-  }
-  return Array.from(stats.entries())
-    .map(([name, s]) => ({
-      name,
-      ...s,
-      winRate: Math.round((s.wins / s.games) * 100),
-      avgKDA: s.deaths === 0 ? "Perfect" : ((s.kills + s.assists) / s.deaths).toFixed(1),
-    }))
-    .sort((a, b) => b.games - a.games);
-}
-
-export function AnalyticsClient({
-  matches,
-  coachingSessions,
-  rankSnapshots,
-  ddragonVersion,
-  activeGoal,
-  readOnly,
-}: AnalyticsClientProps) {
-  const { user } = useAuth();
-  const _isReadOnly = readOnly || user?.isDemoUser;
-  const locale = user?.locale ?? DEFAULT_LOCALE;
+export function AnalyticsClient({ data }: AnalyticsClientProps) {
   const t = useTranslations("Analytics");
-  const cc = useChartColors();
 
-  const rollingWR = useMemo(() => computeRollingWinRate(matches, locale), [matches, locale]);
-  const matchupStats = useMemo(() => computeMatchupStats(matches), [matches]);
-  const runeStats = useMemo(() => computeRuneStats(matches), [matches]);
-  const championStats = useMemo(() => computeChampionStats(matches), [matches]);
-  const rankChartData = useMemo(
-    () => prepareRankChartData(rankSnapshots, locale),
-    [rankSnapshots, locale],
-  );
-
-  // Compute goal target cumulative LP for chart reference line
-  const goalTargetLP = useMemo(() => {
-    if (!activeGoal) return null;
-    return toCumulativeLP(activeGoal.targetTier, activeGoal.targetDivision, 0);
-  }, [activeGoal]);
-
-  const goalTargetLabel = useMemo(() => {
-    if (!activeGoal) return "";
-    const tierName = activeGoal.targetTier.charAt(0) + activeGoal.targetTier.slice(1).toLowerCase();
-    return activeGoal.targetDivision ? `${tierName} ${activeGoal.targetDivision}` : tierName;
-  }, [activeGoal]);
+  const {
+    rankChartData,
+    lpChartMeta,
+    rollingWR,
+    coachingBands,
+    topMatchups,
+    runeStats,
+    championStats,
+    meaningfulCount,
+    totalCount,
+    ddragonVersion,
+    goalTargetLP,
+    goalTargetLabel,
+  } = data;
 
   // ─── Sort state for Rune Keystones table ──────────────────────────────────
   type RuneSortKey = "games" | "winRate";
   const [runeSortKey, setRuneSortKey] = useState<RuneSortKey>("games");
   const [runeSortDesc, setRuneSortDesc] = useState(true);
+  const [showAllRunes, setShowAllRunes] = useState(false);
 
   const sortedRuneStats = useMemo(() => {
     return [...runeStats].sort((a, b) => {
@@ -268,6 +114,7 @@ export function AnalyticsClient({
   type ChampSortKey = "games" | "winRate" | "avgKDA";
   const [champSortKey, setChampSortKey] = useState<ChampSortKey>("games");
   const [champSortDesc, setChampSortDesc] = useState(true);
+  const [showAllChamps, setShowAllChamps] = useState(false);
 
   const sortedChampionStats = useMemo(() => {
     return [...championStats].sort((a, b) => {
@@ -291,143 +138,14 @@ export function AnalyticsClient({
     }
   }
 
-  // Coaching session indices for shaded bands between consecutive sessions
-  // Must use the same filtered (remake-excluded) array that rollingWR uses,
-  // so band indices align with chart x-axis values.
-  const coachingBands = useMemo(() => {
-    const meaningful = matches.filter((m) => m.result !== "Remake");
-    // Map each session to its closest match index in the filtered array
-    const sessionIndices = coachingSessions.map((s) => {
-      const sessionTime = s.date.getTime();
-      let closestIdx = 0;
-      let closestDiff = Infinity;
-      for (let i = 0; i < meaningful.length; i++) {
-        const diff = Math.abs(meaningful[i].gameDate.getTime() - sessionTime);
-        if (diff < closestDiff) {
-          closestDiff = diff;
-          closestIdx = i;
-        }
-      }
-      return { index: closestIdx + 1, coachName: s.coachName, status: s.status };
-    });
+  const visibleRunes = showAllRunes
+    ? sortedRuneStats
+    : sortedRuneStats.slice(0, TABLE_INITIAL_ROWS);
+  const visibleChamps = showAllChamps
+    ? sortedChampionStats
+    : sortedChampionStats.slice(0, TABLE_INITIAL_ROWS);
 
-    // Build bands between consecutive sessions
-    const bands: Array<{
-      x1: number;
-      x2: number;
-      label: string;
-      isOngoing: boolean;
-    }> = [];
-    for (let i = 0; i < sessionIndices.length - 1; i++) {
-      const from = sessionIndices[i];
-      const to = sessionIndices[i + 1];
-      bands.push({
-        x1: from.index,
-        x2: to.index,
-        label: from.coachName,
-        isOngoing: false,
-      });
-    }
-    // If there's at least one session, add a trailing band from last session to end
-    if (sessionIndices.length > 0) {
-      const last = sessionIndices[sessionIndices.length - 1];
-      if (last.index < rollingWR.length) {
-        bands.push({
-          x1: last.index,
-          x2: rollingWR.length,
-          label: last.coachName,
-          isOngoing: last.status === "scheduled",
-        });
-      }
-    }
-    return { sessionIndices, bands };
-  }, [matches, coachingSessions, rollingWR.length]);
-
-  // Top matchup data for bar chart (top 10 by games played)
-  const topMatchups = matchupStats.slice(0, 10);
-
-  // LP chart: compute boundaries and promotion/demotion markers
-  const lpChartMeta = useMemo(() => {
-    if (rankChartData.length < 2) return null;
-
-    const allLP = rankChartData.map((d) => d.cumulativeLP);
-    const minLP = Math.min(...allLP);
-    const maxLP = Math.max(...allLP);
-    // Add some padding
-    const padding = Math.max((maxLP - minLP) * 0.1, 20);
-    const yMin = Math.max(0, Math.floor((minLP - padding) / 100) * 100);
-    const yMax = Math.ceil((maxLP + padding) / 100) * 100;
-
-    const tierBoundaries = getTierBoundaries(yMin, yMax);
-
-    // Detect tier changes (framed as milestones, not promotions/demotions)
-    const events: Array<{
-      index: number;
-      type: "promotion" | "demotion";
-      from: string;
-      to: string;
-    }> = [];
-    for (let i = 1; i < rankChartData.length; i++) {
-      const prev = rankChartData[i - 1];
-      const curr = rankChartData[i];
-      if (prev.tier !== curr.tier) {
-        events.push({
-          index: i,
-          type: curr.cumulativeLP > prev.cumulativeLP ? "promotion" : "demotion",
-          from: formatTierDivision(prev.tier, prev.division),
-          to: formatTierDivision(curr.tier, curr.division),
-        });
-      }
-    }
-
-    // Net LP change
-    const first = rankChartData[0];
-    const last = rankChartData[rankChartData.length - 1];
-    const netChange = last.cumulativeLP - first.cumulativeLP;
-
-    // Peak rank achieved (highest cumulative LP point)
-    let peakIndex = 0;
-    let peakLP = rankChartData[0].cumulativeLP;
-    for (let i = 1; i < rankChartData.length; i++) {
-      if (rankChartData[i].cumulativeLP > peakLP) {
-        peakLP = rankChartData[i].cumulativeLP;
-        peakIndex = i;
-      }
-    }
-    const peakRank = formatRank(peakLP);
-
-    // First-time-in-tier milestones: detect the first snapshot where a tier appears
-    const seenTiers = new Set<string>();
-    const milestones: Array<{ index: number; tier: string }> = [];
-    for (let i = 0; i < rankChartData.length; i++) {
-      const tier = rankChartData[i].tier;
-      if (tier && !seenTiers.has(tier)) {
-        seenTiers.add(tier);
-        // Skip the very first data point — that's just the starting tier, not a milestone
-        if (i > 0) {
-          milestones.push({ index: i, tier });
-        }
-      }
-    }
-
-    return { yMin, yMax, tierBoundaries, events, netChange, peakIndex, peakRank, milestones };
-  }, [rankChartData]);
-
-  // Adjusted tier boundaries — extends range to include goal target if present
-  const adjustedTierBoundaries = useMemo(() => {
-    if (!lpChartMeta || goalTargetLP === null) return null;
-    const yMin = Math.min(lpChartMeta.yMin, Math.floor((goalTargetLP - 50) / 100) * 100);
-    const yMax = Math.max(lpChartMeta.yMax, Math.ceil((goalTargetLP + 50) / 100) * 100);
-    // Only recompute if range actually expanded
-    if (yMin < lpChartMeta.yMin || yMax > lpChartMeta.yMax) {
-      return getTierBoundaries(yMin, yMax);
-    }
-    return null; // Use original
-  }, [lpChartMeta, goalTargetLP]);
-
-  const meaningfulCount = useMemo(() => filterMeaningful(matches).length, [matches]);
-
-  if (matches.length === 0) {
+  if (totalCount === 0) {
     return (
       <div className="space-y-6">
         <div>
@@ -450,480 +168,20 @@ export function AnalyticsClient({
         <p className="text-muted-foreground">{t("gamesAnalyzed", { count: meaningfulCount })}</p>
       </div>
 
-      {/* Rank Journey + Win Rate side-by-side */}
-      <div className="animate-in-up-delay-1 grid gap-6 lg:grid-cols-2">
-        {rankChartData.length >= 2 && lpChartMeta ? (
-          <Card className="surface-glow">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Trophy className="h-4 w-4 text-gold" />
-                {t("rankJourney")}
-              </CardTitle>
-              <CardDescription>
-                <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                  <span className="font-medium text-foreground/80">
-                    {t("peakLabel", { rank: lpChartMeta.peakRank })}
-                  </span>
-                  {lpChartMeta.netChange !== 0 && (
-                    <span
-                      className={`font-mono font-semibold ${
-                        lpChartMeta.netChange >= 0 ? "text-win" : "text-loss"
-                      }`}
-                    >
-                      {lpChartMeta.netChange >= 0 ? "+" : ""}
-                      {t("lpOverall", { value: lpChartMeta.netChange })}
-                    </span>
-                  )}
-                </span>
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="h-[300px]">
-                <ResponsiveContainer width="100%" height="100%">
-                  <AreaChart data={rankChartData}>
-                    <defs>
-                      <linearGradient id="lpGradient" x1="0" y1="0" x2="0" y2="1">
-                        <stop offset="5%" stopColor={cc.gold} stopOpacity={0.3} />
-                        <stop offset="95%" stopColor={cc.gold} stopOpacity={0} />
-                      </linearGradient>
-                    </defs>
-                    <CartesianGrid strokeDasharray="3 3" stroke={cc.chartGrid} />
-                    <XAxis
-                      dataKey="date"
-                      stroke={cc.chartAxis}
-                      fontSize={12}
-                      interval="preserveStartEnd"
-                    />
-                    <YAxis
-                      stroke={cc.chartAxis}
-                      fontSize={12}
-                      domain={[
-                        goalTargetLP !== null
-                          ? Math.min(lpChartMeta.yMin, Math.floor((goalTargetLP - 50) / 100) * 100)
-                          : lpChartMeta.yMin,
-                        goalTargetLP !== null
-                          ? Math.max(lpChartMeta.yMax, Math.ceil((goalTargetLP + 50) / 100) * 100)
-                          : lpChartMeta.yMax,
-                      ]}
-                      tickFormatter={(v: number) => formatRank(v).split("—")[0].trim()}
-                    />
-                    <Tooltip
-                      contentStyle={{
-                        backgroundColor: cc.chartTooltipBg,
-                        border: `1px solid ${cc.chartTooltipBorder}`,
-                        borderRadius: "8px",
-                      }}
-                      content={({ active, payload }) => {
-                        if (!active || !payload || !payload[0]) return null;
-                        const d = payload[0].payload as (typeof rankChartData)[0];
-                        const idx = rankChartData.findIndex((r) => r.timestamp === d.timestamp);
-                        const isPeak = idx === lpChartMeta.peakIndex;
-                        const milestone = lpChartMeta.milestones.find((m) => m.index === idx);
-                        return (
-                          <div className="rounded-lg border border-border/50 bg-surface-elevated p-3 shadow-lg">
-                            {isPeak && (
-                              <p className="mb-1 text-xs font-semibold text-gold">
-                                {t("tooltips.peakRankAchieved")}
-                              </p>
-                            )}
-                            {milestone && (
-                              <p className="mb-1 text-xs font-semibold text-win">
-                                {t("tooltips.firstTimeInTier", { tier: milestone.tier })}
-                              </p>
-                            )}
-                            <p className="font-semibold text-gold">
-                              {formatTierDivision(d.tier, d.division)}
-                            </p>
-                            <p className="text-sm">
-                              <span className="text-gold/80">{d.lp} LP</span>
-                            </p>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              {d.wins}W {d.losses}L &middot; {d.date}
-                            </p>
-                          </div>
-                        );
-                      }}
-                    />
-                    {/* Tier boundary reference lines */}
-                    {(adjustedTierBoundaries ?? lpChartMeta.tierBoundaries).map((b) => (
-                      <ReferenceLine
-                        key={b.label}
-                        y={b.lp}
-                        stroke={cc.electric}
-                        strokeDasharray="6 3"
-                        label={{
-                          value: b.label,
-                          fill: cc.electric,
-                          fontSize: 11,
-                          position: "right",
-                        }}
-                      />
-                    ))}
-                    {/* Goal target reference line */}
-                    {goalTargetLP !== null && (
-                      <ReferenceLine
-                        y={goalTargetLP}
-                        stroke={cc.gold}
-                        strokeDasharray="8 4"
-                        strokeWidth={2}
-                        label={({ viewBox }: { viewBox: { x: number; y: number } }) => {
-                          const label = t("chartLabels.goalTarget", { rank: goalTargetLabel });
-                          return (
-                            <g>
-                              {/* Target/crosshair icon */}
-                              <g transform={`translate(${viewBox.x + 4}, ${viewBox.y - 8})`}>
-                                <circle
-                                  cx="6"
-                                  cy="6"
-                                  r="5"
-                                  fill="none"
-                                  stroke={cc.gold}
-                                  strokeWidth="1.5"
-                                />
-                                <circle cx="6" cy="6" r="2" fill={cc.gold} />
-                                <line
-                                  x1="6"
-                                  y1="0"
-                                  x2="6"
-                                  y2="2.5"
-                                  stroke={cc.gold}
-                                  strokeWidth="1.5"
-                                />
-                                <line
-                                  x1="6"
-                                  y1="9.5"
-                                  x2="6"
-                                  y2="12"
-                                  stroke={cc.gold}
-                                  strokeWidth="1.5"
-                                />
-                                <line
-                                  x1="0"
-                                  y1="6"
-                                  x2="2.5"
-                                  y2="6"
-                                  stroke={cc.gold}
-                                  strokeWidth="1.5"
-                                />
-                                <line
-                                  x1="9.5"
-                                  y1="6"
-                                  x2="12"
-                                  y2="6"
-                                  stroke={cc.gold}
-                                  strokeWidth="1.5"
-                                />
-                              </g>
-                              <text
-                                x={viewBox.x + 20}
-                                y={viewBox.y - 3}
-                                fill={cc.gold}
-                                fontSize={11}
-                                fontWeight="bold"
-                              >
-                                {label}
-                              </text>
-                            </g>
-                          );
-                        }}
-                      />
-                    )}
-                    {/* Promotion/demotion markers */}
-                    {lpChartMeta.events.map((e, i) => (
-                      <ReferenceLine
-                        key={`event-${i}`}
-                        x={rankChartData[e.index].date}
-                        stroke={e.type === "promotion" ? cc.chartPromotion : cc.chartDemotion}
-                        strokeDasharray="4 4"
-                        label={{
-                          value:
-                            e.type === "promotion"
-                              ? t("chartLabels.reached", { tier: e.to.split(" ")[0] })
-                              : t("chartLabels.backTo", { tier: e.to.split(" ")[0] }),
-                          fill: e.type === "promotion" ? cc.chartPromotion : cc.chartDemotion,
-                          fontSize: 10,
-                          position: "top",
-                        }}
-                      />
-                    ))}
-                    <Area
-                      type="monotone"
-                      dataKey="cumulativeLP"
-                      stroke={cc.gold}
-                      strokeWidth={2}
-                      fill="url(#lpGradient)"
-                      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-                      dot={(props: any) => {
-                        // Highlight promotion/demotion points
-                        const isEvent = lpChartMeta.events.some(
-                          (e: { index: number }) => e.index === props.index,
-                        );
-                        // Highlight peak rank point
-                        const isPeak = props.index === lpChartMeta.peakIndex;
-                        if (isPeak) {
-                          return (
-                            <g key={props.index}>
-                              <circle
-                                cx={props.cx}
-                                cy={props.cy}
-                                r={6}
-                                fill={cc.gold}
-                                stroke={cc.goldLight}
-                                strokeWidth={2}
-                              />
-                              <text
-                                x={props.cx}
-                                y={props.cy - 12}
-                                textAnchor="middle"
-                                fill={cc.goldLight}
-                                fontSize={9}
-                                fontWeight="bold"
-                              >
-                                {t("peak")}
-                              </text>
-                            </g>
-                          );
-                        }
-                        if (isEvent) {
-                          return (
-                            <circle
-                              key={props.index}
-                              cx={props.cx}
-                              cy={props.cy}
-                              r={5}
-                              fill={cc.gold}
-                              stroke={cc.background}
-                              strokeWidth={2}
-                            />
-                          );
-                        }
-                        return (
-                          <circle
-                            key={props.index}
-                            cx={props.cx}
-                            cy={props.cy}
-                            r={2}
-                            fill={cc.gold}
-                            opacity={0.5}
-                          />
-                        );
-                      }}
-                      activeDot={{ r: 5, fill: cc.goldLight }}
-                    />
-                  </AreaChart>
-                </ResponsiveContainer>
-              </div>
-            </CardContent>
-          </Card>
-        ) : (
-          <Card className="surface-glow">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Trophy className="h-4 w-4 text-gold" />
-                {t("rankJourney")}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm text-muted-foreground">{t("notEnoughRankData")}</p>
-            </CardContent>
-          </Card>
-        )}
+      {/* Charts — lazy-loaded (recharts ~360 KB deferred) */}
+      <AnalyticsCharts
+        rankChartData={rankChartData}
+        lpChartMeta={lpChartMeta}
+        rollingWR={rollingWR}
+        coachingBands={coachingBands}
+        topMatchups={topMatchups}
+        goalTargetLP={goalTargetLP}
+        goalTargetLabel={goalTargetLabel}
+      />
 
-        {/* Win Rate Over Time */}
-        <Card className="surface-glow">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <TrendingUp className="h-4 w-4 text-gold" />
-              {t("winRateOverTime")}
-            </CardTitle>
-            <CardDescription>
-              {coachingBands.bands.length > 0
-                ? t("coachingBandsDescription")
-                : t("noCoachingSessions")}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="h-[300px]">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={rollingWR}>
-                  <CartesianGrid strokeDasharray="3 3" stroke={cc.chartGrid} />
-                  <XAxis
-                    dataKey="date"
-                    stroke={cc.chartAxis}
-                    fontSize={12}
-                    interval="preserveStartEnd"
-                  />
-                  <YAxis
-                    stroke={cc.chartAxis}
-                    fontSize={12}
-                    domain={[0, 100]}
-                    tickFormatter={(v) => `${v}%`}
-                  />
-                  <Tooltip
-                    cursor={{ stroke: cc.chartReference }}
-                    content={({ active, payload }) => {
-                      if (!active || !payload || !payload[0]) return null;
-                      const d = payload[0].payload as (typeof rollingWR)[0];
-                      return (
-                        <div className="rounded-lg border border-border/50 bg-surface-elevated p-3 shadow-lg">
-                          <p className="text-sm font-semibold text-foreground">{d.date}</p>
-                          <p className="text-sm">
-                            {t("tooltips.winRate")}{" "}
-                            <span className={d.winRate >= 50 ? "text-gold" : "text-loss"}>
-                              {d.winRate}%
-                            </span>
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            {t("tooltips.gameNumber", { index: d.index })}
-                          </p>
-                        </div>
-                      );
-                    }}
-                  />
-                  <ReferenceLine
-                    y={50}
-                    stroke={cc.chartReference}
-                    strokeDasharray="3 3"
-                    label={{ value: "50%", fill: cc.chartAxis, fontSize: 11 }}
-                  />
-                  {/* Shaded bands between coaching sessions */}
-                  {coachingBands.bands.map((band, i) => (
-                    <ReferenceArea
-                      key={`band-${i}`}
-                      x1={band.x1}
-                      x2={band.x2}
-                      fill={cc.neonPurple}
-                      fillOpacity={band.isOngoing ? 0.08 : 0.12}
-                      strokeOpacity={0}
-                    />
-                  ))}
-                  {/* Coaching session markers (vertical lines at each session) */}
-                  {coachingBands.sessionIndices.map((s, i) => (
-                    <ReferenceLine
-                      key={`session-${i}`}
-                      x={s.index}
-                      stroke={cc.neonPurple}
-                      strokeOpacity={s.status === "scheduled" ? 0.6 : 1}
-                      strokeDasharray={s.status === "scheduled" ? "6 4" : "4 4"}
-                      label={{
-                        value: s.coachName,
-                        fill: cc.neonPurple,
-                        fontSize: 10,
-                        position: "top",
-                      }}
-                    />
-                  ))}
-                  <Line
-                    type="monotone"
-                    dataKey="winRate"
-                    stroke={cc.gold}
-                    strokeWidth={2}
-                    dot={false}
-                    activeDot={{ r: 4 }}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
+      {/* Rune Keystones + Champion Stats (no recharts needed) */}
       <div className="grid gap-6 lg:grid-cols-2">
-        {/* Matchup Win Rates */}
-        <Card className="surface-glow">
-          <CardHeader>
-            <CardTitle>{t("matchupWinRates")}</CardTitle>
-            <CardDescription>{t("topMatchupsDescription")}</CardDescription>
-          </CardHeader>
-          <CardContent>
-            {topMatchups.length === 0 ? (
-              <p className="text-sm text-muted-foreground">{t("noMatchupData")}</p>
-            ) : (
-              <div style={{ height: Math.max(200, topMatchups.length * 40 + 40) }}>
-                <ResponsiveContainer width="100%" height="100%">
-                  <BarChart data={topMatchups} layout="vertical">
-                    <CartesianGrid strokeDasharray="3 3" stroke={cc.chartGrid} />
-                    <XAxis
-                      type="number"
-                      domain={[0, 100]}
-                      tickFormatter={(v) => `${v}%`}
-                      stroke={cc.chartAxis}
-                      fontSize={12}
-                    />
-                    <YAxis
-                      type="category"
-                      dataKey="name"
-                      width={100}
-                      stroke={cc.chartAxis}
-                      fontSize={12}
-                      tick={({
-                        x,
-                        y,
-                        payload,
-                      }: {
-                        x: string | number;
-                        y: string | number;
-                        payload: { value: string };
-                      }) => (
-                        <a href={`/scout?enemy=${encodeURIComponent(payload.value)}`}>
-                          <g transform={`translate(${x},${y})`} style={{ cursor: "pointer" }}>
-                            <image
-                              href={getLocalChampionIconUrl(payload.value, 20)}
-                              x={-98}
-                              y={-10}
-                              width={20}
-                              height={20}
-                              clipPath="inset(0 round 2px)"
-                            />
-                            <text
-                              x={-74}
-                              y={0}
-                              dy={4}
-                              fill={cc.mutedForeground}
-                              fontSize={12}
-                              textAnchor="start"
-                            >
-                              {payload.value}
-                            </text>
-                          </g>
-                        </a>
-                      )}
-                    />
-                    <Tooltip
-                      cursor={{ fill: `color-mix(in oklch, ${cc.chartGrid}, transparent 70%)` }}
-                      content={({ active, payload }) => {
-                        if (!active || !payload || !payload[0]) return null;
-                        const d = payload[0].payload as (typeof topMatchups)[0];
-                        return (
-                          <div className="rounded-lg border border-border/50 bg-surface-elevated p-3 shadow-lg">
-                            <p className="font-semibold text-foreground">{d.name}</p>
-                            <p className="text-sm">
-                              Win Rate:{" "}
-                              <span className={d.winRate >= 50 ? "text-gold" : "text-loss"}>
-                                {d.winRate}%
-                              </span>{" "}
-                              <span className="text-muted-foreground">
-                                ({d.wins}W {d.losses}L / {d.games} games)
-                              </span>
-                            </p>
-                          </div>
-                        );
-                      }}
-                    />
-                    <ReferenceLine x={50} stroke={cc.chartReference} strokeDasharray="3 3" />
-                    <Bar dataKey="winRate" radius={[0, 4, 4, 0]}>
-                      {topMatchups.map((entry, index) => (
-                        <Cell key={index} fill={entry.winRate >= 50 ? cc.gold : cc.loss} />
-                      ))}
-                    </Bar>
-                  </BarChart>
-                </ResponsiveContainer>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Rune Comparison */}
+        {/* Rune Comparison — shares grid row with matchup chart above on lg */}
         <Card className="surface-glow">
           <CardHeader>
             <CardTitle>{t("runeKeystones")}</CardTitle>
@@ -933,60 +191,77 @@ export function AnalyticsClient({
             {runeStats.length === 0 ? (
               <p className="text-sm text-muted-foreground">{t("noRuneData")}</p>
             ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{t("tableHeaders.keystone")}</TableHead>
-                    <TableHead className="text-center">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="-ml-1.5 h-6 px-1.5 text-xs"
-                        onClick={() => toggleRuneSort("games")}
-                      >
-                        {t("tableHeaders.games")}
-                        {runeSortKey === "games" && <ArrowUpDown className="ml-1 h-3 w-3" />}
-                      </Button>
-                    </TableHead>
-                    <TableHead className="text-center">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="-ml-1.5 h-6 px-1.5 text-xs"
-                        onClick={() => toggleRuneSort("winRate")}
-                      >
-                        {t("tableHeaders.winRate")}
-                        {runeSortKey === "winRate" && <ArrowUpDown className="ml-1 h-3 w-3" />}
-                      </Button>
-                    </TableHead>
-                    <TableHead className="text-center">{t("tableHeaders.wl")}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {sortedRuneStats.map((rune) => (
-                    <TableRow key={rune.name}>
-                      <TableCell className="text-sm font-medium">
-                        <span className="flex items-center gap-1.5">
-                          <RuneIcon keystoneName={rune.name} alt={rune.name} size={18} />
-                          {rune.name}
-                        </span>
-                      </TableCell>
-                      <TableCell className="text-center font-mono text-sm">{rune.games}</TableCell>
-                      <TableCell className="text-center">
-                        <Badge
-                          variant={rune.winRate >= 50 ? "default" : "destructive"}
-                          className="font-mono text-xs"
+              <>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>{t("tableHeaders.keystone")}</TableHead>
+                      <TableHead className="text-center">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="-ml-1.5 h-6 px-1.5 text-xs"
+                          onClick={() => toggleRuneSort("games")}
                         >
-                          {rune.winRate}%
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-center font-mono text-sm text-muted-foreground">
-                        {rune.wins}W {rune.losses}L
-                      </TableCell>
+                          {t("tableHeaders.games")}
+                          {runeSortKey === "games" && <ArrowUpDown className="ml-1 h-3 w-3" />}
+                        </Button>
+                      </TableHead>
+                      <TableHead className="text-center">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="-ml-1.5 h-6 px-1.5 text-xs"
+                          onClick={() => toggleRuneSort("winRate")}
+                        >
+                          {t("tableHeaders.winRate")}
+                          {runeSortKey === "winRate" && <ArrowUpDown className="ml-1 h-3 w-3" />}
+                        </Button>
+                      </TableHead>
+                      <TableHead className="text-center">{t("tableHeaders.wl")}</TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  </TableHeader>
+                  <TableBody>
+                    {visibleRunes.map((rune) => (
+                      <TableRow key={rune.name}>
+                        <TableCell className="text-sm font-medium">
+                          <span className="flex items-center gap-1.5">
+                            <RuneIcon keystoneName={rune.name} alt={rune.name} size={18} />
+                            {rune.name}
+                          </span>
+                        </TableCell>
+                        <TableCell className="text-center font-mono text-sm">
+                          {rune.games}
+                        </TableCell>
+                        <TableCell className="text-center">
+                          <Badge
+                            variant={rune.winRate >= 50 ? "default" : "destructive"}
+                            className="font-mono text-xs"
+                          >
+                            {rune.winRate}%
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-center font-mono text-sm text-muted-foreground">
+                          {rune.wins}W {rune.losses}L
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+                {sortedRuneStats.length > TABLE_INITIAL_ROWS && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="mt-2 w-full text-xs text-muted-foreground"
+                    onClick={() => setShowAllRunes((v) => !v)}
+                  >
+                    {showAllRunes ? t("showLess") : t("showAll", { count: sortedRuneStats.length })}
+                    <ChevronDown
+                      className={`ml-1 h-3 w-3 transition-transform ${showAllRunes ? "rotate-180" : ""}`}
+                    />
+                  </Button>
+                )}
+              </>
             )}
           </CardContent>
         </Card>
@@ -1002,77 +277,94 @@ export function AnalyticsClient({
           {sortedChampionStats.length === 0 ? (
             <p className="text-sm text-muted-foreground">{t("noChampionData")}</p>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t("tableHeaders.champion")}</TableHead>
-                  <TableHead className="text-center">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="-ml-1.5 h-6 px-1.5 text-xs"
-                      onClick={() => toggleChampSort("games")}
-                    >
-                      {t("tableHeaders.games")}
-                      {champSortKey === "games" && <ArrowUpDown className="ml-1 h-3 w-3" />}
-                    </Button>
-                  </TableHead>
-                  <TableHead className="text-center">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="-ml-1.5 h-6 px-1.5 text-xs"
-                      onClick={() => toggleChampSort("winRate")}
-                    >
-                      {t("tableHeaders.winRate")}
-                      {champSortKey === "winRate" && <ArrowUpDown className="ml-1 h-3 w-3" />}
-                    </Button>
-                  </TableHead>
-                  <TableHead className="text-center">{t("tableHeaders.wl")}</TableHead>
-                  <TableHead className="text-center">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="-ml-1.5 h-6 px-1.5 text-xs"
-                      onClick={() => toggleChampSort("avgKDA")}
-                    >
-                      {t("tableHeaders.avgKda")}
-                      {champSortKey === "avgKDA" && <ArrowUpDown className="ml-1 h-3 w-3" />}
-                    </Button>
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {sortedChampionStats.map((champ) => (
-                  <TableRow key={champ.name}>
-                    <TableCell className="text-sm font-medium">
-                      <ChampionLink
-                        champion={champ.name}
-                        ddragonVersion={ddragonVersion}
-                        linkTo="scout-your"
-                        iconSize={24}
-                        textClassName="font-medium text-sm"
-                      />
-                    </TableCell>
-                    <TableCell className="text-center font-mono text-sm">{champ.games}</TableCell>
-                    <TableCell className="text-center">
-                      <Badge
-                        variant={champ.winRate >= 50 ? "default" : "destructive"}
-                        className="font-mono text-xs"
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t("tableHeaders.champion")}</TableHead>
+                    <TableHead className="text-center">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="-ml-1.5 h-6 px-1.5 text-xs"
+                        onClick={() => toggleChampSort("games")}
                       >
-                        {champ.winRate}%
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-center font-mono text-sm text-muted-foreground">
-                      {champ.wins}W {champ.losses}L
-                    </TableCell>
-                    <TableCell className="text-center font-mono text-sm">
-                      {champ.avgKDA === "Perfect" ? t("perfectKda") : champ.avgKDA}
-                    </TableCell>
+                        {t("tableHeaders.games")}
+                        {champSortKey === "games" && <ArrowUpDown className="ml-1 h-3 w-3" />}
+                      </Button>
+                    </TableHead>
+                    <TableHead className="text-center">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="-ml-1.5 h-6 px-1.5 text-xs"
+                        onClick={() => toggleChampSort("winRate")}
+                      >
+                        {t("tableHeaders.winRate")}
+                        {champSortKey === "winRate" && <ArrowUpDown className="ml-1 h-3 w-3" />}
+                      </Button>
+                    </TableHead>
+                    <TableHead className="text-center">{t("tableHeaders.wl")}</TableHead>
+                    <TableHead className="text-center">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="-ml-1.5 h-6 px-1.5 text-xs"
+                        onClick={() => toggleChampSort("avgKDA")}
+                      >
+                        {t("tableHeaders.avgKda")}
+                        {champSortKey === "avgKDA" && <ArrowUpDown className="ml-1 h-3 w-3" />}
+                      </Button>
+                    </TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {visibleChamps.map((champ) => (
+                    <TableRow key={champ.name}>
+                      <TableCell className="text-sm font-medium">
+                        <ChampionLink
+                          champion={champ.name}
+                          ddragonVersion={ddragonVersion}
+                          linkTo="scout-your"
+                          iconSize={24}
+                          textClassName="font-medium text-sm"
+                        />
+                      </TableCell>
+                      <TableCell className="text-center font-mono text-sm">{champ.games}</TableCell>
+                      <TableCell className="text-center">
+                        <Badge
+                          variant={champ.winRate >= 50 ? "default" : "destructive"}
+                          className="font-mono text-xs"
+                        >
+                          {champ.winRate}%
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-center font-mono text-sm text-muted-foreground">
+                        {champ.wins}W {champ.losses}L
+                      </TableCell>
+                      <TableCell className="text-center font-mono text-sm">
+                        {champ.avgKDA === "Perfect" ? t("perfectKda") : champ.avgKDA}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {sortedChampionStats.length > TABLE_INITIAL_ROWS && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mt-2 w-full text-xs text-muted-foreground"
+                  onClick={() => setShowAllChamps((v) => !v)}
+                >
+                  {showAllChamps
+                    ? t("showLess")
+                    : t("showAll", { count: sortedChampionStats.length })}
+                  <ChevronDown
+                    className={`ml-1 h-3 w-3 transition-transform ${showAllChamps ? "rotate-180" : ""}`}
+                  />
+                </Button>
+              )}
+            </>
           )}
         </CardContent>
       </Card>

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -24,19 +24,7 @@ async function getCachedAnalyticsData(
 export default async function AnalyticsPage() {
   const user = await requireUser();
   const dateRange = await getSeasonDateRange();
-  const { allMatches, sessions, ranks, ddragonVersion, activeGoal } = await getCachedAnalyticsData(
-    user.id,
-    user.activeRiotAccountId,
-    dateRange,
-  );
+  const data = await getCachedAnalyticsData(user.id, user.activeRiotAccountId, dateRange);
 
-  return (
-    <AnalyticsClient
-      matches={allMatches}
-      coachingSessions={sessions}
-      rankSnapshots={ranks}
-      ddragonVersion={ddragonVersion}
-      activeGoal={activeGoal}
-    />
-  );
+  return <AnalyticsClient data={data} />;
 }

--- a/src/lib/queries/analytics.ts
+++ b/src/lib/queries/analytics.ts
@@ -1,22 +1,462 @@
 /**
- * Shared analytics queries.
- * Extracted from (app)/analytics/page.tsx for reuse in (demo)/analytics/page.tsx.
+ * Shared analytics queries + server-side aggregation.
+ * All heavy data processing happens here so the client receives only
+ * pre-computed chart data and table stats (~25 KB instead of ~256 KB).
  */
 
 import { eq, asc, and, gte, lte } from "drizzle-orm";
 
+import type { RankSnapshot } from "@/db/schema";
 import type { DateRange } from "@/lib/seasons";
 
 import { db } from "@/db";
 import { matches, coachingSessions, rankSnapshots, challenges } from "@/db/schema";
+import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { accountScope } from "@/lib/match-queries";
+import { toCumulativeLP, getTierBoundaries, formatRank, formatTierDivision } from "@/lib/rank";
 import { getLatestVersion } from "@/lib/riot-api";
+
+// ─── Exported types for chart/table data ─────────────────────────────────────
+
+export interface RankChartPoint {
+  date: string;
+  cumulativeLP: number;
+  tier: string;
+  division: string;
+  lp: number;
+  wins: number;
+  losses: number;
+  timestamp: number;
+}
+
+export interface LPChartMeta {
+  yMin: number;
+  yMax: number;
+  tierBoundaries: Array<{ lp: number; label: string }>;
+  events: Array<{
+    index: number;
+    type: "promotion" | "demotion";
+    from: string;
+    to: string;
+  }>;
+  netChange: number;
+  peakIndex: number;
+  peakRank: string;
+  milestones: Array<{ index: number; tier: string }>;
+}
+
+export interface WinRatePoint {
+  index: number;
+  date: string;
+  winRate: number;
+}
+
+export interface CoachingBands {
+  sessionIndices: Array<{ index: number; coachName: string; status: string }>;
+  bands: Array<{ x1: number; x2: number; label: string; isOngoing: boolean }>;
+}
+
+export interface MatchupStat {
+  name: string;
+  wins: number;
+  losses: number;
+  games: number;
+  winRate: number;
+}
+
+export interface RuneStat {
+  name: string;
+  wins: number;
+  losses: number;
+  games: number;
+  winRate: number;
+}
+
+export interface ChampionStat {
+  name: string;
+  wins: number;
+  losses: number;
+  games: number;
+  winRate: number;
+  kills: number;
+  deaths: number;
+  assists: number;
+  avgKDA: string;
+}
+
+// ─── LTTB downsampling ───────────────────────────────────────────────────────
+
+/**
+ * Largest-Triangle-Three-Buckets downsampling.
+ * Reduces an array to `threshold` points while preserving visual shape.
+ * `getValue` extracts the Y value from each item; X is the array index.
+ * `preserveIndices` are always kept (e.g. peak, events).
+ */
+function lttbDownsample<T>(
+  data: T[],
+  threshold: number,
+  getValue: (item: T) => number,
+  preserveIndices?: Set<number>,
+): T[] {
+  if (data.length <= threshold) return data;
+
+  // Collect indices that must be preserved
+  const mustKeep = new Set<number>([0, data.length - 1]);
+  if (preserveIndices) {
+    for (const idx of preserveIndices) mustKeep.add(idx);
+  }
+
+  // Standard LTTB with forced preservation
+  const sampled: T[] = [data[0]];
+  const sampledIndices = new Set<number>([0]);
+
+  const bucketSize = (data.length - 2) / (threshold - 2);
+
+  let prevIndex = 0;
+
+  for (let i = 1; i < threshold - 1; i++) {
+    const bucketStart = Math.floor((i - 1) * bucketSize) + 1;
+    const bucketEnd = Math.min(Math.floor(i * bucketSize) + 1, data.length - 1);
+
+    // Next bucket average (for triangle area calculation)
+    const nextBucketStart = Math.min(Math.floor(i * bucketSize) + 1, data.length - 1);
+    const nextBucketEnd = Math.min(Math.floor((i + 1) * bucketSize) + 1, data.length - 1);
+    let avgX = 0;
+    let avgY = 0;
+    const nextBucketLen = nextBucketEnd - nextBucketStart + 1;
+    for (let j = nextBucketStart; j <= nextBucketEnd; j++) {
+      avgX += j;
+      avgY += getValue(data[j]);
+    }
+    avgX /= nextBucketLen;
+    avgY /= nextBucketLen;
+
+    // Check if any must-keep index falls in this bucket
+    let forcedIdx = -1;
+    for (let j = bucketStart; j < bucketEnd; j++) {
+      if (mustKeep.has(j) && !sampledIndices.has(j)) {
+        forcedIdx = j;
+        break;
+      }
+    }
+
+    if (forcedIdx >= 0) {
+      sampled.push(data[forcedIdx]);
+      sampledIndices.add(forcedIdx);
+      prevIndex = forcedIdx;
+    } else {
+      // Pick point with largest triangle area
+      let maxArea = -1;
+      let bestIdx = bucketStart;
+      const prevY = getValue(data[prevIndex]);
+
+      for (let j = bucketStart; j < bucketEnd; j++) {
+        const area = Math.abs(
+          (prevIndex - avgX) * (getValue(data[j]) - prevY) - (prevIndex - j) * (avgY - prevY),
+        );
+        if (area > maxArea) {
+          maxArea = area;
+          bestIdx = j;
+        }
+      }
+      sampled.push(data[bestIdx]);
+      sampledIndices.add(bestIdx);
+      prevIndex = bestIdx;
+    }
+  }
+
+  // Add any remaining must-keep indices that weren't captured
+  const remaining: Array<{ idx: number; item: T }> = [];
+  for (const idx of mustKeep) {
+    if (!sampledIndices.has(idx)) {
+      remaining.push({ idx, item: data[idx] });
+    }
+  }
+
+  sampled.push(data[data.length - 1]);
+  sampledIndices.add(data.length - 1);
+
+  // Merge remaining must-keep points and re-sort by original index
+  if (remaining.length > 0) {
+    // Build index→item map for sorting
+    const all: Array<{ idx: number; item: T }> = [];
+    // We need original indices for sampled items too — reconstruct from data
+    const finalSet = new Set<number>(sampledIndices);
+    for (const r of remaining) finalSet.add(r.idx);
+
+    for (const idx of finalSet) {
+      all.push({ idx, item: data[idx] });
+    }
+    all.sort((a, b) => a.idx - b.idx);
+    return all.map((a) => a.item);
+  }
+
+  return sampled;
+}
+
+// ─── Aggregation functions (run server-side) ─────────────────────────────────
+
+interface RawMatch {
+  gameDate: Date;
+  result: string;
+  championName: string;
+  matchupChampionName: string | null;
+  runeKeystoneName: string | null;
+  kills: number;
+  deaths: number;
+  assists: number;
+}
+
+interface RawSession {
+  id: number;
+  coachName: string;
+  date: Date;
+  status: "scheduled" | "completed";
+}
+
+const MAX_CHART_POINTS = 50;
+
+function prepareRankChartData(snapshots: RankSnapshot[], locale: string): RankChartPoint[] {
+  const data: RankChartPoint[] = [];
+
+  for (const s of snapshots) {
+    const clp = toCumulativeLP(s.tier, s.division, s.lp);
+    if (clp === null) continue;
+
+    const dateStr = formatDate(s.capturedAt, locale, "short-compact");
+    const tierName = s.tier ? s.tier.charAt(0) + s.tier.slice(1).toLowerCase() : "";
+
+    data.push({
+      date: dateStr,
+      cumulativeLP: clp,
+      tier: tierName,
+      division: s.division || "",
+      lp: s.lp || 0,
+      wins: s.wins || 0,
+      losses: s.losses || 0,
+      timestamp: s.capturedAt.getTime(),
+    });
+  }
+
+  return data;
+}
+
+function computeLPChartMeta(rankChartData: RankChartPoint[]): LPChartMeta | null {
+  if (rankChartData.length < 2) return null;
+
+  const allLP = rankChartData.map((d) => d.cumulativeLP);
+  const minLP = Math.min(...allLP);
+  const maxLP = Math.max(...allLP);
+  const padding = Math.max((maxLP - minLP) * 0.1, 20);
+  const yMin = Math.max(0, Math.floor((minLP - padding) / 100) * 100);
+  const yMax = Math.ceil((maxLP + padding) / 100) * 100;
+
+  const tierBoundaries = getTierBoundaries(yMin, yMax);
+
+  // Detect tier changes
+  const events: LPChartMeta["events"] = [];
+  for (let i = 1; i < rankChartData.length; i++) {
+    const prev = rankChartData[i - 1];
+    const curr = rankChartData[i];
+    if (prev.tier !== curr.tier) {
+      events.push({
+        index: i,
+        type: curr.cumulativeLP > prev.cumulativeLP ? "promotion" : "demotion",
+        from: formatTierDivision(prev.tier, prev.division),
+        to: formatTierDivision(curr.tier, curr.division),
+      });
+    }
+  }
+
+  // Net LP change
+  const first = rankChartData[0];
+  const last = rankChartData[rankChartData.length - 1];
+  const netChange = last.cumulativeLP - first.cumulativeLP;
+
+  // Peak rank
+  let peakIndex = 0;
+  let peakLP = rankChartData[0].cumulativeLP;
+  for (let i = 1; i < rankChartData.length; i++) {
+    if (rankChartData[i].cumulativeLP > peakLP) {
+      peakLP = rankChartData[i].cumulativeLP;
+      peakIndex = i;
+    }
+  }
+  const peakRank = formatRank(peakLP);
+
+  // First-time-in-tier milestones
+  const seenTiers = new Set<string>();
+  const milestones: Array<{ index: number; tier: string }> = [];
+  for (let i = 0; i < rankChartData.length; i++) {
+    const tier = rankChartData[i].tier;
+    if (tier && !seenTiers.has(tier)) {
+      seenTiers.add(tier);
+      if (i > 0) milestones.push({ index: i, tier });
+    }
+  }
+
+  return { yMin, yMax, tierBoundaries, events, netChange, peakIndex, peakRank, milestones };
+}
+
+function computeRollingWinRate(
+  rawMatches: RawMatch[],
+  locale: string,
+  window = 20,
+): WinRatePoint[] {
+  const meaningful = rawMatches.filter((m) => m.result !== "Remake");
+  const data: WinRatePoint[] = [];
+  for (let i = 0; i < meaningful.length; i++) {
+    const start = Math.max(0, i - window + 1);
+    const slice = meaningful.slice(start, i + 1);
+    const wins = slice.filter((m) => m.result === "Victory").length;
+    const wr = Math.round((wins / slice.length) * 100);
+    const dateStr = formatDate(meaningful[i].gameDate, locale, "short-compact");
+    data.push({ index: i + 1, date: dateStr, winRate: wr });
+  }
+  return data;
+}
+
+function computeCoachingBands(
+  rawMatches: RawMatch[],
+  sessions: RawSession[],
+  wrLength: number,
+): CoachingBands {
+  const meaningful = rawMatches.filter((m) => m.result !== "Remake");
+  const sessionIndices = sessions.map((s) => {
+    const sessionTime = s.date.getTime();
+    let closestIdx = 0;
+    let closestDiff = Infinity;
+    for (let i = 0; i < meaningful.length; i++) {
+      const diff = Math.abs(meaningful[i].gameDate.getTime() - sessionTime);
+      if (diff < closestDiff) {
+        closestDiff = diff;
+        closestIdx = i;
+      }
+    }
+    return { index: closestIdx + 1, coachName: s.coachName, status: s.status };
+  });
+
+  const bands: CoachingBands["bands"] = [];
+  for (let i = 0; i < sessionIndices.length - 1; i++) {
+    const from = sessionIndices[i];
+    const to = sessionIndices[i + 1];
+    bands.push({
+      x1: from.index,
+      x2: to.index,
+      label: from.coachName,
+      isOngoing: false,
+    });
+  }
+  if (sessionIndices.length > 0) {
+    const last = sessionIndices[sessionIndices.length - 1];
+    if (last.index < wrLength) {
+      bands.push({
+        x1: last.index,
+        x2: wrLength,
+        label: last.coachName,
+        isOngoing: last.status === "scheduled",
+      });
+    }
+  }
+  return { sessionIndices, bands };
+}
+
+function computeMatchupStats(rawMatches: RawMatch[]): MatchupStat[] {
+  const stats = new Map<string, { wins: number; losses: number; games: number }>();
+  for (const m of rawMatches) {
+    if (m.result === "Remake") continue;
+    const name = m.matchupChampionName || "Unknown";
+    const existing = stats.get(name) || { wins: 0, losses: 0, games: 0 };
+    existing.games++;
+    if (m.result === "Victory") existing.wins++;
+    else existing.losses++;
+    stats.set(name, existing);
+  }
+  return Array.from(stats.entries())
+    .map(([name, s]) => ({
+      name,
+      ...s,
+      winRate: Math.round((s.wins / s.games) * 100),
+    }))
+    .sort((a, b) => b.games - a.games);
+}
+
+function computeRuneStats(rawMatches: RawMatch[]): RuneStat[] {
+  const stats = new Map<string, { wins: number; losses: number; games: number }>();
+  for (const m of rawMatches) {
+    if (m.result === "Remake") continue;
+    const name = m.runeKeystoneName || "Unknown";
+    const existing = stats.get(name) || { wins: 0, losses: 0, games: 0 };
+    existing.games++;
+    if (m.result === "Victory") existing.wins++;
+    else existing.losses++;
+    stats.set(name, existing);
+  }
+  return Array.from(stats.entries())
+    .map(([name, s]) => ({
+      name,
+      ...s,
+      winRate: Math.round((s.wins / s.games) * 100),
+    }))
+    .sort((a, b) => b.games - a.games);
+}
+
+function computeChampionStats(rawMatches: RawMatch[]): ChampionStat[] {
+  const stats = new Map<
+    string,
+    { wins: number; losses: number; games: number; kills: number; deaths: number; assists: number }
+  >();
+  for (const m of rawMatches) {
+    if (m.result === "Remake") continue;
+    const existing = stats.get(m.championName) || {
+      wins: 0,
+      losses: 0,
+      games: 0,
+      kills: 0,
+      deaths: 0,
+      assists: 0,
+    };
+    existing.games++;
+    if (m.result === "Victory") existing.wins++;
+    else existing.losses++;
+    existing.kills += m.kills;
+    existing.deaths += m.deaths;
+    existing.assists += m.assists;
+    stats.set(m.championName, existing);
+  }
+  return Array.from(stats.entries())
+    .map(([name, s]) => ({
+      name,
+      ...s,
+      winRate: Math.round((s.wins / s.games) * 100),
+      avgKDA: s.deaths === 0 ? "Perfect" : ((s.kills + s.assists) / s.deaths).toFixed(1),
+    }))
+    .sort((a, b) => b.games - a.games);
+}
+
+// ─── Main query + aggregation ────────────────────────────────────────────────
+
+export interface AnalyticsData {
+  rankChartData: RankChartPoint[];
+  lpChartMeta: LPChartMeta | null;
+  rollingWR: WinRatePoint[];
+  coachingBands: CoachingBands;
+  topMatchups: MatchupStat[];
+  runeStats: RuneStat[];
+  championStats: ChampionStat[];
+  meaningfulCount: number;
+  totalCount: number;
+  ddragonVersion: string;
+  activeGoal: { targetTier: string; targetDivision: string | null } | null;
+  goalTargetLP: number | null;
+  goalTargetLabel: string;
+}
 
 export async function getAnalyticsData(
   userId: string,
   riotAccountId: string | null,
   dateRange?: DateRange | null,
-) {
+): Promise<AnalyticsData> {
   const dateConditions = dateRange
     ? [
         gte(matches.gameDate, dateRange.start),
@@ -67,13 +507,121 @@ export async function getAnalyticsData(
     }),
   ]);
 
+  const goal = activeGoal
+    ? { targetTier: activeGoal.targetTier!, targetDivision: activeGoal.targetDivision }
+    : null;
+
+  // Use default locale for server-side formatting (client locale not available)
+  const locale = DEFAULT_LOCALE;
+
+  // ── Rank chart data + meta ──
+  let rankChartData = prepareRankChartData(ranks, locale);
+  let lpChartMeta = computeLPChartMeta(rankChartData);
+
+  // Downsample rank data preserving key points
+  if (lpChartMeta && rankChartData.length > MAX_CHART_POINTS) {
+    const preserveIndices = new Set<number>([lpChartMeta.peakIndex]);
+    for (const e of lpChartMeta.events) preserveIndices.add(e.index);
+    for (const m of lpChartMeta.milestones) preserveIndices.add(m.index);
+
+    rankChartData = lttbDownsample(
+      rankChartData,
+      MAX_CHART_POINTS,
+      (d) => d.cumulativeLP,
+      preserveIndices,
+    );
+    // Recompute meta with downsampled data (indices change)
+    lpChartMeta = computeLPChartMeta(rankChartData);
+  }
+
+  // ── Win rate ──
+  let rollingWR = computeRollingWinRate(allMatches, locale);
+  const coachingBands = computeCoachingBands(allMatches, sessions, rollingWR.length);
+
+  // Downsample win rate data
+  if (rollingWR.length > MAX_CHART_POINTS) {
+    // Preserve coaching session indices
+    const preserveIndices = new Set<number>();
+    for (const s of coachingBands.sessionIndices) {
+      // Session index is 1-based, array is 0-based
+      const arrIdx = rollingWR.findIndex((p) => p.index === s.index);
+      if (arrIdx >= 0) preserveIndices.add(arrIdx);
+    }
+
+    const originalLength = rollingWR.length;
+    rollingWR = lttbDownsample(rollingWR, MAX_CHART_POINTS, (d) => d.winRate, preserveIndices);
+
+    // Remap coaching band indices to downsampled data
+    const indexMap = new Map<number, number>();
+    for (let i = 0; i < rollingWR.length; i++) {
+      indexMap.set(rollingWR[i].index, i + 1);
+    }
+
+    // Remap session indices
+    for (const s of coachingBands.sessionIndices) {
+      const mapped = indexMap.get(s.index);
+      if (mapped !== undefined) {
+        s.index = mapped;
+      } else {
+        // Find closest downsampled point
+        let closest = 1;
+        let closestDist = Infinity;
+        for (const [origIdx, newIdx] of indexMap) {
+          const dist = Math.abs(origIdx - s.index);
+          if (dist < closestDist) {
+            closestDist = dist;
+            closest = newIdx;
+          }
+        }
+        s.index = closest;
+      }
+    }
+
+    // Remap bands
+    for (const band of coachingBands.bands) {
+      const mappedX1 = indexMap.get(band.x1);
+      const mappedX2 = indexMap.get(band.x2);
+      if (mappedX1 !== undefined) band.x1 = mappedX1;
+      if (mappedX2 !== undefined) band.x2 = mappedX2;
+      // If x2 was the original length, map to new length
+      if (band.x2 === originalLength) band.x2 = rollingWR.length;
+    }
+
+    // Re-index the downsampled win rate points sequentially
+    for (let i = 0; i < rollingWR.length; i++) {
+      rollingWR[i].index = i + 1;
+    }
+  }
+
+  // ── Table data ──
+  const matchupStats = computeMatchupStats(allMatches);
+  const topMatchups = matchupStats.slice(0, 10);
+  const runeStats = computeRuneStats(allMatches);
+  const championStats = computeChampionStats(allMatches);
+
+  const meaningfulCount = allMatches.filter((m) => m.result !== "Remake").length;
+
+  // ── Goal ──
+  const goalTargetLP = goal ? toCumulativeLP(goal.targetTier, goal.targetDivision, 0) : null;
+  let goalTargetLabel = "";
+  if (goal) {
+    const tierName = goal.targetTier.charAt(0) + goal.targetTier.slice(1).toLowerCase();
+    goalTargetLabel = goal.targetDivision ? `${tierName} ${goal.targetDivision}` : tierName;
+  }
+
   return {
-    allMatches,
-    sessions,
-    ranks,
+    rankChartData,
+    lpChartMeta,
+    rollingWR,
+    coachingBands,
+    topMatchups,
+    runeStats,
+    championStats,
+    meaningfulCount,
+    totalCount: allMatches.length,
     ddragonVersion,
-    activeGoal: activeGoal
-      ? { targetTier: activeGoal.targetTier!, targetDivision: activeGoal.targetDivision }
-      : null,
+    activeGoal: goal,
+    goalTargetLP: goalTargetLP ?? null,
+    goalTargetLabel,
   };
 }

--- a/tests/e2e/coaching-flow.spec.ts
+++ b/tests/e2e/coaching-flow.spec.ts
@@ -87,10 +87,12 @@ test.describe("Coaching flow", () => {
     // Click "Complete Session" link
     await page.getByRole("link", { name: "Complete Session" }).click();
     await page.waitForURL(/\/coaching\/\d+\/complete/, { timeout: 10_000 });
+    await page.waitForLoadState("networkidle", { timeout: 10_000 });
 
     // Wait for the complete page to fully load (the form title appears)
-    await expect(page.getByText("Complete Coaching Session").first()).toBeVisible({
-      timeout: 10_000,
+    // Note: i18n value is sentence case — "Complete coaching session"
+    await expect(page.getByText("Complete coaching session").first()).toBeVisible({
+      timeout: 15_000,
     });
 
     // Scope to main to avoid duplicate elements from streaming/hydration


### PR DESCRIPTION
## Summary

Major performance overhaul for the analytics page, which was the slowest page in the app (3.4s download, 1481 DOM nodes, 56 MB heap, 256 KB RSC payload).

- **Server-side pre-aggregation**: All 5 data aggregation functions moved from client `useMemo` to the server query. Only pre-computed chart data and table stats travel over the wire (~25 KB instead of ~256 KB raw match/rank data)
- **LTTB downsampling**: Rank journey and win rate charts capped at 50 data points using Largest-Triangle-Three-Buckets algorithm, preserving key events (peak rank, promotions, coaching sessions). Produces smooth `monotone` curves instead of jagged/noisy lines
- **Eliminated per-point SVG dots**: Replaced the custom dot renderer (622 `<circle>` elements) with `dot={false}` + `ReferenceDot` only for peak and promotion/demotion events (~5 dots total)
- **Lazy-loaded recharts**: Extracted all 3 chart cards into `analytics-charts.tsx` and dynamic-imported with `next/dynamic` (`ssr: false`), deferring the ~360 KB recharts bundle
- **Capped tables**: Rune keystones and champion stats tables show top 10 rows by default with a "show all" toggle
- **Increased rolling window**: Win rate rolling average changed from 10 → 20 games for inherently smoother trend lines

### Expected impact

| Metric | Before | After (estimated) |
|--------|--------|--------------------|
| RSC payload | 256 KB | ~25 KB |
| DOM nodes | 1,481 | ~400-500 |
| SVG circles | 622 | ~5 |
| Document download | 3.4s | ~1s |
| JS heap | 56 MB | ~20 MB |

Fixes #270