### PR TITLE
fix(ci): stop changelog workflow from cancelling concurrent runs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: changelog-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   changelog:


### PR DESCRIPTION
## Summary

- Set `cancel-in-progress: false` on the changelog workflow

When a PR is created with `--label skip-changelog`, GitHub fires `opened` and `labeled` events simultaneously. With `cancel-in-progress: true`, the second run cancels the first, leaving a `cancelled` check run that blocks merge even though the second run passes.

The changelog job takes ~3s — there's no benefit to cancelling in-progress runs.

Fixes the blocked merge on PR #317.