### PR TITLE
feat: add skip and bulk mark-all-reviewed for pending reviews

### DIFF
--- a/changelog/en/2026-05-01-review-skip-bulk.mdx
+++ b/changelog/en/2026-05-01-review-skip-bulk.mdx
@@ -1,0 +1,11 @@
+---
+version: "2026.05.3"
+date: "2026-05-01"
+title: "Skip and bulk-review options for pending games"
+tags: ["feature"]
+---
+
+The review page now has two new ways to clear your backlog faster:
+
+- **Skip button** — each pending review card has a "Skip" button that marks the game as reviewed without adding any highlights or notes. Perfect for games you don't need to analyze.
+- **Mark all as reviewed** — a single button in the pending tab header lets you mark every remaining game as reviewed at once, with a confirmation dialog to prevent accidents.

--- a/changelog/es/2026-05-01-review-skip-bulk.mdx
+++ b/changelog/es/2026-05-01-review-skip-bulk.mdx
@@ -1,0 +1,11 @@
+---
+version: "2026.05.3"
+date: "2026-05-01"
+title: "Opciones de omitir y revisión masiva para partidas pendientes"
+tags: ["feature"]
+---
+
+La página de revisión ahora tiene dos formas nuevas de reducir tu cola de pendientes más rápido:
+
+- **Botón omitir** — cada tarjeta de revisión pendiente tiene un botón "Omitir" que marca la partida como revisada sin añadir aciertos ni notas. Perfecto para partidas que no necesitas analizar.
+- **Marcar todas como revisadas** — un solo botón en la cabecera de la pestaña de pendientes te permite marcar todas las partidas restantes como revisadas de una vez, con un diálogo de confirmación para evitar accidentes.

--- a/messages/en.json
+++ b/messages/en.json
@@ -272,10 +272,12 @@
     "notesOptional": "Notes (optional)",
     "notes": "Notes",
     "saveReview": "Save & mark reviewed",
