### PR TITLE
feat: pre-select most-played champion in matchup scout

### DIFF
--- a/changelog/en/2026-05-01-scout-default-champion.mdx
+++ b/changelog/en/2026-05-01-scout-default-champion.mdx
@@ -1,0 +1,8 @@
+---
+version: "2026.05.2"
+date: "2026-05-01"
+title: "Matchup scout now pre-selects your most-played champion"
+tags: ["improvement"]
+---
+
+The matchup scout page used to open with both champion dropdowns empty, forcing you to pick your main before seeing anything useful. Now it automatically selects your most-played champion, so you're one step closer to scouting a matchup the moment you land on the page.

--- a/changelog/es/2026-05-01-scout-default-champion.mdx
+++ b/changelog/es/2026-05-01-scout-default-champion.mdx
@@ -1,0 +1,8 @@
+---
+version: "2026.05.2"
+date: "2026-05-01"
+title: "El scout de enfrentamientos ahora preselecciona tu campeón más jugado"
+tags: ["improvement"]
+---
+
+La página de scout solía abrirse con ambos selectores de campeón vacíos, obligándote a elegir tu main antes de ver algo útil. Ahora selecciona automáticamente tu campeón más jugado, así estás un paso más cerca de analizar un enfrentamiento en cuanto entras a la página.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "levelrise",
-  "version": "2026.05.1",
+  "version": "2026.05.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/src/app/(app)/scout/scout-client.tsx
+++ b/src/app/(app)/scout/scout-client.tsx
@@ -450,9 +450,15 @@ export function ScoutClient({
 
   // Sync URL params -> local state when browser back/forward navigation occurs
   const isUpdatingUrl = useRef(false);
+  const isInitialMount = useRef(true);
   useEffect(() => {
     if (isUpdatingUrl.current) {
       isUpdatingUrl.current = false;
+      return;
+    }
+    // Skip the initial mount — state is already initialized from server props
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
       return;
     }
     const urlYour = searchParams.get("your") || "";

--- a/src/lib/queries/scout.ts
+++ b/src/lib/queries/scout.ts
@@ -88,7 +88,7 @@ export async function getScoutData(
     ddragonVersion,
     allChampions,
     isRiotLinked,
-    initialYourChampion: params.your || "",
+    initialYourChampion: params.your || mostPlayed[0]?.name || "",
     initialEnemyChampion: params.enemy || "",
     mostPlayed,
     mostFaced,


### PR DESCRIPTION
## Summary

- The scout page now pre-selects the user's most-played champion in the "your champion" dropdown instead of starting blank
- URL query params (`?your=...`) still take priority for deep links
- One-line change in `src/lib/queries/scout.ts`

Fixes #278

## Changelog

- Version 2026.05.2: Matchup scout now pre-selects your most-played champion