### PR TITLE
Fix flaky E2E tests and add coverage for 6 untested pages

### DIFF
--- a/src/app/(app)/challenges/new/new-challenge-client.tsx
+++ b/src/app/(app)/challenges/new/new-challenge-client.tsx
@@ -204,6 +204,7 @@ export function NewChallengeClient({
           } else {
             toast.success(t("toasts.challengeCreated"));
             resetWizard();
+            router.refresh();
             router.push("/challenges");
           }
         } catch {
@@ -227,6 +228,7 @@ export function NewChallengeClient({
           } else {
             toast.success(t("toasts.challengeCreated"));
             resetWizard();
+            router.refresh();
             router.push("/challenges");
           }
         } catch {

--- a/tests/e2e/achievements-flow.spec.ts
+++ b/tests/e2e/achievements-flow.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+
+import { reseedDatabase } from "./helpers/reseed";
+
+/**
+ * E2E: Achievements page
+ *
+ * Verifies the achievements page loads with summary stats,
+ * category tabs, and achievement cards from seeded data.
+ */
+
+test.beforeAll(async () => {
+  await reseedDatabase();
+});
+
+test.describe("Achievements", () => {
+  test("page loads with summary and achievement cards", async ({ page }) => {
+    await page.goto("/achievements");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Page title
+    await expect(main.getByRole("heading", { level: 1 })).toBeVisible({ timeout: 10_000 });
+
+    // Summary badge showing "X of Y" unlocked
+    await expect(main.getByText(/\d+.*of.*\d+/i).first()).toBeVisible();
+  });
+
+  test("category tabs are visible", async ({ page }) => {
+    await page.goto("/achievements");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Should have tab list with category tabs
+    await expect(page.getByRole("tablist").first()).toBeVisible({ timeout: 10_000 });
+
+    // At least the "All" tab should exist
+    await expect(page.getByRole("tab").first()).toBeVisible();
+  });
+
+  test("achievement cards display tier badges or descriptions", async ({ page }) => {
+    await page.goto("/achievements");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Seed data has 28 pre-unlocked achievements with tier badges (Iron, Bronze, etc.)
+    await expect(main.getByText(/iron|bronze|silver|gold/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/tests/e2e/analytics-flow.spec.ts
+++ b/tests/e2e/analytics-flow.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+
+import { reseedDatabase } from "./helpers/reseed";
+
+/**
+ * E2E: Analytics page
+ *
+ * Verifies the analytics page loads with charts, champion stats table,
+ * and rune keystones table from seeded match data.
+ */
+
+test.beforeAll(async () => {
+  await reseedDatabase();
+});
+
+test.describe("Analytics", () => {
+  test("page loads with heading and game count", async ({ page }) => {
+    await page.goto("/analytics");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Page title
+    await expect(main.getByRole("heading", { level: 1 })).toBeVisible({ timeout: 10_000 });
+
+    // Should show "X games analyzed" text
+    await expect(main.getByText(/games analyzed/i).first()).toBeVisible();
+  });
+
+  test("champion stats table is visible", async ({ page }) => {
+    await page.goto("/analytics");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Champion stats section
+    await expect(main.getByText(/champion stats/i).first()).toBeVisible({ timeout: 10_000 });
+
+    // Table should have rows with champion data (win rate badges)
+    await expect(main.getByText(/%/).first()).toBeVisible();
+  });
+
+  test("rune keystones table is visible", async ({ page }) => {
+    await page.goto("/analytics");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Rune keystones section
+    await expect(main.getByText(/rune keystones/i).first()).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/tests/e2e/coaching-flow.spec.ts
+++ b/tests/e2e/coaching-flow.spec.ts
@@ -77,15 +77,15 @@ test.describe("Coaching flow", () => {
     await expect(page.getByText("Wave management").first()).toBeVisible();
     await expect(page.getByText("Vision control").first()).toBeVisible();
     // Should show "Complete Session" CTA
-    await expect(page.getByRole("link", { name: "Complete Session" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Complete session" })).toBeVisible();
   });
 
   test("complete the new coaching session with action items", async ({ page }) => {
     test.skip(!newSessionUrl, "Skipped — scheduling test did not pass");
     await page.goto(newSessionUrl!);
 
-    // Click "Complete Session" link
-    await page.getByRole("link", { name: "Complete Session" }).click();
+    // Click "Complete session" link (sentence case per i18n)
+    await page.getByRole("link", { name: "Complete session" }).click();
     await page.waitForURL(/\/coaching\/\d+\/complete/, { timeout: 10_000 });
     await page.waitForLoadState("networkidle", { timeout: 10_000 });
 

--- a/tests/e2e/dashboard-flow.spec.ts
+++ b/tests/e2e/dashboard-flow.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+
+import { reseedDatabase } from "./helpers/reseed";
+
+/**
+ * E2E: Dashboard page
+ *
+ * Verifies the dashboard loads with rank info, stat cards,
+ * recent matches, and widget sections.
+ */
+
+test.beforeAll(async () => {
+  await reseedDatabase();
+});
+
+test.describe("Dashboard", () => {
+  test("displays rank, win rate, streak, and KDA cards", async ({ page }) => {
+    await page.goto("/dashboard");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Rank card should show a tier (seed data has Gold)
+    await expect(main.getByText(/Gold/i).first()).toBeVisible({ timeout: 10_000 });
+
+    // Win rate card — look for percentage
+    await expect(main.getByText(/%/).first()).toBeVisible();
+
+    // KDA card — look for slash-separated numbers (e.g. "5.2/3.1/7.0")
+    await expect(main.getByText(/\d+\.\d+\/\d+\.\d+\/\d+\.\d+/).first()).toBeVisible();
+  });
+
+  test("shows recent matches section with match cards", async ({ page }) => {
+    await page.goto("/dashboard");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // "Recent games" heading or similar
+    await expect(main.getByText(/recent games/i).first()).toBeVisible({ timeout: 10_000 });
+
+    // Match cards link to /matches/
+    await expect(main.locator('a[href*="/matches/"]').first()).toBeVisible();
+  });
+
+  test("shows coaching widget", async ({ page }) => {
+    await page.goto("/dashboard");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Coaching widget should be visible (seed data has coaching sessions)
+    await expect(main.getByText(/coaching/i).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("shows challenges widget", async ({ page }) => {
+    await page.goto("/dashboard");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Challenges widget — seed data has active challenges
+    await expect(main.getByText(/challenges/i).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("shows action items section", async ({ page }) => {
+    await page.goto("/dashboard");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Action items card (seed data has active action items)
+    await expect(main.getByText(/action items/i).first()).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/tests/e2e/duo-flow.spec.ts
+++ b/tests/e2e/duo-flow.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+
+import { reseedDatabase } from "./helpers/reseed";
+
+/**
+ * E2E: Duo page
+ *
+ * Verifies the duo page loads with partner stats, KDA cards,
+ * champion synergy, and recent games. The demo user has a duo
+ * partner configured with 26 duo games in the seed data.
+ */
+
+test.beforeAll(async () => {
+  await reseedDatabase();
+});
+
+test.describe("Duo", () => {
+  test("page loads with duo stats cards", async ({ page }) => {
+    await page.goto("/duo");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Page title
+    await expect(main.getByRole("heading", { level: 1 })).toBeVisible({ timeout: 10_000 });
+
+    // Duo win rate card — should show a percentage
+    await expect(main.getByText(/%/).first()).toBeVisible();
+  });
+
+  test("shows games together count", async ({ page }) => {
+    await page.goto("/duo");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Should show games together label and a number
+    await expect(main.getByText(/games together/i).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("shows champion synergy section", async ({ page }) => {
+    await page.goto("/duo");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Champion synergy card
+    await expect(main.getByText(/synergy/i).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("shows recent duo games", async ({ page }) => {
+    await page.goto("/duo");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Recent duo games section with match links
+    await expect(main.getByText(/recent duo games/i).first()).toBeVisible({ timeout: 10_000 });
+    await expect(main.locator('a[href*="/matches/"]').first()).toBeVisible();
+  });
+});

--- a/tests/e2e/goals-flow.spec.ts
+++ b/tests/e2e/goals-flow.spec.ts
@@ -151,6 +151,9 @@ test.describe("Challenges flow", () => {
       timeout: 10_000,
     });
 
+    // After deletion revalidation, the tab may reset to Active — re-click Past
+    await main.getByRole("tab", { name: /Past challenges/ }).click();
+
     // "Reach Platinum IV" (retired from earlier test) should still be there
     await expect(main.getByText("Reach Platinum IV")).toBeVisible();
   });

--- a/tests/e2e/matches-flow.spec.ts
+++ b/tests/e2e/matches-flow.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+
+import { reseedDatabase } from "./helpers/reseed";
+
+/**
+ * E2E: Matches list and detail pages
+ *
+ * Verifies the match list loads with filters and pagination,
+ * and that clicking a match navigates to a detail page.
+ */
+
+test.beforeAll(async () => {
+  await reseedDatabase();
+});
+
+test.describe("Matches list", () => {
+  test("displays match cards with summary stats", async ({ page }) => {
+    await page.goto("/matches");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Heading
+    await expect(main.getByRole("heading", { level: 1 })).toBeVisible({ timeout: 10_000 });
+
+    // Summary line with wins/losses/win rate
+    await expect(main.getByText(/\d+W.*\d+L.*\d+%/i).first()).toBeVisible();
+
+    // At least one match card linking to detail
+    await expect(main.locator('a[href*="/matches/"]').first()).toBeVisible();
+  });
+
+  test("filter dropdowns are visible", async ({ page }) => {
+    await page.goto("/matches");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Result filter
+    await expect(page.locator('[aria-label="Filter by result"]')).toBeVisible();
+
+    // Champion filter
+    await expect(page.locator('[aria-label="Filter by champion"]')).toBeVisible();
+
+    // Review filter
+    await expect(page.locator('[aria-label="Filter by review status"]')).toBeVisible();
+  });
+
+  test("navigating to match detail page loads content", async ({ page }) => {
+    // Use a known seeded match ID
+    await page.goto("/matches/EUW1_7000000010");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Should not redirect to login
+    await expect(page).not.toHaveURL(/\/login/);
+
+    // Should show match content (KDA, champion name, etc.)
+    await expect(main.getByText(/\//).first()).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/tests/e2e/scout-flow.spec.ts
+++ b/tests/e2e/scout-flow.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+import { reseedDatabase } from "./helpers/reseed";
+
+/**
+ * E2E: Scout page
+ *
+ * Verifies the scout page loads with champion pickers,
+ * pre-selects the most-played champion, and can load a matchup report.
+ */
+
+test.beforeAll(async () => {
+  await reseedDatabase();
+});
+
+test.describe("Scout", () => {
+  test("page loads with champion pickers", async ({ page }) => {
+    await page.goto("/scout");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Page title
+    await expect(main.getByRole("heading", { level: 1 })).toBeVisible({ timeout: 10_000 });
+
+    // Both champion combobox buttons should be present (role="combobox")
+    const comboboxes = main.getByRole("combobox");
+    await expect(comboboxes.first()).toBeVisible();
+    await expect(comboboxes.nth(1)).toBeVisible();
+  });
+
+  test("your champion is pre-selected from most-played", async ({ page }) => {
+    await page.goto("/scout");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // The first combobox (your champion) should show a champion name, not the placeholder
+    // Pre-selected from most-played champion (PR #331)
+    const yourCombobox = main.getByRole("combobox").first();
+    await expect(yourCombobox).toBeVisible({ timeout: 10_000 });
+    // The button text should NOT contain the placeholder text when pre-selected
+    await expect(yourCombobox).not.toHaveText(/select.*champion/i, { timeout: 10_000 });
+  });
+
+  test("shows empty state when no enemy selected", async ({ page }) => {
+    await page.goto("/scout");
+    const main = page.getByRole("main");
+    await main.waitFor({ state: "visible" });
+
+    // Should show the "select enemy" prompt
+    await expect(main.getByText(/select.*enemy/i).first()).toBeVisible({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix 3 flaky E2E tests (coaching-flow case mismatch, goals-flow router cache race, goals-flow tab reset after deletion)
- Add `router.refresh()` before `router.push("/challenges")` in new-challenge-client to prevent stale Router Cache
- Add E2E coverage for 6 previously untested pages: dashboard, matches, analytics, scout, achievements, duo
- Full suite: **50 tests, 0 failures**

## Details

### Flaky test fixes

1. **coaching-flow.spec.ts:80** — Test expected `"Complete Session"` but i18n renders `"Complete session"` (sentence case)
2. **goals-flow.spec.ts:129** — After creating a challenge, `router.push("/challenges")` could serve a stale prefetch. Fixed by calling `router.refresh()` first in both by-date and by-games submit paths
3. **goals-flow.spec.ts:155** — After deleting a challenge, page re-renders and tabs reset to "Active" default. Fixed by re-clicking the Past tab after deletion

### New E2E tests

| Spec file | Page | Tests |
|-----------|------|-------|
| `dashboard-flow.spec.ts` | Dashboard | rank, win rate, KDA, recent matches, coaching widget, challenges widget, action items |
| `matches-flow.spec.ts` | Matches | list with stats, filter dropdowns, match detail page |
| `analytics-flow.spec.ts` | Analytics | heading, champion stats table, rune keystones table |
| `scout-flow.spec.ts` | Scout | champion pickers, pre-selected most-played, empty state |
| `achievements-flow.spec.ts` | Achievements | summary, category tabs, tier badges |
| `duo-flow.spec.ts` | Duo | stats cards, games together, synergy, recent duo games |