### PR TITLE
fix: format manifest.json in DDragon assets workflow

### DIFF
--- a/.github/workflows/ddragon-assets.yml
+++ b/.github/workflows/ddragon-assets.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run DDragon optimizer
         run: npx tsx scripts/optimize-ddragon.ts
 
+      - name: Format generated files
+        run: npx oxfmt public/assets/ddragon/manifest.json
+
       - name: Read manifest version
         id: manifest
         run: |


### PR DESCRIPTION
## Summary

- Adds an `oxfmt` formatting step before the "Create Pull Request" step in the DDragon assets workflow, fixing the lefthook pre-commit hook failure that was rejecting the automated commit.

Fixes the failure in https://github.com/beagleknight/levelrise/actions/runs/25305688708