### PR TITLE
fix: add loading skeleton for sidebar on slow networks

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -7,6 +7,7 @@ import { connection } from "next/server";
 import { Suspense } from "react";
 
 import { AppSidebar } from "@/components/app-sidebar";
+import { AppSidebarSkeleton } from "@/components/app-sidebar-skeleton";
 import { HtmlLangSync } from "@/components/html-lang-sync";
 import { ImpersonationBanner } from "@/components/impersonation-banner";
 import { Toaster } from "@/components/ui/sonner";
@@ -120,7 +121,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               Skip to main content
             </a>
             <ImpersonationBanner />
-            <Suspense>
+            <Suspense fallback={<AppSidebarSkeleton />}>
               <SidebarWithUser />
             </Suspense>
             <main id="main-content" tabIndex={-1} className="flex-1 outline-none md:ml-64">

--- a/src/components/app-sidebar-skeleton.tsx
+++ b/src/components/app-sidebar-skeleton.tsx
@@ -1,0 +1,84 @@
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Lightweight skeleton placeholder for the sidebar.
+ * Rendered as the Suspense fallback while user data loads on slow networks.
+ * Mirrors the visual structure of AppSidebar / SidebarContent.
+ */
+export function AppSidebarSkeleton() {
+  return (
+    <aside className="fixed top-0 left-0 z-40 hidden h-screen w-64 border-r border-border/50 bg-card md:block">
+      <div className="flex h-full flex-col">
+        {/* Logo + sync button */}
+        <div className="flex h-14 items-center justify-between px-4">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-5 w-5 rounded" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+          <Skeleton className="h-8 w-8 rounded-md" />
+        </div>
+        <Separator />
+
+        {/* Season filter */}
+        <div className="px-3 pt-2 pb-1">
+          <Skeleton className="h-9 w-full rounded-md" />
+        </div>
+        <Separator />
+
+        {/* Nav sections */}
+        <div className="flex-1 px-3 py-4">
+          {/* Dashboard */}
+          <div className="space-y-1">
+            <Skeleton className="h-9 w-full rounded-lg" />
+          </div>
+
+          {/* Tracker section */}
+          <Skeleton className="mt-6 mb-2 ml-3 h-3 w-16" />
+          <div className="space-y-1">
+            <Skeleton className="h-9 w-full rounded-lg" />
+            <Skeleton className="h-9 w-full rounded-lg" />
+            <Skeleton className="h-9 w-full rounded-lg" />
+            <Skeleton className="h-9 w-full rounded-lg" />
+          </div>
+
+          {/* Insights section */}
+          <Skeleton className="mt-6 mb-2 ml-3 h-3 w-16" />
+          <div className="space-y-1">
+            <Skeleton className="h-9 w-full rounded-lg" />
+            <Skeleton className="h-9 w-full rounded-lg" />
+          </div>
+
+          {/* Coaching section */}
+          <Skeleton className="mt-6 mb-2 ml-3 h-3 w-20" />
+          <div className="space-y-1">
+            <Skeleton className="h-9 w-full rounded-lg" />
+            <Skeleton className="h-9 w-full rounded-lg" />
+          </div>
+
+          <Separator className="my-4" />
+
+          {/* Bottom nav */}
+          <div className="space-y-1">
+            <Skeleton className="h-9 w-full rounded-lg" />
+            <Skeleton className="h-9 w-full rounded-lg" />
+            <Skeleton className="h-9 w-full rounded-lg" />
+            <Skeleton className="h-9 w-full rounded-lg" />
+          </div>
+        </div>
+
+        {/* User menu */}
+        <Separator />
+        <div className="p-3">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-8 w-8 rounded-full" />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton className="h-3.5 w-24" />
+              <Skeleton className="h-3 w-16" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `AppSidebarSkeleton` component that mirrors the sidebar structure (logo, season filter, nav sections, user menu) using the existing `<Skeleton>` component
- Wire it as the `<Suspense fallback>` in the app layout so the sidebar no longer pops in without transition on slow connections

Fixes #291