### PR TITLE
fix: show N/A for solo win rate when no solo games played

### DIFF
--- a/changelog/en/2026-05-01-duo-solo-winrate-fix.mdx
+++ b/changelog/en/2026-05-01-duo-solo-winrate-fix.mdx
@@ -1,0 +1,10 @@
+---
+version: "2026.05.1"
+date: "2026-05-01"
+title: "Duo page no longer shows misleading solo comparison with zero games"
+tags: ["fix"]
+---
+
+The duo page used to show "Solo win rate: 0%" and a fake "+X% duo diff" when you had zero solo games — making it look like your duo partner was carrying you, when really there was just no data to compare against.
+
+Now it shows "N/A" for the solo win rate and disables the comparison until you've played enough solo games to make it meaningful.

--- a/changelog/es/2026-05-01-duo-solo-winrate-fix.mdx
+++ b/changelog/es/2026-05-01-duo-solo-winrate-fix.mdx
@@ -1,0 +1,10 @@
+---
+version: "2026.05.1"
+date: "2026-05-01"
+title: "La página de dúo ya no muestra una comparación engañosa sin partidas en solo"
+tags: ["fix"]
+---
+
+La página de dúo mostraba "Winrate en solo: 0%" y una diferencia falsa de "+X% dúo" cuando no tenías partidas en solo — haciendo parecer que tu compañero te estaba llevando, cuando en realidad no había datos para comparar.
+
+Ahora muestra "N/D" para el winrate en solo y desactiva la comparación hasta que tengas suficientes partidas en solo para que sea significativa.

--- a/messages/en.json
+++ b/messages/en.json
@@ -649,7 +649,10 @@
       "soloWinRateLabel": "Solo win rate",
       "soloGamesCount": "{soloGames} games solo",
       "duoDiffLabel": "Duo diff",
-      "vsSolo": "vs solo"
+      "vsSolo": "vs solo",
+      "notAvailable": "N/A",
+      "noSoloGames": "Play solo games to compare",
+      "noSoloComparison": "Need solo games to compare"
     },
     "kda": {
       "yourAvgKdaTitle": "Your avg KDA (duo)",

--- a/messages/es.json
+++ b/messages/es.json
@@ -649,7 +649,10 @@
       "soloWinRateLabel": "Win rate en solitario",
       "soloGamesCount": "{soloGames} partidas solo",
       "duoDiffLabel": "Diferencia dúo",
-      "vsSolo": "vs solo"
+      "vsSolo": "vs solo",
+      "notAvailable": "N/D",
+      "noSoloGames": "Juega partidas en solo para comparar",
+      "noSoloComparison": "Se necesitan partidas en solo para comparar"
     },
     "kda": {
       "yourAvgKdaTitle": "Tu KDA promedio (dúo)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "levelrise",
-  "version": "2026.04.31",
+  "version": "2026.05.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "levelrise",
-      "version": "2026.04.31",
+      "version": "2026.05.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/google": "^3.0.58",
@@ -5380,7 +5380,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "levelrise",
-  "version": "2026.04.31",
+  "version": "2026.05.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/src/app/(app)/duo/duo-client.tsx
+++ b/src/app/(app)/duo/duo-client.tsx
@@ -154,40 +154,60 @@ export function DuoStatsCards({ stats }: { stats: DuoStats }) {
             <TrendingUp className="h-4 w-4" />
             {t("stats.soloWinRateLabel")}
           </div>
-          <p className={`text-2xl font-bold ${stats.soloWinRate >= 50 ? "text-win" : "text-loss"}`}>
-            {stats.soloWinRate}%
-          </p>
-          <p className="text-xs text-muted-foreground">
-            {t("stats.soloGamesCount", { soloGames: stats.soloGames })}
-          </p>
+          {stats.soloWinRate !== null ? (
+            <>
+              <p
+                className={`text-2xl font-bold ${stats.soloWinRate >= 50 ? "text-win" : "text-loss"}`}
+              >
+                {stats.soloWinRate}%
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {t("stats.soloGamesCount", { soloGames: stats.soloGames })}
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="text-2xl font-bold text-muted-foreground">{t("stats.notAvailable")}</p>
+              <p className="text-xs text-muted-foreground">{t("stats.noSoloGames")}</p>
+            </>
+          )}
         </CardContent>
       </Card>
 
       <Card className="surface-glow">
         <CardContent className="pt-6">
           <div className="mb-1 flex items-center gap-2 text-sm text-muted-foreground">
-            {stats.winRate > stats.soloWinRate ? (
+            {stats.soloWinRate !== null && stats.winRate > stats.soloWinRate ? (
               <TrendingUp className="h-4 w-4 text-win" />
-            ) : stats.winRate < stats.soloWinRate ? (
+            ) : stats.soloWinRate !== null && stats.winRate < stats.soloWinRate ? (
               <TrendingDown className="h-4 w-4 text-loss" />
             ) : (
               <Swords className="h-4 w-4" />
             )}
             {t("stats.duoDiffLabel")}
           </div>
-          <p
-            className={`text-2xl font-bold ${
-              stats.winRate - stats.soloWinRate > 0
-                ? "text-win"
-                : stats.winRate - stats.soloWinRate < 0
-                  ? "text-loss"
-                  : ""
-            }`}
-          >
-            {stats.winRate - stats.soloWinRate > 0 ? "+" : ""}
-            {stats.winRate - stats.soloWinRate}%
-          </p>
-          <p className="text-xs text-muted-foreground">{t("stats.vsSolo")}</p>
+          {stats.soloWinRate !== null ? (
+            <>
+              <p
+                className={`text-2xl font-bold ${
+                  stats.winRate - stats.soloWinRate > 0
+                    ? "text-win"
+                    : stats.winRate - stats.soloWinRate < 0
+                      ? "text-loss"
+                      : ""
+                }`}
+              >
+                {stats.winRate - stats.soloWinRate > 0 ? "+" : ""}
+                {stats.winRate - stats.soloWinRate}%
+              </p>
+              <p className="text-xs text-muted-foreground">{t("stats.vsSolo")}</p>
+            </>
+          ) : (
+            <>
+              <p className="text-2xl font-bold text-muted-foreground">—</p>
+              <p className="text-xs text-muted-foreground">{t("stats.noSoloComparison")}</p>
+            </>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/app/actions/duo.ts
+++ b/src/app/actions/duo.ts
@@ -38,7 +38,7 @@ export interface DuoStats {
   partnerAvgAssists: number;
   soloGames: number;
   soloWins: number;
-  soloWinRate: number;
+  soloWinRate: number | null;
 }
 
 export interface DuoGameRow {
@@ -163,7 +163,7 @@ async function getCachedDuoStats(
     soloGames: solo?.totalGames ?? 0,
     soloWins: solo?.wins ?? 0,
     soloWinRate:
-      solo && solo.totalGames > 0 ? Math.round(((solo.wins ?? 0) / solo.totalGames) * 100) : 0,
+      solo && solo.totalGames > 0 ? Math.round(((solo.wins ?? 0) / solo.totalGames) * 100) : null,
   };
 }
 


### PR DESCRIPTION
## Summary

- When a player has 0 solo games, the duo page now shows "N/A" instead of a misleading "0%" solo win rate
- The duo diff comparison card shows "—" instead of a fake "+X%" badge when there's no solo baseline
- Added i18n keys for both EN and ES locales

Fixes #276

## Changelog

- Version 2026.05.1: Duo page no longer shows misleading solo comparison with zero games