### PR TITLE
fix: add thegreenvintage analytics domain to CSP

### DIFF
--- a/.opencode/skills/security/SKILL.md
+++ b/.opencode/skills/security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security
-description: Security patterns for levelrise — CSP, cookie flags, error sanitization, auth checks, URL validation, and supply-chain monitoring
+description: Security patterns for levelrise — CSP, cookie flags, error sanitization, auth checks, URL validation, and supply-chain monitoring. Use when adding external scripts, third-party analytics, tracking pixels, or any new <Script> / <script> tag.
 ---
 
 ## What I do
@@ -34,7 +34,16 @@ When adding a new external CDN, image host, or script source:
 
 1. Update the CSP in `next.config.ts`
 2. Add only the specific domain needed (never use `*`)
-3. Test with browser DevTools console — CSP violations appear there
+3. Match the directive to the resource type:
+   - `<script src="...">` → add to `script-src`
+   - `<link>` / inline styles from CDN → add to `style-src`
+   - `<img src="...">` → add to `img-src`
+   - `fetch()` / XHR / beacon → add to `connect-src`
+   - `<iframe>` → add to `frame-src`
+4. Analytics/tracking scripts typically need BOTH `script-src` (to load the JS) AND `connect-src` (to send beacons/events back)
+5. Test with browser DevTools console — CSP violations appear there
+
+**MANDATORY**: Whenever you add a `<script>` tag, `next/script`, or any external script reference, you MUST update the CSP in the same PR. Forgetting this causes a runtime block with zero functionality — the script silently fails.
 
 ### Why `'unsafe-inline'` is needed
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,11 +10,11 @@ const isDev = process.env.NODE_ENV === "development";
 
 const cspDirectives = [
   "default-src 'self'",
-  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://sdk.canny.io`,
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://sdk.canny.io https://stats.thegreenvintage.com`,
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob: https://ddragon.leagueoflegends.com https://cdn.discordapp.com https://raw.communitydragon.org https://*.canny.io",
   "font-src 'self'",
-  "connect-src 'self' https://*.canny.io",
+  "connect-src 'self' https://*.canny.io https://stats.thegreenvintage.com",
   "object-src 'none'",
   "frame-src https://*.canny.io",
   "worker-src 'self' blob:",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,11 +40,13 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <head>
-        <script
-          defer
-          data-domain="levelrise.app"
-          src="https://stats.thegreenvintage.com/js/script.js"
-        />
+        {process.env.NODE_ENV === "production" && (
+          <script
+            defer
+            data-domain="levelrise.app"
+            src="https://stats.thegreenvintage.com/js/script.js"
+          />
+        )}
       </head>
       <body className="min-h-screen bg-background font-sans antialiased">
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>


### PR DESCRIPTION
## Summary

- Adds `https://stats.thegreenvintage.com` to `script-src` and `connect-src` CSP directives so the analytics script can load and send beacons
- Upgrades the security skill to explicitly trigger when adding external scripts and documents which CSP directive maps to which resource type

## Labels

skip-changelog