+    "skipReview": "Skip",
     "editReview": "Edit review",
     "reviewed": "Reviewed",
     "toasts": {
       "reviewSaved": "Review saved!",
+      "reviewSkipped": "Game skipped — marked as reviewed.",
       "reviewSavedAndSkipped": "Review saved & VOD review skipped.",
       "postGameReviewSaved": "Post-game review saved!",
       "failedToSaveReview": "Failed to save review.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -272,10 +272,12 @@
     "notesOptional": "Notas (opcional)",
     "notes": "Notas",
     "saveReview": "Guardar y marcar revisada",
+    "skipReview": "Omitir",
     "editReview": "Editar revisión",
     "reviewed": "Revisada",
     "toasts": {
       "reviewSaved": "¡Revisión guardada!",
+      "reviewSkipped": "Partida omitida — marcada como revisada.",
       "reviewSavedAndSkipped": "Revisión guardada y VOD omitido.",
       "postGameReviewSaved": "¡Revisión post-partida guardada!",
       "failedToSaveReview": "Error al guardar la revisión.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "levelrise",
-  "version": "2026.05.2",
+  "version": "2026.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "levelrise",
-      "version": "2026.05.2",
+      "version": "2026.5.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/google": "^3.0.67",
@@ -3908,9 +3908,9 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
-      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3920,37 +3920,37 @@
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.4"
+        "tailwindcss": "4.2.2"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
-      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-x64": "4.2.4",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
-      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
       "cpu": [
         "arm64"
       ],
@@ -3965,9 +3965,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
-      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
       "cpu": [
         "arm64"
       ],
@@ -3982,9 +3982,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
-      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
       "cpu": [
         "x64"
       ],
@@ -3999,9 +3999,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
-      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
       "cpu": [
         "x64"
       ],
@@ -4016,9 +4016,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
-      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
       "cpu": [
         "arm"
       ],
@@ -4033,9 +4033,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
-      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
       "cpu": [
         "arm64"
       ],
@@ -4050,9 +4050,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
-      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
       "cpu": [
         "arm64"
       ],
@@ -4067,9 +4067,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
-      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
       "cpu": [
         "x64"
       ],
@@ -4084,9 +4084,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
-      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
       "cpu": [
         "x64"
       ],
@@ -4101,9 +4101,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
-      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -4195,9 +4195,9 @@
       "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
-      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
       "cpu": [
         "arm64"
       ],
@@ -4212,9 +4212,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
-      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
       "cpu": [
         "x64"
       ],
@@ -4229,17 +4229,17 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.4.tgz",
-      "integrity": "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
+      "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.2.4",
-        "@tailwindcss/oxide": "4.2.4",
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
-        "tailwindcss": "4.2.4"
+        "tailwindcss": "4.2.2"
       }
     },
     "node_modules/@types/canvas-confetti": {
@@ -4377,12 +4377,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/react": {
@@ -5099,14 +5099,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.3"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -8044,16 +8044,16 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8649,9 +8649,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "levelrise",
-  "version": "2026.05.2",
+  "version": "2026.5.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/src/app/(app)/review/review-client.tsx
+++ b/src/app/(app)/review/review-client.tsx
@@ -15,6 +15,7 @@ import {
   Sparkles,
   Crosshair,
   Globe,
+  SkipForward,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
@@ -24,7 +25,7 @@ import { toast } from "sonner";
 
 import type { Match } from "@/db/schema";
 
-import { saveReview } from "@/app/actions/matches";
+import { saveReview, bulkMarkReviewed } from "@/app/actions/matches";
 import {
   ActionItemCheckin,
   type ActionItemOutcome,
@@ -44,6 +45,16 @@ import { PositionIcon, getRoleRelevance, getPositionLabel } from "@/components/p
 import { ResultBadge, ResultBar } from "@/components/result-badge";
 import { TopicClickGrid, type TopicToggle } from "@/components/topic-click-grid";
 import { TourHelpButton } from "@/components/tour-help-button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -194,6 +205,7 @@ function PendingReviewCard({
   existingHighlights,
   ddragonVersion,
   onReviewed,
+  onSkipped,
   locale,
   isExpanded,
   onToggleExpand,
@@ -205,6 +217,7 @@ function PendingReviewCard({
   existingHighlights: HighlightItem[];
   ddragonVersion: string;
   onReviewed: (matchId: string) => void;
+  onSkipped: (matchId: string) => void;
   locale: string;
   isExpanded: boolean;
   onToggleExpand: () => void;
@@ -243,6 +256,24 @@ function PendingReviewCard({
   );
   const [isPending, startTransition] = useTransition();
   const t = useTranslations("Review");
+
+  const handleSkip = useCallback(() => {
+    startTransition(async () => {
+      try {
+        const result = await saveReview(match.id, {
+          highlights: [],
+        });
+        if (result && "error" in result) {
+          toast.error(result.error);
+        } else {
+          toast.success(t("toasts.reviewSkipped"));
+          onSkipped(match.id);
+        }
+      } catch {
+        toast.error(t("toasts.failedToSaveReview"));
+      }
+    });
+  }, [match.id, onSkipped, t]);
 
   const handleSave = useCallback(() => {
     startTransition(async () => {
@@ -342,8 +373,16 @@ function PendingReviewCard({
           {/* Action item check-in */}
           <ActionItemCheckin items={outcomes} onChange={setOutcomes} />
 
-          {/* Save button */}
-          <div className="flex items-center justify-end">
+          {/* Save / Skip buttons */}
+          <div className="flex items-center justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={handleSkip} disabled={isPending}>
+              {isPending ? (
+                <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+              ) : (
+                <SkipForward className="mr-2 h-3 w-3" />
+              )}
+              {t("skipReview")}
+            </Button>
             <Button size="sm" onClick={handleSave} disabled={isPending}>
               {isPending ? (
                 <Loader2 className="mr-2 h-3 w-3 animate-spin" />
@@ -738,6 +777,32 @@ export function ReviewClient({
     router.refresh();
   }, [router]);
 
+  const [isBulkPending, startBulkTransition] = useTransition();
+  const [bulkDialogOpen, setBulkDialogOpen] = useState(false);
+
+  const handleBulkMarkReviewed = useCallback(() => {
+    startBulkTransition(async () => {
+      try {
+        const ids = pendingMatches.map((m) => m.id);
+        const result = await bulkMarkReviewed(ids);
+        if (result && "error" in result) {
+          toast.error(t("toasts.failedToMarkReviewed"));
+        } else {
+          toast.success(t("toasts.bulkMarkReviewed", { count: ids.length }));
+          setActionedIds((prev) => {
+            const next = new Set(prev);
+            for (const id of ids) next.add(id);
+            return next;
+          });
+          setExpandedId(null);
+        }
+      } catch {
+        toast.error(t("toasts.failedToMarkReviewed"));
+      }
+      setBulkDialogOpen(false);
+    });
+  }, [pendingMatches, t]);
+
   const originalUnreviewedCount = unreviewedMatches.length;
   const paginatedPending = paginate(pendingMatches, pendingPage);
 
@@ -850,6 +915,43 @@ export function ReviewClient({
                 <div className="flex items-center justify-between gap-2" data-tour="review-sort">
                   <p className="text-xs text-muted-foreground">{t("pendingHint")}</p>
                   <div className="flex items-center gap-1.5">
+                    <AlertDialog open={bulkDialogOpen} onOpenChange={setBulkDialogOpen}>
+                      <AlertDialogTrigger
+                        render={
+                          <Button variant="ghost" size="sm" disabled={isBulkPending}>
+                            <CheckCircle2 className="mr-2 h-3 w-3" />
+                            {t("markAllReviewed")}
+                          </Button>
+                        }
+                      />
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>
+                            {t("markAllReviewedConfirmTitle", {
+                              count: pendingMatches.length,
+                            })}
+                          </AlertDialogTitle>
+                          <AlertDialogDescription>
+                            {t("markAllReviewedConfirmDescription")}
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+                          <Button
+                            size="sm"
+                            onClick={handleBulkMarkReviewed}
+                            disabled={isBulkPending}
+                          >
+                            {isBulkPending ? (
+                              <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                            ) : (
+                              <CheckCircle2 className="mr-2 h-3 w-3" />
+                            )}
+                            {t("markAllReviewed")}
+                          </Button>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
                     <Select
                       value={pendingSortMode}
                       onValueChange={(v) =>
@@ -883,6 +985,7 @@ export function ReviewClient({
                     existingHighlights={getHighlightItems(match.id)}
                     ddragonVersion={ddragonVersion}
                     onReviewed={handleReviewed}
+                    onSkipped={handleReviewed}
                     locale={locale}
                     isExpanded={expandedId === match.id}
                     onToggleExpand={() =>

--- a/src/app/actions/matches.ts
+++ b/src/app/actions/matches.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 
 import { db } from "@/db";
@@ -101,4 +101,33 @@ export async function saveReview(
   void evaluateAchievements(user.id);
 
   return { success: true };
+}
+
+/**
+ * Mark multiple matches as reviewed in bulk (with empty review data).
+ * Used for the "mark all as reviewed" action on the pending review tab.
+ */
+export async function bulkMarkReviewed(matchIds: string[]) {
+  const user = await requireUser();
+  await blockIfImpersonating();
+  await blockDemoWrites();
+
+  if (matchIds.length === 0) return { success: true, count: 0 };
+
+  // Mark all matches as reviewed with empty data
+  await db
+    .update(matches)
+    .set({ reviewed: true })
+    .where(and(eq(matches.userId, user.id), inArray(matches.id, matchIds)));
+
+  revalidatePath("/matches");
+  revalidatePath("/review");
+  revalidatePath("/scout");
+  revalidatePath("/coaching");
+  invalidateReviewCaches(user.id);
+
+  // Evaluate achievements
+  void evaluateAchievements(user.id);
+
+  return { success: true, count: matchIds.length };
 }

--- a/tests/e2e/review-flow.spec.ts
+++ b/tests/e2e/review-flow.spec.ts
@@ -6,7 +6,8 @@ import { reseedDatabase } from "./helpers/reseed";
  * E2E: Review lifecycle (2-tab system)
  *
  * Covers: viewing pending matches, clicking topic toggles,
- * adding notes, saving a review, and verifying the reviewed tab.
+ * adding notes, saving a review, skipping a review,
+ * bulk mark all as reviewed, and verifying the reviewed tab.
  * Tests run serially — order matters.
  */
 
@@ -59,6 +60,53 @@ test.describe("Review flow", () => {
 
     // Wait for toast confirmation
     await expect(page.getByText("Review saved!")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("skip a pending review without adding any data", async ({ page }) => {
+    await page.goto("/review");
+
+    // Wait for a pending card to be visible
+    const firstCard = page.locator('[class*="surface-glow"]').first();
+    await expect(firstCard).toBeVisible();
+
+    // Click the Skip button on the first expanded card
+    const skipButton = firstCard.getByText("Skip");
+    await expect(skipButton).toBeVisible();
+    await skipButton.click();
+
+    // Wait for toast confirmation
+    await expect(page.getByText("Game skipped")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("bulk mark all pending reviews as reviewed", async ({ page }) => {
+    await page.goto("/review");
+
+    // Wait for pending matches to load
+    await expect(page.getByText("waiting for review").first()).toBeVisible();
+
+    // Click "Mark all reviewed" button
+    const markAllButton = page.getByRole("button", { name: /Mark all reviewed/i }).first();
+    await expect(markAllButton).toBeVisible();
+    await markAllButton.click();
+
+    // Confirmation dialog should appear
+    await expect(page.getByText("This will skip VOD review")).toBeVisible({ timeout: 5_000 });
+
+    // Confirm the action by clicking the confirm button in the dialog
+    const confirmButton = page.getByRole("button", { name: /Mark all reviewed/i }).last();
+    await confirmButton.click();
+
+    // Wait for toast confirmation (e.g., "Marked 33 games as reviewed.")
+    await expect(page.getByText(/games? as reviewed/i)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Should now show "All caught up!" empty state
+    await expect(page.getByText("All caught up!").first()).toBeVisible({
       timeout: 10_000,
     });
   });


### PR DESCRIPTION
## Summary

- Add per-match **Skip** button on each pending review card — marks the game as reviewed with empty data, same optimistic removal and auto-advance behavior as save
- Add **Mark all as reviewed** bulk action in the pending tab header with a confirmation dialog
- New `bulkMarkReviewed` server action for efficient batch updates
- E2E tests for both skip and bulk review flows
- Changelog entry + i18n keys in both EN and ES

Fixes #280

## Changelog

- Version 2026.05.3: skip and bulk-review options for pending games