### PR TITLE
fix: add tooltip to retire button on challenges page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -952,6 +952,7 @@
     "overdue": "Deadline passed on {date}. Challenge is still active.",
     "deadline": "Target date: {date}",
     "retire": "Retire",
+    "retireTooltip": "Retiring removes the challenge without counting as a failure.",
     "retireConfirm": "Retire this challenge? This cannot be undone.",
     "deleteConfirm": "Delete this challenge? This cannot be undone.",
     "completedOn": "Completed on {date}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -952,6 +952,7 @@
     "overdue": "La fecha límite pasó el {date}. El desafío sigue activo.",
     "deadline": "Fecha objetivo: {date}",
     "retire": "Retirar",
+    "retireTooltip": "Retirar elimina el desafío sin contar como un fracaso.",
     "retireConfirm": "¿Retirar este desafío? No se puede deshacer.",
     "deleteConfirm": "¿Eliminar este desafío? No se puede deshacer.",
     "completedOn": "Completado el {date}",

--- a/src/app/(app)/challenges/challenges-client.tsx
+++ b/src/app/(app)/challenges/challenges-client.tsx
@@ -317,16 +317,23 @@ function ActiveChallengeCard({
           <div className="flex gap-2">
             <TooltipProvider>
               <Tooltip>
-                <TooltipTrigger>
-                  <Button variant="outline" size="sm" onClick={handleRetire} disabled={isRetiring}>
-                    {isRetiring ? (
-                      <Loader2 className="mr-2 h-3 w-3 animate-spin" />
-                    ) : (
-                      <Archive className="mr-2 h-3 w-3" />
-                    )}
-                    {t("retire")}
-                  </Button>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleRetire}
+                      disabled={isRetiring}
+                    >
+                      {isRetiring ? (
+                        <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                      ) : (
+                        <Archive className="mr-2 h-3 w-3" />
+                      )}
+                      {t("retire")}
+                    </Button>
+                  }
+                />
                 <TooltipContent>{t("retireTooltip")}</TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/src/app/(app)/challenges/challenges-client.tsx
+++ b/src/app/(app)/challenges/challenges-client.tsx
@@ -28,6 +28,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Progress, ProgressLabel } from "@/components/ui/progress";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAuth } from "@/lib/auth-client";
 import { formatDate, DEFAULT_LOCALE } from "@/lib/format";
 import { formatTierDivision, calculateProgress } from "@/lib/rank";
@@ -314,14 +315,21 @@ function ActiveChallengeCard({
         {/* Actions */}
         {!readOnly && (
           <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={handleRetire} disabled={isRetiring}>
-              {isRetiring ? (
-                <Loader2 className="mr-2 h-3 w-3 animate-spin" />
-              ) : (
-                <Archive className="mr-2 h-3 w-3" />
-              )}
-              {t("retire")}
-            </Button>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Button variant="outline" size="sm" onClick={handleRetire} disabled={isRetiring}>
+                    {isRetiring ? (
+                      <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                    ) : (
+                      <Archive className="mr-2 h-3 w-3" />
+                    )}
+                    {t("retire")}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t("retireTooltip")}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         )}
       </CardContent>


### PR DESCRIPTION
## Summary

- Wrap the "Retire" button on the challenges page with a tooltip explaining that retiring removes the challenge without counting as a failure
- Add i18n keys for both English and Spanish

Fixes #283

## Changelog

skip-changelog — tooltip is a minor UX polish that players wouldn't notice without being told.